### PR TITLE
refactor!: restructure stack and config into subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-09
+
 ### Changed
 
-- `bucket add` auto-discovers CloudFormation stack when no cached metadata exists, removing the need to run `quiltx stack` first
+- **BREAKING**: `quiltx stack` is now a subcommand namespace with:
+  - `quiltx stack catalog` — show/set the Quilt catalog (replaces `quiltx config`)
+  - `quiltx stack cfn` — discover the CloudFormation stack (replaces bare `quiltx stack`)
+- **BREAKING**: `quiltx config` removed as a top-level command; use `quiltx stack catalog` instead
+- `bucket add` auto-discovers CloudFormation stack when no cached metadata exists, removing the need to run `quiltx stack cfn` first
 
 ## [0.4.8] - 2026-04-06
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Quilt extension toolkit for working with [Quilt](https://quiltdata.com) catalogs
 uvx quiltx
 
 # Configure a Quilt catalog
-uvx quiltx config https://open.quiltdata.com
+uvx quiltx stack catalog https://open.quiltdata.com
 
 # Register a cross-account S3 bucket
 uvx quiltx bucket add s3://my-data-bucket
 
 # Discover the Quilt CloudFormation stack
-uvx quiltx stack
+uvx quiltx stack cfn
 
 # Open an interactive shell in a running ECS task
 uvx quiltx ecs
@@ -32,10 +32,11 @@ uvx quiltx <tool> --help
 ## Tools
 
 - **bucket** — Register S3 buckets with Quilt (policy, SNS, notifications)
-- **config** — Configure and display Quilt catalog settings
 - **ecs** — Interactive shell access to running ECS tasks via Session Manager
 - **logs** — Display and tail CloudWatch logs for the configured catalog
-- **stack** — Discover the Quilt CloudFormation stack and cache metadata
+- **stack** — Manage Quilt stack
+  - **stack catalog** — Configure and display Quilt catalog settings
+  - **stack cfn** — Discover the Quilt CloudFormation stack and cache metadata
 
 ## Python API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.4.9"
+version = "0.5.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.4.9"
+__version__ = "0.5.0"

--- a/quiltx/tools/stack/__init__.py
+++ b/quiltx/tools/stack/__init__.py
@@ -1,0 +1,63 @@
+"""Quilt stack management commands."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from importlib import import_module
+
+SUBCOMMANDS = {
+    "catalog": "quiltx.tools.stack.catalog",
+    "cfn": "quiltx.tools.stack.cfn",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="quiltx stack",
+        description="Manage Quilt stack: catalog connection, CloudFormation discovery, and access control.",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="subcommand",
+        title="subcommands",
+        metavar="SUBCOMMAND",
+    )
+
+    subparsers.add_parser(
+        "catalog",
+        help="Show or set the Quilt catalog configured by quilt3.",
+        add_help=False,
+    )
+    subparsers.add_parser(
+        "cfn",
+        help="Discover and store information about the CloudFormation stack for the configured catalog.",
+        add_help=False,
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+
+    if not argv:
+        parser.print_help()
+        return 1
+
+    args, remaining = parser.parse_known_args(argv)
+
+    if not args.subcommand:
+        parser.print_help()
+        return 1
+
+    if args.subcommand not in SUBCOMMANDS:
+        print(f"Error: Unknown subcommand '{args.subcommand}'", file=sys.stderr)
+        return 1
+
+    module = import_module(SUBCOMMANDS[args.subcommand])
+    return module.main(remaining)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quiltx/tools/stack/catalog.py
+++ b/quiltx/tools/stack/catalog.py
@@ -10,7 +10,8 @@ import quiltx
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Show or set the Quilt catalog configured by quilt3."
+        prog="quiltx stack catalog",
+        description="Show or set the Quilt catalog configured by quilt3.",
     )
     parser.add_argument(
         "catalog_url",

--- a/quiltx/tools/stack/cfn.py
+++ b/quiltx/tools/stack/cfn.py
@@ -12,9 +12,10 @@ from quiltx import stack as stack_lib
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        prog="quiltx stack cfn",
         description=(
             "Discover and store information about the CloudFormation stack for the configured catalog."
-        )
+        ),
     )
     parser.add_argument(
         "--catalog-name",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,16 @@ def test_list_tools(capsys) -> None:
     assert len(cli.TOOLS) > 0
 
 
+def test_config_not_top_level() -> None:
+    """Test that config is no longer a top-level tool (moved to stack catalog)."""
+    assert "config" not in cli.TOOLS
+
+
+def test_stack_is_top_level() -> None:
+    """Test that stack is a top-level tool."""
+    assert "stack" in cli.TOOLS
+
+
 def test_run_tool_unknown(capsys) -> None:
     """Test running an unknown tool fails gracefully."""
     result = cli.run_tool("nonexistent", [])
@@ -44,6 +54,30 @@ def test_main_shows_tools(capsys) -> None:
     assert "available tools:" in captured.out
     # Check that at least one tool is shown
     assert any(tool in captured.out for tool in cli.TOOLS.keys())
+
+
+def test_stack_no_subcommand(capsys) -> None:
+    """Test that 'quiltx stack' with no subcommand shows help."""
+    result = cli.main(["stack"])
+    assert result == 1
+
+    captured = capsys.readouterr()
+    assert "catalog" in captured.out
+    assert "cfn" in captured.out
+
+
+def test_stack_catalog_help() -> None:
+    """Test that 'quiltx stack catalog --help' works."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["stack", "catalog", "--help"])
+    assert exc_info.value.code == 0
+
+
+def test_stack_cfn_help() -> None:
+    """Test that 'quiltx stack cfn --help' works."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["stack", "cfn", "--help"])
+    assert exc_info.value.code == 0
 
 
 def test_run_tool_exists() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for the config tool."""
+"""Tests for the catalog tool (quiltx stack catalog)."""
 
 from __future__ import annotations
 
@@ -6,12 +6,12 @@ from pathlib import Path
 
 import quilt3.util as util
 
-from quiltx.tools import config
+from quiltx.tools.stack import catalog
 
 
-def test_config_show_displays_config(capsys) -> None:
-    """Test that config without args displays the current config."""
-    result = config.main([])
+def test_catalog_show_displays_config(capsys) -> None:
+    """Test that catalog without args displays the current config."""
+    result = catalog.main([])
     # Should succeed since quilt3 has default config
     assert result == 0
 
@@ -20,13 +20,13 @@ def test_config_show_displays_config(capsys) -> None:
     assert "navigator_url" in captured.out or "registry" in captured.out
 
 
-def test_config_sets_catalog() -> None:
-    """Test that config tool configures the catalog."""
+def test_catalog_sets_catalog() -> None:
+    """Test that catalog tool configures the catalog."""
     config_path = Path(util.CONFIG_PATH)
     backup = config_path.read_bytes() if config_path.exists() else None
 
     try:
-        result = config.main([util.OPEN_DATA_URL])
+        result = catalog.main([util.OPEN_DATA_URL])
         assert result == 0
 
         # Verify config was set
@@ -42,17 +42,17 @@ def test_config_sets_catalog() -> None:
             config_path.write_bytes(backup)
 
 
-def test_config_show_after_set(capsys) -> None:
-    """Test that config without args displays the configured catalog."""
+def test_catalog_show_after_set(capsys) -> None:
+    """Test that catalog without args displays the configured catalog."""
     config_path = Path(util.CONFIG_PATH)
     backup = config_path.read_bytes() if config_path.exists() else None
 
     try:
         # First configure
-        config.main([util.OPEN_DATA_URL])
+        catalog.main([util.OPEN_DATA_URL])
 
         # Then show
-        result = config.main([])
+        result = catalog.main([])
         assert result == 0
 
         captured = capsys.readouterr()
@@ -65,9 +65,9 @@ def test_config_show_after_set(capsys) -> None:
             config_path.write_bytes(backup)
 
 
-def test_config_without_args_shows_current(capsys) -> None:
-    """Test that config without args shows current configuration."""
-    result = config.main([])
+def test_catalog_without_args_shows_current(capsys) -> None:
+    """Test that catalog without args shows current configuration."""
+    result = catalog.main([])
     # Should succeed since quilt3 has default config
     assert result == 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.4.9"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "quilt3" },


### PR DESCRIPTION
## Summary

- **BREAKING**: `quiltx config` removed — use `quiltx stack catalog` instead
- **BREAKING**: bare `quiltx stack` removed — use `quiltx stack cfn` instead
- `quiltx stack` is now a namespace with subcommands: `catalog`, `cfn`
- Prepares for `quiltx stack acl` to manage bucket policies, roles, and SSO mappings
- Version bumped to 0.5.0

## Test plan

- [x] All 83 unit tests pass
- [x] black and mypy clean
- [x] Pre-push hooks pass (black, mypy, poe test)
- [x] Manual: `quiltx stack catalog` shows current config
- [x] Manual: `quiltx stack cfn --catalog-name <name>` discovers stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)