### PR TITLE
Add declarative stack ACL tool (v0.6.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3.11
@@ -9,6 +9,7 @@ repos:
     hooks:
       - id: mypy
         args: ["quiltx", "tests"]
+        additional_dependencies: ["PyYAML", "types-PyYAML"]
         pass_filenames: false
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-04-09
 
 ### Added
 
-- `quiltx stack acl` for declarative reconciliation of Quilt buckets, managed policies, managed roles, and SSO mappings from YAML
+- `quiltx stack acl <config.yml>` for declarative reconciliation of Quilt buckets, managed policies, managed roles, and SSO mappings from YAML
+- `quiltx stack acl` (no args) dumps the current server ACL state for inspection
+- `--dry-run` flag to preview ACL changes without applying them
+- `--verbose` flag for detailed diff output including SSO and default-role details
+- Progress output during ACL apply (bucket, policy, role, SSO steps)
+- SSO create-vs-update detection: creates new SSO config or updates existing one as needed
+- Default role configuration moved into SSO config for cleaner YAML semantics
+- `auto_login` decorator in `quiltx.config` for automatic session refresh on auth failure
+- `normalize_catalog_url()` helper in `quiltx.config`
+- Public Python API: `AclConfig`, `AclDiff`, `CurrentState`, `all_buckets`, `apply_acl`, `build_sso_config`, `compute_diff`, `fetch_current_state`, `parse_acl_config`, `print_diff` exported from `quiltx`
 
 ### Changed
 
 - Add `pyyaml` as a runtime dependency for YAML-backed ACL configuration
 - Require `quilt3>=7.3.0` so `quiltx stack acl` can use the new admin policies API
+- `set_catalog_url()` now normalizes the URL (adds `https://`, strips trailing slash)
 
 ## [0.5.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `quiltx stack acl` for declarative reconciliation of Quilt buckets, managed policies, managed roles, and SSO mappings from YAML
+
+### Changed
+
+- Add `pyyaml` as a runtime dependency for YAML-backed ACL configuration
+- Require `quilt3>=7.3.0` so `quiltx stack acl` can use the new admin policies API
+
 ## [0.5.0] - 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Quilt extension toolkit for working with [Quilt](https://quiltdata.com) catalogs.
 
-## Usage
+## Quick start
 
 ```bash
 # See available tools
@@ -13,43 +13,60 @@ uvx quiltx
 # Configure a Quilt catalog
 uvx quiltx stack catalog https://open.quiltdata.com
 
-# Register a cross-account S3 bucket
-uvx quiltx bucket add s3://my-data-bucket
-
-# Discover the Quilt CloudFormation stack
-uvx quiltx stack cfn
-
-# Apply declarative ACL configuration from YAML
-uvx quiltx stack acl config.yml
-
-# Open an interactive shell in a running ECS task
-uvx quiltx ecs
-
-# Tail CloudWatch logs
-uvx quiltx logs --minutes 30 --filter "ERROR"
-
-# Get help for a specific tool
+# Get help for any tool
 uvx quiltx <tool> --help
 ```
 
 ## Tools
 
-- **bucket** — Register S3 buckets with Quilt (policy, SNS, notifications)
+- **bucket** — Register cross-account S3 buckets with Quilt (policy, SNS, notifications)
 - **ecs** — Interactive shell access to running ECS tasks via Session Manager
 - **logs** — Display and tail CloudWatch logs for the configured catalog
-- **stack** — Manage Quilt stack
-  - **stack acl** — Declarative ACL reconciliation (buckets, policies, roles, SSO) from YAML
+- **stack** — Manage Quilt stack:
+  - **stack acl** — Declarative access-control-list (ACL) reconciliation from YAML
   - **stack catalog** — Configure and display Quilt catalog settings
   - **stack cfn** — Discover the Quilt CloudFormation stack and cache metadata
 
 ## Stack ACL
 
-Declaratively manage a Quilt stack's access control — buckets, policies, roles,
-and SSO — from a single YAML file.
-See [demo-stack-acl.yml](spec/060-stack-acl/demo-stack-acl.yml) for a sample
-configuration.
+`quiltx stack acl` declaratively manages a Quilt stack's access control lists
+(ACLs) — buckets, policies, roles, and SSO mappings — from a single YAML file.
+Instead of clicking through the catalog admin UI, you define the desired state
+in version-controlled YAML and let the tool reconcile it against the server.
 
-### CLI
+### YAML example
+
+```yaml
+# Access control lists for a Quilt stack
+bucket_policies:
+  public:
+    read:
+      - quilt-example
+  internal:
+    read_write:
+      - quilt-bake
+      - quilt-dev
+    read:
+      - quilt-leadership
+
+roles:
+  visitor:
+    bucket_policies: [public]
+  member:
+    bucket_policies: [public, internal]
+    default: true          # assigned to new users
+
+sso:
+  - match:
+      groups: Employees
+    roles: [member]
+    admin: true
+  - match:
+      groups: Everyone
+    roles: [visitor]
+```
+
+### CLI usage
 
 ```bash
 # Show current server ACL state
@@ -79,45 +96,27 @@ from quiltx import (
     apply_acl,
 )
 
-# Parse a YAML config file
 config = parse_acl_config("config.yml")
-
-# Fetch live state from the Quilt stack
 current = fetch_current_state()
-
-# Compute and display the diff
 diff = compute_diff(config, current)
 print_diff(diff, verbose=True, desired=config, current=current)
 
-# Apply changes
 if diff.has_changes():
-    warnings = apply_acl(diff, current)
+    apply_acl(diff, current)
 ```
 
-## Python API — Config & Stack
+## Config and stack API
 
 ```python
-from quiltx import get_catalog_url, get_catalog_region, get_catalog_config, set_catalog_url
+from quiltx import get_catalog_url, get_catalog_region, set_catalog_url
 from quiltx.stack import find_matching_stack
 
-# Configure a catalog
 set_catalog_url("https://open.quiltdata.com")
+print(get_catalog_url())     # https://open.quiltdata.com
+print(get_catalog_region())  # us-east-1
 
-# Read catalog configuration
-print(get_catalog_url())    # https://open.quiltdata.com
-print(get_catalog_region()) # us-east-1
-print(get_catalog_config()) # full config dict
-
-# Discover stack
 stack = find_matching_stack(get_catalog_url())
 print(stack["StackName"])
-
-# Register an S3 bucket (policy, SNS, notifications, catalog)
-from quiltx.bucket import add_bucket
-
-result = add_bucket("my-data-bucket", title="My Data")
-print(result.sns_topic_arn)
-print(result.already_registered)
 ```
 
 ## Persistent install (optional)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ uvx quiltx bucket add s3://my-data-bucket
 # Discover the Quilt CloudFormation stack
 uvx quiltx stack cfn
 
+# Apply declarative ACL configuration from YAML
+uvx quiltx stack acl config.yml
+
 # Open an interactive shell in a running ECS task
 uvx quiltx ecs
 
@@ -35,10 +38,63 @@ uvx quiltx <tool> --help
 - **ecs** — Interactive shell access to running ECS tasks via Session Manager
 - **logs** — Display and tail CloudWatch logs for the configured catalog
 - **stack** — Manage Quilt stack
+  - **stack acl** — Declarative ACL reconciliation (buckets, policies, roles, SSO) from YAML
   - **stack catalog** — Configure and display Quilt catalog settings
   - **stack cfn** — Discover the Quilt CloudFormation stack and cache metadata
 
-## Python API
+## Stack ACL
+
+Declaratively manage a Quilt stack's access control — buckets, policies, roles,
+and SSO — from a single YAML file.
+See [demo-stack-acl.yml](spec/060-stack-acl/demo-stack-acl.yml) for a sample
+configuration.
+
+### CLI
+
+```bash
+# Show current server ACL state
+uvx quiltx stack acl
+
+# Preview changes (dry run)
+uvx quiltx stack acl config.yml --dry-run
+
+# Preview with full detail
+uvx quiltx stack acl config.yml --dry-run --verbose
+
+# Apply changes (with confirmation prompt)
+uvx quiltx stack acl config.yml
+
+# Apply without prompting
+uvx quiltx stack acl config.yml --yes
+```
+
+### Python API
+
+```python
+from quiltx import (
+    parse_acl_config,
+    fetch_current_state,
+    compute_diff,
+    print_diff,
+    apply_acl,
+)
+
+# Parse a YAML config file
+config = parse_acl_config("config.yml")
+
+# Fetch live state from the Quilt stack
+current = fetch_current_state()
+
+# Compute and display the diff
+diff = compute_diff(config, current)
+print_diff(diff, verbose=True, desired=config, current=current)
+
+# Apply changes
+if diff.has_changes():
+    warnings = apply_acl(diff, current)
+```
+
+## Python API — Config & Stack
 
 ```python
 from quiltx import get_catalog_url, get_catalog_region, get_catalog_config, set_catalog_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "quilt3",
+  "pyyaml",
+  "quilt3>=7.3.0",
   "rich"
 ]
 
@@ -25,7 +26,8 @@ dev = [
   "mypy",
   "pre-commit",
   "poethepoet",
-  "pytest"
+  "pytest",
+  "types-PyYAML",
 ]
 docs = [
   "mkdocs>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.5.0"
+version = "0.6.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/__init__.py
+++ b/quiltx/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from quiltx._version import __version__ as __version__
 from quiltx.config import (
+    auto_login as auto_login,
     get_catalog_config as get_catalog_config,
     get_catalog_region as get_catalog_region,
     get_catalog_url as get_catalog_url,
@@ -12,6 +13,7 @@ from quiltx.config import (
 
 __all__ = [
     "__version__",
+    "auto_login",
     "get_catalog_config",
     "get_catalog_region",
     "get_catalog_url",

--- a/quiltx/__init__.py
+++ b/quiltx/__init__.py
@@ -3,6 +3,18 @@
 from __future__ import annotations
 
 from quiltx._version import __version__ as __version__
+from quiltx.acl import (
+    AclConfig as AclConfig,
+    AclDiff as AclDiff,
+    CurrentState as CurrentState,
+    all_buckets as all_buckets,
+    apply_acl as apply_acl,
+    build_sso_config as build_sso_config,
+    compute_diff as compute_diff,
+    fetch_current_state as fetch_current_state,
+    parse_acl_config as parse_acl_config,
+    print_diff as print_diff,
+)
 from quiltx.config import (
     auto_login as auto_login,
     get_catalog_config as get_catalog_config,
@@ -13,9 +25,19 @@ from quiltx.config import (
 
 __all__ = [
     "__version__",
+    "AclConfig",
+    "AclDiff",
+    "CurrentState",
+    "all_buckets",
+    "apply_acl",
     "auto_login",
+    "build_sso_config",
+    "compute_diff",
+    "fetch_current_state",
     "get_catalog_config",
     "get_catalog_region",
     "get_catalog_url",
+    "parse_acl_config",
+    "print_diff",
     "set_catalog_url",
 ]

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -1,0 +1,491 @@
+"""Declarative ACL reconciliation for Quilt stacks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from quilt3.admin import buckets as admin_buckets
+from quilt3.admin import policies as admin_policies
+from quilt3.admin import roles as admin_roles
+from quilt3.admin import sso_config as admin_sso_config
+from quilt3.admin.types import Permission
+
+
+@dataclass(frozen=True)
+class AclBucketPolicy:
+    name: str
+    read: list[str] = field(default_factory=list)
+    read_write: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AclRole:
+    name: str
+    bucket_policies: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AclSsoMapping:
+    match: dict[str, str]
+    roles: list[str]
+    admin: bool = False
+
+
+@dataclass(frozen=True)
+class AclConfig:
+    bucket_policies: dict[str, AclBucketPolicy]
+    roles: dict[str, AclRole]
+    sso: list[AclSsoMapping]
+
+
+@dataclass(frozen=True)
+class CurrentState:
+    buckets: dict[str, Any]
+    managed_policies: dict[str, Any]
+    unmanaged_policies: dict[str, Any]
+    all_policies: dict[str, Any]
+    managed_roles: dict[str, Any]
+    unmanaged_roles: dict[str, Any]
+    all_roles: dict[str, Any]
+    sso_config_text: str | None
+    default_role_name: str | None
+
+
+@dataclass(frozen=True)
+class PolicyUpdate:
+    title: str
+    permissions: list[Permission]
+
+
+@dataclass(frozen=True)
+class RoleUpdate:
+    name: str
+    policy_titles: list[str]
+
+
+@dataclass
+class AclDiff:
+    buckets_to_add: list[str] = field(default_factory=list)
+    policies_to_create: list[PolicyUpdate] = field(default_factory=list)
+    policies_to_update: list[PolicyUpdate] = field(default_factory=list)
+    policies_to_delete: list[str] = field(default_factory=list)
+    roles_to_create: list[RoleUpdate] = field(default_factory=list)
+    roles_to_update: list[RoleUpdate] = field(default_factory=list)
+    roles_to_delete: list[str] = field(default_factory=list)
+    sso_config_text: str | None = None
+    sso_needs_update: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    def has_changes(self) -> bool:
+        return any(
+            (
+                self.buckets_to_add,
+                self.policies_to_create,
+                self.policies_to_update,
+                self.policies_to_delete,
+                self.roles_to_create,
+                self.roles_to_update,
+                self.roles_to_delete,
+                self.sso_needs_update,
+            )
+        )
+
+
+def parse_acl_config(path: str | Path) -> AclConfig:
+    """Load and validate ACL configuration from YAML."""
+    raw = yaml.safe_load(Path(path).read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("ACL config must be a mapping at the top level")
+
+    raw_bucket_policies = raw.get("bucket_policies") or {}
+    raw_roles = raw.get("roles") or {}
+    raw_sso = raw.get("sso") or []
+
+    if not isinstance(raw_bucket_policies, dict):
+        raise ValueError("'bucket_policies' must be a mapping")
+    if not isinstance(raw_roles, dict):
+        raise ValueError("'roles' must be a mapping")
+    if not isinstance(raw_sso, list):
+        raise ValueError("'sso' must be a list")
+
+    bucket_policies: dict[str, AclBucketPolicy] = {}
+    for name, value in raw_bucket_policies.items():
+        if not isinstance(name, str):
+            raise ValueError("Bucket policy names must be strings")
+        if not isinstance(value, dict):
+            raise ValueError(f"Bucket policy '{name}' must be a mapping")
+        read = _coerce_string_list(
+            value.get("read", []), f"bucket_policies.{name}.read"
+        )
+        read_write = _coerce_string_list(
+            value.get("read_write", []), f"bucket_policies.{name}.read_write"
+        )
+        bucket_policies[name] = AclBucketPolicy(
+            name=name,
+            read=sorted(set(read)),
+            read_write=sorted(set(read_write)),
+        )
+
+    roles: dict[str, AclRole] = {}
+    for name, value in raw_roles.items():
+        if not isinstance(name, str):
+            raise ValueError("Role names must be strings")
+        if not isinstance(value, dict):
+            raise ValueError(f"Role '{name}' must be a mapping")
+        policy_names = _coerce_string_list(
+            value.get("bucket_policies", []), f"roles.{name}.bucket_policies"
+        )
+        missing = sorted(set(policy_names) - bucket_policies.keys())
+        if missing:
+            raise ValueError(
+                f"Role '{name}' references unknown bucket policies: {', '.join(missing)}"
+            )
+        roles[name] = AclRole(name=name, bucket_policies=policy_names)
+
+    sso: list[AclSsoMapping] = []
+    for index, value in enumerate(raw_sso):
+        if not isinstance(value, dict):
+            raise ValueError(f"sso[{index}] must be a mapping")
+        match = value.get("match")
+        if not isinstance(match, dict) or not match:
+            raise ValueError(f"sso[{index}].match must be a non-empty mapping")
+        normalized_match: dict[str, str] = {}
+        for key, match_value in match.items():
+            if not isinstance(key, str):
+                raise ValueError(f"sso[{index}].match keys must be strings")
+            if not isinstance(match_value, str):
+                raise ValueError(f"sso[{index}].match.{key} must be a string")
+            normalized_match[key] = match_value
+
+        mapping_roles = _coerce_string_list(
+            value.get("roles", []), f"sso[{index}].roles"
+        )
+        if not mapping_roles:
+            raise ValueError(f"sso[{index}].roles must not be empty")
+        missing_roles = sorted(set(mapping_roles) - roles.keys())
+        if missing_roles:
+            raise ValueError(
+                f"sso[{index}] references unknown roles: {', '.join(missing_roles)}"
+            )
+
+        admin = value.get("admin", False)
+        if not isinstance(admin, bool):
+            raise ValueError(f"sso[{index}].admin must be a boolean")
+
+        sso.append(
+            AclSsoMapping(match=normalized_match, roles=mapping_roles, admin=admin)
+        )
+
+    return AclConfig(bucket_policies=bucket_policies, roles=roles, sso=sso)
+
+
+def all_buckets(config: AclConfig) -> set[str]:
+    """Return all buckets referenced by the ACL config."""
+    result: set[str] = set()
+    for policy in config.bucket_policies.values():
+        result.update(policy.read)
+        result.update(policy.read_write)
+    return result
+
+
+def fetch_current_state() -> CurrentState:
+    """Fetch current buckets, policies, roles, and SSO configuration."""
+    bucket_items = {bucket.name: bucket for bucket in admin_buckets.list()}
+
+    managed_policies: dict[str, Any] = {}
+    unmanaged_policies: dict[str, Any] = {}
+    for policy in admin_policies.list():
+        if policy.managed:
+            managed_policies[policy.title] = policy
+        else:
+            unmanaged_policies[policy.title] = policy
+
+    managed_roles: dict[str, Any] = {}
+    unmanaged_roles: dict[str, Any] = {}
+    for role in admin_roles.list():
+        typename = getattr(role, "typename__", "")
+        if typename == "ManagedRole":
+            managed_roles[role.name] = role
+        else:
+            unmanaged_roles[role.name] = role
+
+    sso_config = admin_sso_config.get()
+    default_role = admin_roles.get_default()
+    return CurrentState(
+        buckets=bucket_items,
+        managed_policies=managed_policies,
+        unmanaged_policies=unmanaged_policies,
+        all_policies={**unmanaged_policies, **managed_policies},
+        managed_roles=managed_roles,
+        unmanaged_roles=unmanaged_roles,
+        all_roles={**unmanaged_roles, **managed_roles},
+        sso_config_text=None if sso_config is None else sso_config.text,
+        default_role_name=None if default_role is None else default_role.name,
+    )
+
+
+def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
+    """Compute the actions required to reconcile ACL state."""
+    diff = AclDiff()
+    diff.buckets_to_add = sorted(all_buckets(desired) - current.buckets.keys())
+
+    for name, bucket_policy in desired.bucket_policies.items():
+        desired_permissions = _permissions_for_policy(bucket_policy)
+        if name in current.unmanaged_policies:
+            diff.warnings.append(
+                f"Policy '{name}' already exists as unmanaged; skipping managed policy update."
+            )
+            continue
+
+        current_policy = current.managed_policies.get(name)
+        if current_policy is None:
+            diff.policies_to_create.append(
+                PolicyUpdate(title=name, permissions=desired_permissions)
+            )
+            continue
+
+        if _canonical_permissions(current_policy.permissions) != _canonical_permissions(
+            desired_permissions
+        ):
+            diff.policies_to_update.append(
+                PolicyUpdate(title=name, permissions=desired_permissions)
+            )
+
+    diff.policies_to_delete = sorted(
+        title
+        for title in current.managed_policies.keys()
+        if title not in desired.bucket_policies
+    )
+
+    for name, role in desired.roles.items():
+        if name in current.unmanaged_roles:
+            diff.warnings.append(
+                f"Role '{name}' already exists as unmanaged; skipping managed role update."
+            )
+            continue
+
+        current_role = current.managed_roles.get(name)
+        desired_policy_titles = sorted(role.bucket_policies)
+        if current_role is None:
+            diff.roles_to_create.append(
+                RoleUpdate(name=name, policy_titles=desired_policy_titles)
+            )
+            continue
+
+        current_policy_titles = sorted(policy.title for policy in current_role.policies)
+        if current_policy_titles != desired_policy_titles:
+            diff.roles_to_update.append(
+                RoleUpdate(name=name, policy_titles=desired_policy_titles)
+            )
+
+    current_sso_roles = _extract_sso_roles(current.sso_config_text)
+    diff.roles_to_delete = sorted(
+        name
+        for name in current.managed_roles.keys()
+        if name not in desired.roles
+        and name not in current_sso_roles
+        and name != current.default_role_name
+    )
+
+    for name in sorted(current.managed_roles.keys() - set(desired.roles)):
+        if name in current_sso_roles:
+            diff.warnings.append(
+                f"Role '{name}' is still referenced by the current SSO config; skipping delete."
+            )
+        elif name == current.default_role_name:
+            diff.warnings.append(
+                f"Role '{name}' is the current default role; skipping delete."
+            )
+
+    desired_sso_text = build_sso_config(desired.sso) if desired.sso else None
+    if desired_sso_text is not None and not _same_yaml(
+        current.sso_config_text, desired_sso_text
+    ):
+        diff.sso_config_text = desired_sso_text
+        diff.sso_needs_update = True
+
+    return diff
+
+
+def build_sso_config(mappings: list[AclSsoMapping]) -> str:
+    """Translate simplified SSO mappings to Quilt's schema-based YAML."""
+    payload: dict[str, Any] = {
+        "version": "1.0",
+        "mappings": [],
+    }
+    for mapping in mappings:
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for key, value in mapping.match.items():
+            if key == "groups":
+                properties[key] = {
+                    "type": "array",
+                    "contains": {"const": value},
+                }
+            else:
+                properties[key] = {"const": value}
+            required.append(key)
+
+        payload["mappings"].append(
+            {
+                "schema": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+                "roles": list(mapping.roles),
+                "admin": mapping.admin,
+            }
+        )
+    return yaml.safe_dump(payload, sort_keys=False)
+
+
+def print_diff(diff: AclDiff) -> None:
+    """Print a readable summary of ACL changes."""
+    for bucket in diff.buckets_to_add:
+        print(f"+ bucket {bucket}")
+
+    for policy in diff.policies_to_create:
+        print(f"+ policy {policy.title}")
+    for policy in diff.policies_to_update:
+        print(f"~ policy {policy.title}")
+    for title in diff.policies_to_delete:
+        print(f"- policy {title}")
+
+    for role in diff.roles_to_create:
+        print(f"+ role {role.name}")
+    for role in diff.roles_to_update:
+        print(f"~ role {role.name}")
+    for name in diff.roles_to_delete:
+        print(f"- role {name}")
+
+    if diff.sso_needs_update:
+        print("~ sso config")
+
+    for warning in diff.warnings:
+        print(f"! {warning}")
+
+    if not diff.has_changes() and not diff.warnings:
+        print("Stack ACL is up to date")
+
+
+def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
+    """Apply ACL changes. Returns any runtime warnings."""
+    warnings = list(diff.warnings)
+
+    for bucket in diff.buckets_to_add:
+        try:
+            admin_buckets.add(bucket, bucket)
+        except Exception as exc:  # pragma: no cover - external API surface
+            warnings.append(f"Bucket '{bucket}' could not be added: {exc}")
+
+    known_policies = dict(current.all_policies)
+    for policy in diff.policies_to_create:
+        created = admin_policies.create_managed(
+            policy.title, permissions=policy.permissions
+        )
+        known_policies[policy.title] = created
+    for policy in diff.policies_to_update:
+        updated = admin_policies.update_managed(
+            policy.title,
+            title=policy.title,
+            permissions=policy.permissions,
+            roles=[],
+        )
+        known_policies[policy.title] = updated
+
+    for role in diff.roles_to_create:
+        try:
+            policy_ids = _resolve_policy_ids(role.policy_titles, known_policies)
+        except KeyError as exc:
+            warnings.append(
+                f"Role '{role.name}' skipped: unknown policy {exc.args[0]!r}."
+            )
+            continue
+        admin_roles.create_managed(role.name, policies=policy_ids)
+
+    for role in diff.roles_to_update:
+        try:
+            policy_ids = _resolve_policy_ids(role.policy_titles, known_policies)
+        except KeyError as exc:
+            warnings.append(
+                f"Role '{role.name}' skipped: unknown policy {exc.args[0]!r}."
+            )
+            continue
+        admin_roles.update_managed(role.name, name=role.name, policies=policy_ids)
+
+    if diff.sso_needs_update and diff.sso_config_text is not None:
+        admin_sso_config.set(diff.sso_config_text)
+
+    for role_name in diff.roles_to_delete:
+        try:
+            admin_roles.delete(role_name)
+        except Exception as exc:  # pragma: no cover - external API surface
+            warnings.append(f"Role '{role_name}' could not be deleted: {exc}")
+
+    for policy_title in diff.policies_to_delete:
+        try:
+            admin_policies.delete(policy_title)
+        except Exception as exc:  # pragma: no cover - external API surface
+            warnings.append(f"Policy '{policy_title}' could not be deleted: {exc}")
+
+    return warnings
+
+
+def _coerce_string_list(value: Any, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"'{field_name}' must be a list")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError(f"'{field_name}' entries must all be strings")
+    return list(value)
+
+
+def _permissions_for_policy(policy: AclBucketPolicy) -> list[Permission]:
+    permissions = [Permission.read(bucket) for bucket in sorted(set(policy.read))]
+    permissions.extend(
+        Permission.read_write(bucket) for bucket in sorted(set(policy.read_write))
+    )
+    return permissions
+
+
+def _canonical_permissions(permissions: list[Permission]) -> list[tuple[str, str]]:
+    return sorted(
+        (permission.bucket, str(permission.level)) for permission in permissions
+    )
+
+
+def _same_yaml(left: str | None, right: str | None) -> bool:
+    return yaml.safe_load(left or "") == yaml.safe_load(right or "")
+
+
+def _resolve_policy_ids(
+    policy_titles: list[str], known_policies: dict[str, Any]
+) -> list[str]:
+    return [known_policies[title].id for title in policy_titles]
+
+
+def _extract_sso_roles(config_text: str | None) -> set[str]:
+    if not config_text:
+        return set()
+    loaded = yaml.safe_load(config_text) or {}
+    if not isinstance(loaded, dict):
+        return set()
+
+    roles = set()
+    default_role = loaded.get("default_role")
+    if isinstance(default_role, str):
+        roles.add(default_role)
+
+    mappings = loaded.get("mappings") or []
+    if isinstance(mappings, list):
+        for mapping in mappings:
+            if isinstance(mapping, dict):
+                mapping_roles = mapping.get("roles") or []
+                if isinstance(mapping_roles, list):
+                    roles.update(
+                        role for role in mapping_roles if isinstance(role, str)
+                    )
+    return roles

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from quiltx.config import auto_login
 from quilt3.admin import buckets as admin_buckets
 from quilt3.admin import policies as admin_policies
 from quilt3.admin import roles as admin_roles
@@ -76,6 +78,7 @@ class AclDiff:
     roles_to_update: list[RoleUpdate] = field(default_factory=list)
     roles_to_delete: list[str] = field(default_factory=list)
     sso_config_text: str | None = None
+    sso_is_create: bool = False
     sso_needs_update: bool = False
     warnings: list[str] = field(default_factory=list)
 
@@ -191,6 +194,7 @@ def all_buckets(config: AclConfig) -> set[str]:
     return result
 
 
+@auto_login
 def fetch_current_state() -> CurrentState:
     """Fetch current buckets, policies, roles, and SSO configuration."""
     bucket_items = {bucket.name: bucket for bucket in admin_buckets.list()}
@@ -305,6 +309,7 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
         current.sso_config_text, desired_sso_text
     ):
         diff.sso_config_text = desired_sso_text
+        diff.sso_is_create = current.sso_config_text is None
         diff.sso_needs_update = True
 
     return diff
@@ -343,27 +348,39 @@ def build_sso_config(mappings: list[AclSsoMapping]) -> str:
     return yaml.safe_dump(payload, sort_keys=False)
 
 
-def print_diff(diff: AclDiff) -> None:
+def print_diff(diff: AclDiff, *, verbose: bool = False) -> None:
     """Print a readable summary of ACL changes."""
     for bucket in diff.buckets_to_add:
         print(f"+ bucket {bucket}")
 
     for policy in diff.policies_to_create:
         print(f"+ policy {policy.title}")
+        if verbose:
+            _print_permissions(policy.permissions)
     for policy in diff.policies_to_update:
         print(f"~ policy {policy.title}")
+        if verbose:
+            _print_permissions(policy.permissions)
     for title in diff.policies_to_delete:
         print(f"- policy {title}")
 
     for role in diff.roles_to_create:
         print(f"+ role {role.name}")
+        if verbose:
+            print(f"    policies: {', '.join(role.policy_titles)}")
     for role in diff.roles_to_update:
         print(f"~ role {role.name}")
+        if verbose:
+            print(f"    policies: {', '.join(role.policy_titles)}")
     for name in diff.roles_to_delete:
         print(f"- role {name}")
 
     if diff.sso_needs_update:
-        print("~ sso config")
+        prefix = "+" if diff.sso_is_create else "~"
+        print(f"{prefix} sso config")
+        if verbose and diff.sso_config_text:
+            for line in diff.sso_config_text.rstrip().splitlines():
+                print(f"    {line}")
 
     for warning in diff.warnings:
         print(f"! {warning}")
@@ -379,6 +396,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
     for bucket in diff.buckets_to_add:
         try:
             admin_buckets.add(bucket, bucket)
+            print(f"  + bucket {bucket}")
         except Exception as exc:  # pragma: no cover - external API surface
             warnings.append(f"Bucket '{bucket}' could not be added: {exc}")
 
@@ -388,6 +406,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
             policy.title, permissions=policy.permissions
         )
         known_policies[policy.title] = created
+        print(f"  + policy {policy.title}")
     for policy in diff.policies_to_update:
         updated = admin_policies.update_managed(
             policy.title,
@@ -396,6 +415,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
             roles=[],
         )
         known_policies[policy.title] = updated
+        print(f"  ~ policy {policy.title}")
 
     for role in diff.roles_to_create:
         try:
@@ -406,6 +426,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
             )
             continue
         admin_roles.create_managed(role.name, policies=policy_ids)
+        print(f"  + role {role.name}")
 
     for role in diff.roles_to_update:
         try:
@@ -416,23 +437,33 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
             )
             continue
         admin_roles.update_managed(role.name, name=role.name, policies=policy_ids)
+        print(f"  ~ role {role.name}")
 
     if diff.sso_needs_update and diff.sso_config_text is not None:
         admin_sso_config.set(diff.sso_config_text)
+        prefix = "+" if diff.sso_is_create else "~"
+        print(f"  {prefix} sso config")
 
     for role_name in diff.roles_to_delete:
         try:
             admin_roles.delete(role_name)
+            print(f"  - role {role_name}")
         except Exception as exc:  # pragma: no cover - external API surface
             warnings.append(f"Role '{role_name}' could not be deleted: {exc}")
 
     for policy_title in diff.policies_to_delete:
         try:
             admin_policies.delete(policy_title)
+            print(f"  - policy {policy_title}")
         except Exception as exc:  # pragma: no cover - external API surface
             warnings.append(f"Policy '{policy_title}' could not be deleted: {exc}")
 
     return warnings
+
+
+def _print_permissions(permissions: list[Permission]) -> None:
+    for perm in permissions:
+        print(f"    {perm.level}: {perm.bucket}")
 
 
 def _coerce_string_list(value: Any, field_name: str) -> list[str]:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +27,7 @@ class AclBucketPolicy:
 class AclRole:
     name: str
     bucket_policies: list[str] = field(default_factory=list)
+    default: bool = False
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,7 @@ class AclConfig:
     bucket_policies: dict[str, AclBucketPolicy]
     roles: dict[str, AclRole]
     sso: list[AclSsoMapping]
+    default_role_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -77,6 +79,8 @@ class AclDiff:
     roles_to_create: list[RoleUpdate] = field(default_factory=list)
     roles_to_update: list[RoleUpdate] = field(default_factory=list)
     roles_to_delete: list[str] = field(default_factory=list)
+    default_role_name: str | None = None
+    default_role_needs_update: bool = False
     sso_config_text: str | None = None
     sso_is_create: bool = False
     sso_needs_update: bool = False
@@ -92,6 +96,7 @@ class AclDiff:
                 self.roles_to_create,
                 self.roles_to_update,
                 self.roles_to_delete,
+                self.default_role_needs_update,
                 self.sso_needs_update,
             )
         )
@@ -133,6 +138,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
         )
 
     roles: dict[str, AclRole] = {}
+    default_roles: list[str] = []
     for name, value in raw_roles.items():
         if not isinstance(name, str):
             raise ValueError("Role names must be strings")
@@ -146,7 +152,18 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError(
                 f"Role '{name}' references unknown bucket policies: {', '.join(missing)}"
             )
-        roles[name] = AclRole(name=name, bucket_policies=policy_names)
+        default = value.get("default", False)
+        if not isinstance(default, bool):
+            raise ValueError(f"roles.{name}.default must be a boolean")
+        if default:
+            default_roles.append(name)
+        roles[name] = AclRole(name=name, bucket_policies=policy_names, default=default)
+
+    if len(default_roles) > 1:
+        raise ValueError(
+            "Only one role may set default: true; found "
+            + ", ".join(sorted(default_roles))
+        )
 
     sso: list[AclSsoMapping] = []
     for index, value in enumerate(raw_sso):
@@ -182,7 +199,13 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             AclSsoMapping(match=normalized_match, roles=mapping_roles, admin=admin)
         )
 
-    return AclConfig(bucket_policies=bucket_policies, roles=roles, sso=sso)
+    default_role_name = default_roles[0] if default_roles else None
+    return AclConfig(
+        bucket_policies=bucket_policies,
+        roles=roles,
+        sso=sso,
+        default_role_name=default_role_name,
+    )
 
 
 def all_buckets(config: AclConfig) -> set[str]:
@@ -304,6 +327,14 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
                 f"Role '{name}' is the current default role; skipping delete."
             )
 
+    if (
+        desired.default_role_name is not None
+        and desired.default_role_name in desired.roles
+        and desired.default_role_name != current.default_role_name
+    ):
+        diff.default_role_name = desired.default_role_name
+        diff.default_role_needs_update = True
+
     desired_sso_text = build_sso_config(desired.sso) if desired.sso else None
     if desired_sso_text is not None and not _same_yaml(
         current.sso_config_text, desired_sso_text
@@ -348,8 +379,22 @@ def build_sso_config(mappings: list[AclSsoMapping]) -> str:
     return yaml.safe_dump(payload, sort_keys=False)
 
 
-def print_diff(diff: AclDiff, *, verbose: bool = False) -> None:
+def print_diff(
+    diff: AclDiff,
+    *,
+    verbose: bool = False,
+    desired: AclConfig | None = None,
+    current: CurrentState | None = None,
+) -> None:
     """Print a readable summary of ACL changes."""
+    if verbose and desired is not None:
+        _print_verbose_state(diff, desired, current)
+        for warning in diff.warnings:
+            print(f"! {warning}")
+        if not diff.has_changes() and not diff.warnings:
+            print("Stack ACL is up to date")
+        return
+
     for bucket in diff.buckets_to_add:
         print(f"+ bucket {bucket}")
 
@@ -374,6 +419,9 @@ def print_diff(diff: AclDiff, *, verbose: bool = False) -> None:
             print(f"    policies: {', '.join(role.policy_titles)}")
     for name in diff.roles_to_delete:
         print(f"- role {name}")
+
+    if diff.default_role_needs_update and diff.default_role_name is not None:
+        print(f"~ default role {diff.default_role_name}")
 
     if diff.sso_needs_update:
         prefix = "+" if diff.sso_is_create else "~"
@@ -439,6 +487,10 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
         admin_roles.update_managed(role.name, name=role.name, policies=policy_ids)
         print(f"  ~ role {role.name}")
 
+    if diff.default_role_needs_update and diff.default_role_name is not None:
+        admin_roles.set_default(diff.default_role_name)
+        print(f"  ~ default role {diff.default_role_name}")
+
     if diff.sso_needs_update and diff.sso_config_text is not None:
         admin_sso_config.set(diff.sso_config_text)
         prefix = "+" if diff.sso_is_create else "~"
@@ -464,6 +516,64 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 def _print_permissions(permissions: list[Permission]) -> None:
     for perm in permissions:
         print(f"    {perm.level}: {perm.bucket}")
+
+
+def _print_verbose_state(
+    diff: AclDiff, desired: AclConfig, current: CurrentState | None
+) -> None:
+    print("Desired ACL:")
+
+    changed_buckets = set(diff.buckets_to_add)
+    for bucket in sorted(all_buckets(desired)):
+        prefix = "+" if bucket in changed_buckets else "="
+        print(f"{prefix} bucket {bucket}")
+
+    created_policies = {policy.title for policy in diff.policies_to_create}
+    updated_policies = {policy.title for policy in diff.policies_to_update}
+    for title, policy in desired.bucket_policies.items():
+        if title in created_policies:
+            prefix = "+"
+        elif title in updated_policies:
+            prefix = "~"
+        else:
+            prefix = "="
+        print(f"{prefix} policy {title}")
+        _print_permissions(_permissions_for_policy(policy))
+
+    created_roles = {role.name for role in diff.roles_to_create}
+    updated_roles = {role.name for role in diff.roles_to_update}
+    for name, role in desired.roles.items():
+        if name in created_roles:
+            prefix = "+"
+        elif name in updated_roles:
+            prefix = "~"
+        else:
+            prefix = "="
+        print(f"{prefix} role {name}")
+        print(f"    policies: {', '.join(role.bucket_policies) or '(none)'}")
+        if role.default:
+            print("    default: true")
+
+    if desired.default_role_name is not None:
+        prefix = "~" if diff.default_role_needs_update else "="
+        print(f"{prefix} default role {desired.default_role_name}")
+
+    if desired.sso:
+        prefix = (
+            "+"
+            if diff.sso_is_create and diff.sso_needs_update
+            else "~" if diff.sso_needs_update else "="
+        )
+        print(f"{prefix} sso config")
+        sso_text = (
+            diff.sso_config_text
+            if diff.sso_config_text is not None
+            else build_sso_config(desired.sso)
+        )
+        for line in sso_text.rstrip().splitlines():
+            print(f"    {line}")
+    elif current is not None and current.sso_config_text:
+        print("= no sso config requested")
 
 
 def _coerce_string_list(value: Any, field_name: str) -> list[str]:
@@ -520,3 +630,8 @@ def _extract_sso_roles(config_text: str | None) -> set[str]:
                         role for role in mapping_roles if isinstance(role, str)
                     )
     return roles
+
+
+def with_default_role(config: AclConfig, default_role_name: str | None) -> AclConfig:
+    """Return a copy of config with the selected default role name."""
+    return replace(config, default_role_name=default_role_name)

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -431,6 +431,57 @@ def print_diff(
         print("Stack ACL is up to date")
 
 
+def print_current_state(current: CurrentState) -> None:
+    """Print a human-readable dump of the current server ACL state."""
+    for name in sorted(current.buckets):
+        print(f"  bucket {name}")
+
+    for title, policy in sorted(current.managed_policies.items()):
+        print(f"  policy {title} (managed)")
+        _print_permissions(policy.permissions)
+    for title, policy in sorted(current.unmanaged_policies.items()):
+        print(f"  policy {title} (unmanaged)")
+        _print_permissions(policy.permissions)
+
+    for name, role in sorted(current.managed_roles.items()):
+        default_tag = " (default)" if name == current.default_role_name else ""
+        policy_names = ", ".join(p.title for p in role.policies) or "(none)"
+        print(f"  role {name}{default_tag} (managed)")
+        print(f"    policies: {policy_names}")
+    for name, role in sorted(current.unmanaged_roles.items()):
+        default_tag = " (default)" if name == current.default_role_name else ""
+        policies = getattr(role, "policies", None)
+        policy_names = ", ".join(p.title for p in policies) if policies else "(n/a)"
+        print(f"  role {name}{default_tag} (unmanaged)")
+        print(f"    policies: {policy_names}")
+
+    if current.sso_config_text:
+        print("  sso config")
+        _print_sso_summary(current.sso_config_text)
+    else:
+        print("  sso config: (none)")
+
+
+def _print_sso_summary(sso_text: str) -> None:
+    """Print a human-friendly summary of SSO mappings."""
+    loaded = yaml.safe_load(sso_text) or {}
+    default_role = loaded.get("default_role")
+    if default_role:
+        print(f"    default_role: {default_role}")
+    for mapping in loaded.get("mappings") or []:
+        match_parts = []
+        props = mapping.get("schema", {}).get("properties", {})
+        for key, schema in props.items():
+            if "contains" in schema:
+                match_parts.append(f"{key}={schema['contains'].get('const', '?')}")
+            elif "const" in schema:
+                match_parts.append(f"{key}={schema['const']}")
+        match_str = ", ".join(match_parts) or "?"
+        roles = mapping.get("roles", [])
+        admin = " (admin)" if mapping.get("admin") else ""
+        print(f"    {match_str} -> [{', '.join(roles)}]{admin}")
+
+
 def apply_acl(
     diff: AclDiff, current: CurrentState, *, verbose: bool = False
 ) -> list[str]:
@@ -515,7 +566,8 @@ def apply_acl(
 
 def _print_permissions(permissions: list[Permission]) -> None:
     for perm in permissions:
-        print(f"    {perm.level}: {perm.bucket}")
+        level = perm.level.name if hasattr(perm.level, "name") else str(perm.level)
+        print(f"    {level}: {perm.bucket}")
 
 
 def _print_apply_step(message: str, *, verbose: bool) -> None:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -79,8 +79,6 @@ class AclDiff:
     roles_to_create: list[RoleUpdate] = field(default_factory=list)
     roles_to_update: list[RoleUpdate] = field(default_factory=list)
     roles_to_delete: list[str] = field(default_factory=list)
-    default_role_name: str | None = None
-    default_role_needs_update: bool = False
     sso_config_text: str | None = None
     sso_is_create: bool = False
     sso_needs_update: bool = False
@@ -96,7 +94,6 @@ class AclDiff:
                 self.roles_to_create,
                 self.roles_to_update,
                 self.roles_to_delete,
-                self.default_role_needs_update,
                 self.sso_needs_update,
             )
         )
@@ -327,15 +324,11 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
                 f"Role '{name}' is the current default role; skipping delete."
             )
 
-    if (
-        desired.default_role_name is not None
-        and desired.default_role_name in desired.roles
-        and desired.default_role_name != current.default_role_name
-    ):
-        diff.default_role_name = desired.default_role_name
-        diff.default_role_needs_update = True
-
-    desired_sso_text = build_sso_config(desired.sso) if desired.sso else None
+    desired_sso_text = (
+        build_sso_config(desired.sso, default_role_name=desired.default_role_name)
+        if desired.sso
+        else None
+    )
     if desired_sso_text is not None and not _same_yaml(
         current.sso_config_text, desired_sso_text
     ):
@@ -346,12 +339,16 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
     return diff
 
 
-def build_sso_config(mappings: list[AclSsoMapping]) -> str:
+def build_sso_config(
+    mappings: list[AclSsoMapping], *, default_role_name: str | None = None
+) -> str:
     """Translate simplified SSO mappings to Quilt's schema-based YAML."""
     payload: dict[str, Any] = {
         "version": "1.0",
         "mappings": [],
     }
+    if default_role_name is not None:
+        payload["default_role"] = default_role_name
     for mapping in mappings:
         properties: dict[str, Any] = {}
         required: list[str] = []
@@ -420,9 +417,6 @@ def print_diff(
     for name in diff.roles_to_delete:
         print(f"- role {name}")
 
-    if diff.default_role_needs_update and diff.default_role_name is not None:
-        print(f"~ default role {diff.default_role_name}")
-
     if diff.sso_needs_update:
         prefix = "+" if diff.sso_is_create else "~"
         print(f"{prefix} sso config")
@@ -437,12 +431,15 @@ def print_diff(
         print("Stack ACL is up to date")
 
 
-def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
+def apply_acl(
+    diff: AclDiff, current: CurrentState, *, verbose: bool = False
+) -> list[str]:
     """Apply ACL changes. Returns any runtime warnings."""
     warnings = list(diff.warnings)
 
     for bucket in diff.buckets_to_add:
         try:
+            _print_apply_step(f"add bucket {bucket}", verbose=verbose)
             admin_buckets.add(bucket, bucket)
             print(f"  + bucket {bucket}")
         except Exception as exc:  # pragma: no cover - external API surface
@@ -450,12 +447,14 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 
     known_policies = dict(current.all_policies)
     for policy in diff.policies_to_create:
+        _print_apply_step(f"create policy {policy.title}", verbose=verbose)
         created = admin_policies.create_managed(
             policy.title, permissions=policy.permissions
         )
         known_policies[policy.title] = created
         print(f"  + policy {policy.title}")
     for policy in diff.policies_to_update:
+        _print_apply_step(f"update policy {policy.title}", verbose=verbose)
         updated = admin_policies.update_managed(
             policy.title,
             title=policy.title,
@@ -467,6 +466,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 
     for role in diff.roles_to_create:
         try:
+            _print_apply_step(f"create role {role.name}", verbose=verbose)
             policy_ids = _resolve_policy_ids(role.policy_titles, known_policies)
         except KeyError as exc:
             warnings.append(
@@ -478,6 +478,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 
     for role in diff.roles_to_update:
         try:
+            _print_apply_step(f"update role {role.name}", verbose=verbose)
             policy_ids = _resolve_policy_ids(role.policy_titles, known_policies)
         except KeyError as exc:
             warnings.append(
@@ -487,17 +488,15 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
         admin_roles.update_managed(role.name, name=role.name, policies=policy_ids)
         print(f"  ~ role {role.name}")
 
-    if diff.default_role_needs_update and diff.default_role_name is not None:
-        admin_roles.set_default(diff.default_role_name)
-        print(f"  ~ default role {diff.default_role_name}")
-
     if diff.sso_needs_update and diff.sso_config_text is not None:
+        _print_apply_step("update sso config", verbose=verbose)
         admin_sso_config.set(diff.sso_config_text)
         prefix = "+" if diff.sso_is_create else "~"
         print(f"  {prefix} sso config")
 
     for role_name in diff.roles_to_delete:
         try:
+            _print_apply_step(f"delete role {role_name}", verbose=verbose)
             admin_roles.delete(role_name)
             print(f"  - role {role_name}")
         except Exception as exc:  # pragma: no cover - external API surface
@@ -505,6 +504,7 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 
     for policy_title in diff.policies_to_delete:
         try:
+            _print_apply_step(f"delete policy {policy_title}", verbose=verbose)
             admin_policies.delete(policy_title)
             print(f"  - policy {policy_title}")
         except Exception as exc:  # pragma: no cover - external API surface
@@ -516,6 +516,11 @@ def apply_acl(diff: AclDiff, current: CurrentState) -> list[str]:
 def _print_permissions(permissions: list[Permission]) -> None:
     for perm in permissions:
         print(f"    {perm.level}: {perm.bucket}")
+
+
+def _print_apply_step(message: str, *, verbose: bool) -> None:
+    if verbose:
+        print(f"-> {message}")
 
 
 def _print_verbose_state(
@@ -554,10 +559,6 @@ def _print_verbose_state(
         if role.default:
             print("    default: true")
 
-    if desired.default_role_name is not None:
-        prefix = "~" if diff.default_role_needs_update else "="
-        print(f"{prefix} default role {desired.default_role_name}")
-
     if desired.sso:
         prefix = (
             "+"
@@ -568,7 +569,9 @@ def _print_verbose_state(
         sso_text = (
             diff.sso_config_text
             if diff.sso_config_text is not None
-            else build_sso_config(desired.sso)
+            else build_sso_config(
+                desired.sso, default_role_name=desired.default_role_name
+            )
         )
         for line in sso_text.rstrip().splitlines():
             print(f"    {line}")

--- a/quiltx/config.py
+++ b/quiltx/config.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+import functools
+import sys
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+T = TypeVar("T")
 
 
 def get_catalog_config() -> dict[str, Any]:
@@ -56,6 +61,37 @@ def get_catalog_region() -> str:
     return str(region)
 
 
+def normalize_catalog_url(catalog_url: str) -> str:
+    """Ensure catalog_url has a scheme, defaulting to https://."""
+    if "://" not in catalog_url:
+        catalog_url = f"https://{catalog_url}"
+    return catalog_url.rstrip("/")
+
+
+def _is_auth_error(exc: Exception) -> bool:
+    """Check if an exception is a quilt3 authentication error."""
+    return "Authentication failed" in str(exc)
+
+
+def auto_login(func: Callable[..., T]) -> Callable[..., T]:
+    """Decorator that auto-runs quilt3 login on authentication failure, then retries."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            if not _is_auth_error(exc):
+                raise
+            print("Session expired. Launching quilt3 login...", file=sys.stderr)
+            import quilt3
+
+            quilt3.login()
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
 def set_catalog_url(catalog_url: str, **config_values: Any) -> dict[str, Any]:
     """Set the catalog URL in quilt3 configuration.
 
@@ -68,4 +104,5 @@ def set_catalog_url(catalog_url: str, **config_values: Any) -> dict[str, Any]:
     """
     import quilt3
 
+    catalog_url = normalize_catalog_url(catalog_url)
     return quilt3.config(catalog_url, **config_values)

--- a/quiltx/tools/stack/__init__.py
+++ b/quiltx/tools/stack/__init__.py
@@ -7,6 +7,7 @@ import sys
 from importlib import import_module
 
 SUBCOMMANDS = {
+    "acl": "quiltx.tools.stack.acl",
     "catalog": "quiltx.tools.stack.catalog",
     "cfn": "quiltx.tools.stack.cfn",
 }
@@ -24,6 +25,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="SUBCOMMAND",
     )
 
+    subparsers.add_parser(
+        "acl",
+        help="Reconcile Quilt bucket, role, policy, and SSO ACLs from YAML.",
+        add_help=False,
+    )
     subparsers.add_parser(
         "catalog",
         help="Show or set the Quilt catalog configured by quilt3.",

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -19,6 +19,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Apply changes without prompting for confirmation.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show planned changes without applying them.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed information about each change.",
+    )
     return parser
 
 
@@ -30,18 +40,23 @@ def main(argv: list[str] | None = None) -> int:
         desired = acl_lib.parse_acl_config(args.config_file)
         current = acl_lib.fetch_current_state()
         diff = acl_lib.compute_diff(desired, current)
-        acl_lib.print_diff(diff)
+        acl_lib.print_diff(diff, verbose=args.verbose)
 
         if not diff.has_changes():
+            return 0
+
+        if args.dry_run:
             return 0
 
         if not args.yes and not _confirm_apply():
             print("Aborted.")
             return 1
 
+        print("Applying...")
         warnings = acl_lib.apply_acl(diff, current)
         for warning in warnings:
             print(f"Warning: {warning}", file=sys.stderr)
+        print("Done.")
         return 0
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -13,7 +13,12 @@ def build_parser() -> argparse.ArgumentParser:
         prog="quiltx stack acl",
         description="Reconcile Quilt bucket, role, policy, and SSO ACLs from YAML.",
     )
-    parser.add_argument("config_file", help="Path to the ACL YAML file.")
+    parser.add_argument(
+        "config_file",
+        nargs="?",
+        default=None,
+        help="Path to the ACL YAML file. If omitted, shows current server state.",
+    )
     parser.add_argument(
         "--yes",
         action="store_true",
@@ -37,6 +42,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        if args.config_file is None:
+            current = acl_lib.fetch_current_state()
+            acl_lib.print_current_state(current)
+            return 0
+
         desired = acl_lib.parse_acl_config(args.config_file)
         desired = acl_lib.with_default_role(
             desired,

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -60,12 +60,16 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
         print("Applying...")
-        warnings = acl_lib.apply_acl(diff, current)
+        warnings = acl_lib.apply_acl(diff, current, verbose=args.verbose)
         for warning in warnings:
             print(f"Warning: {warning}", file=sys.stderr)
         print("Done.")
         return 0
     except Exception as exc:
+        if args.verbose:
+            print(f"Failure type: {type(exc).__name__}", file=sys.stderr)
+            for detail in _format_exception_details(exc):
+                print(detail, file=sys.stderr)
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
@@ -110,6 +114,25 @@ def _resolve_default_role_name(
         raise ValueError(f"Default role selection out of range: {selected}")
 
     return role_names[selected - 1]
+
+
+def _format_exception_details(exc: Exception) -> list[str]:
+    details: list[str] = []
+    errors = getattr(exc, "errors", None)
+    if not isinstance(errors, list):
+        return details
+
+    for index, error in enumerate(errors, start=1):
+        message = getattr(error, "message", None)
+        if message:
+            details.append(f"GraphQL error {index}: {message}")
+        path = getattr(error, "path", None)
+        if path:
+            details.append(f"GraphQL path {index}: {path}")
+        locations = getattr(error, "locations", None)
+        if locations:
+            details.append(f"GraphQL locations {index}: {locations}")
+    return details
 
 
 if __name__ == "__main__":

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -1,0 +1,56 @@
+"""Declarative ACL management for Quilt stacks."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from quiltx import acl as acl_lib
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="quiltx stack acl",
+        description="Reconcile Quilt bucket, role, policy, and SSO ACLs from YAML.",
+    )
+    parser.add_argument("config_file", help="Path to the ACL YAML file.")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Apply changes without prompting for confirmation.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        desired = acl_lib.parse_acl_config(args.config_file)
+        current = acl_lib.fetch_current_state()
+        diff = acl_lib.compute_diff(desired, current)
+        acl_lib.print_diff(diff)
+
+        if not diff.has_changes():
+            return 0
+
+        if not args.yes and not _confirm_apply():
+            print("Aborted.")
+            return 1
+
+        warnings = acl_lib.apply_acl(diff, current)
+        for warning in warnings:
+            print(f"Warning: {warning}", file=sys.stderr)
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _confirm_apply() -> bool:
+    return input("Apply ACL changes? [y/N]: ").strip().lower() in {"y", "yes"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -38,9 +38,16 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         desired = acl_lib.parse_acl_config(args.config_file)
+        desired = acl_lib.with_default_role(
+            desired,
+            _resolve_default_role_name(
+                desired,
+                prompt_for_choice=not args.yes,
+            ),
+        )
         current = acl_lib.fetch_current_state()
         diff = acl_lib.compute_diff(desired, current)
-        acl_lib.print_diff(diff, verbose=args.verbose)
+        acl_lib.print_diff(diff, verbose=args.verbose, desired=desired, current=current)
 
         if not diff.has_changes():
             return 0
@@ -65,6 +72,44 @@ def main(argv: list[str] | None = None) -> int:
 
 def _confirm_apply() -> bool:
     return input("Apply ACL changes? [y/N]: ").strip().lower() in {"y", "yes"}
+
+
+def _resolve_default_role_name(
+    config: acl_lib.AclConfig, *, prompt_for_choice: bool
+) -> str | None:
+    if config.default_role_name is not None:
+        return config.default_role_name
+
+    role_names = list(config.roles)
+    if not role_names:
+        return None
+
+    if not prompt_for_choice:
+        return role_names[0]
+
+    if not sys.stdin.isatty():
+        return role_names[0]
+
+    print("Select the default role:")
+    for index, role_name in enumerate(role_names, start=1):
+        print(f"  {index}. {role_name}")
+
+    try:
+        response = input(f"Default role [1-{len(role_names)}] (default 1): ").strip()
+    except EOFError:
+        return role_names[0]
+    if response == "":
+        return role_names[0]
+
+    try:
+        selected = int(response)
+    except ValueError as exc:
+        raise ValueError(f"Invalid default role selection: {response!r}") from exc
+
+    if not 1 <= selected <= len(role_names):
+        raise ValueError(f"Default role selection out of range: {selected}")
+
+    return role_names[selected - 1]
 
 
 if __name__ == "__main__":

--- a/spec/060-stack-acl/01-stack-acl-plan.md
+++ b/spec/060-stack-acl/01-stack-acl-plan.md
@@ -4,36 +4,6 @@
 
 Branch `060-stack-acl`. The goal is a new CLI command `quiltx stack acl <file.yml>` that declaratively reconciles a Quilt stack's access control (buckets, policies, roles, SSO) from a YAML file. `quilt3.admin` now exposes the necessary APIs (policies, roles, sso_config, buckets).
 
-## YAML format (spec/060-stack-acl/demo-stack-acl.yml)
-
-```yaml
-bucket_policies:
-  public:
-    read:
-      - quilt-example
-  internal:
-    read_write:
-      - quilt-bake
-      - quilt-dev
-    read:
-      - quilt-leadership
-
-roles:
-  visitor:
-    bucket_policies: [public]
-  member:
-    bucket_policies: [public, internal]
-
-sso:
-  - match:
-      groups: Everyone
-    roles: [visitor]
-  - match:
-      groups: Employees
-    roles: [member]
-    admin: true
-```
-
 ## Mapping to quilt3.admin API
 
 | YAML | Quilt API | Notes |

--- a/spec/060-stack-acl/01-stack-acl-plan.md
+++ b/spec/060-stack-acl/01-stack-acl-plan.md
@@ -75,13 +75,12 @@ sso:
 
 **`fetch_current_state() -> CurrentState`** — call `quilt3.admin.{buckets,policies,roles,sso_config}.list()/get()`.
 
-**`compute_diff(desired, current) -> AclDiff`** — compare desired vs current for buckets, policies (by title, match permissions), roles (by name, match policy refs), SSO config. Only touch managed policies/roles.
+**`compute_diff(desired, current) -> AclDiff`** — compare desired vs current for buckets, policies (by title, match permissions), roles (by name, match policy refs), SSO config. Only touch managed policies/roles. If a desired name collides with an existing **unmanaged** policy or role, emit a warning and skip it (do not overwrite).
 
-**`build_sso_config(mappings, default_role) -> str`** — translate simplified `match.groups` to Quilt's JSON Schema SSO format:
+**`build_sso_config(mappings) -> str`** — translate simplified `match.groups` to Quilt's JSON Schema SSO format. Does **not** set a `default_role` (omitted to avoid granting unintended access):
 
 ```yaml
 version: "1.0"
-default_role: <first SSO mapping's first role>
 mappings:
   - schema:
       type: object
@@ -96,11 +95,11 @@ mappings:
 
 **`apply_acl(diff)`** — execute in order:
 
-1. Add buckets (`buckets.add`)
-2. Create/update policies (`policies.create_managed` / `policies.update_managed`)
-3. Create/update roles (`roles.create_managed` / `roles.update_managed`)
-4. Set SSO config (`sso_config.set`)
-5. Remove roles, then policies (reverse order). Skip bucket removal in v1 — warn only.
+1. Add buckets (`buckets.add`) — if a bucket cannot be added (e.g. not found, permissions error), warn and continue
+2. Create/update managed policies (`policies.create_managed` / `policies.update_managed`) — warn and skip on unmanaged name collision
+3. Create/update managed roles (`roles.create_managed` / `roles.update_managed`) — warn and skip on unmanaged name collision
+4. Update SSO config (`sso_config.set`) — merge/replace mappings but never remove the SSO config entirely
+5. Never remove buckets (warn only). Never delete unmanaged roles or policies.
 
 ### Step 2: `quiltx/tools/stack/acl.py` — CLI
 
@@ -130,10 +129,12 @@ Mock `quilt3.admin.*` modules. Test:
 
 ## Safety
 
-- Never remove buckets automatically (warn only)
-- Only manage managed policies/roles; ignore unmanaged (IAM ARN-backed)
-- SSO config is full-replacement (matches Quilt's model)
-- Show full diff before applying; require `--yes` or interactive confirmation
+1. **No default role** — SSO config omits `default_role` to avoid granting unintended access
+2. **No deletion of unmanaged entities** — never delete unmanaged roles or policies; warn on name collision and skip
+3. **Warn on bucket failures** — if a bucket cannot be added, warn and continue (do not abort)
+4. **SSO config is update-only** — set/replace SSO mappings but never remove the SSO config entirely
+5. **Never remove buckets** — warn only
+6. **Show full diff** before applying; require `--yes` or interactive confirmation
 
 ## Verification
 

--- a/spec/060-stack-acl/01-stack-acl-plan.md
+++ b/spec/060-stack-acl/01-stack-acl-plan.md
@@ -1,0 +1,143 @@
+# Plan: `quiltx stack acl` command
+
+## Context
+
+Branch `060-stack-acl`. The goal is a new CLI command `quiltx stack acl <file.yml>` that declaratively reconciles a Quilt stack's access control (buckets, policies, roles, SSO) from a YAML file. `quilt3.admin` now exposes the necessary APIs (policies, roles, sso_config, buckets).
+
+## YAML format (spec/060-stack-acl/demo-stack-acl.yml)
+
+```yaml
+bucket_policies:
+  public:
+    read:
+      - quilt-example
+  internal:
+    read_write:
+      - quilt-bake
+      - quilt-dev
+    read:
+      - quilt-leadership
+
+roles:
+  visitor:
+    bucket_policies: [public]
+  member:
+    bucket_policies: [public, internal]
+
+sso:
+  - match:
+      groups: Everyone
+    roles: [visitor]
+  - match:
+      groups: Employees
+    roles: [member]
+    admin: true
+```
+
+## Mapping to quilt3.admin API
+
+| YAML | Quilt API | Notes |
+|------|-----------|-------|
+| `bucket_policies.X.read/read_write` buckets | `quilt3.admin.buckets.add(name, title)` | Register buckets on stack |
+| `bucket_policies.X` | `quilt3.admin.policies.create_managed(title, permissions)` | 1:1 mapping. `Permission.read(bucket)` / `Permission.read_write(bucket)` |
+| `roles.X` | `quilt3.admin.roles.create_managed(name, policies)` | References policy IDs |
+| `sso` | `quilt3.admin.sso_config.set(yaml_string)` | Translate simplified match format to Quilt's JSON Schema format |
+
+## Files to create
+
+| File | Purpose |
+|------|---------|
+| `quiltx/acl.py` | Core library: parse YAML, diff, apply |
+| `quiltx/tools/stack/acl.py` | CLI subcommand: argparse, main() |
+| `tests/test_acl.py` | Unit tests |
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `quiltx/tools/stack/__init__.py` | Add `"acl"` to `SUBCOMMANDS` dict and `subparsers` |
+| `pyproject.toml` | Add `pyyaml` to dependencies |
+
+## Implementation
+
+### Step 1: `quiltx/acl.py` — core library
+
+**Dataclasses:**
+
+- `AclBucketPolicy(name, read: list[str], read_write: list[str])`
+- `AclRole(name, bucket_policies: list[str])`
+- `AclSsoMapping(match: dict, roles: list[str], admin: bool)`
+- `AclConfig(bucket_policies, roles, sso)`
+
+**`parse_acl_config(path) -> AclConfig`** — `yaml.safe_load`, validate structure, cross-reference check (role refs valid policies, SSO refs valid roles).
+
+**`all_buckets(config) -> set[str]`** — collect all bucket names.
+
+**`fetch_current_state() -> CurrentState`** — call `quilt3.admin.{buckets,policies,roles,sso_config}.list()/get()`.
+
+**`compute_diff(desired, current) -> AclDiff`** — compare desired vs current for buckets, policies (by title, match permissions), roles (by name, match policy refs), SSO config. Only touch managed policies/roles.
+
+**`build_sso_config(mappings, default_role) -> str`** — translate simplified `match.groups` to Quilt's JSON Schema SSO format:
+
+```yaml
+version: "1.0"
+default_role: <first SSO mapping's first role>
+mappings:
+  - schema:
+      type: object
+      properties:
+        groups: { type: array, contains: { const: <group> } }
+      required: [groups]
+    roles: [<role>]
+    admin: <bool>
+```
+
+**`print_diff(diff)`** — rich output with +/−/~ prefixes.
+
+**`apply_acl(diff)`** — execute in order:
+
+1. Add buckets (`buckets.add`)
+2. Create/update policies (`policies.create_managed` / `policies.update_managed`)
+3. Create/update roles (`roles.create_managed` / `roles.update_managed`)
+4. Set SSO config (`sso_config.set`)
+5. Remove roles, then policies (reverse order). Skip bucket removal in v1 — warn only.
+
+### Step 2: `quiltx/tools/stack/acl.py` — CLI
+
+```
+quiltx stack acl <config_file> [--yes]
+```
+
+Flow: parse YAML → fetch current state → compute diff → print diff → confirm (or --yes) → apply.
+
+### Step 3: Register subcommand
+
+Add `"acl": "quiltx.tools.stack.acl"` in `quiltx/tools/stack/__init__.py`.
+
+### Step 4: Dependencies
+
+Add `pyyaml` to `pyproject.toml` dependencies.
+
+### Step 5: Tests
+
+Mock `quilt3.admin.*` modules. Test:
+
+- YAML parsing (valid, invalid, cross-ref errors)
+- Diff computation (add/update/remove for each entity type, unmanaged entities ignored)
+- SSO config translation
+- Apply ordering
+- CLI integration (help, missing file, --yes flag)
+
+## Safety
+
+- Never remove buckets automatically (warn only)
+- Only manage managed policies/roles; ignore unmanaged (IAM ARN-backed)
+- SSO config is full-replacement (matches Quilt's model)
+- Show full diff before applying; require `--yes` or interactive confirmation
+
+## Verification
+
+1. `./poe test` — unit tests pass
+2. Manual: create a test YAML, run `quiltx stack acl test.yml` against a dev stack, verify diff output
+3. Manual: run with `--yes`, verify policies/roles/SSO created via Quilt admin UI
+4. Re-run same file — should print "Stack ACL is up to date"

--- a/spec/060-stack-acl/demo-stack-acl.yml
+++ b/spec/060-stack-acl/demo-stack-acl.yml
@@ -24,10 +24,10 @@ roles:
 
 sso:
   - match:
-      groups: Everyone
-    roles: [visitor]
-
-  - match:
       groups: Employees
     roles: [member]
     admin: true
+
+  - match:
+      groups: Everyone
+    roles: [visitor]

--- a/spec/060-stack-acl/demo-stack-acl.yml
+++ b/spec/060-stack-acl/demo-stack-acl.yml
@@ -21,6 +21,7 @@ roles:
 
   member:
     bucket_policies: [public, internal]
+    default: true
 
 sso:
   - match:

--- a/spec/060-stack-acl/demo-stack-acl.yml
+++ b/spec/060-stack-acl/demo-stack-acl.yml
@@ -1,0 +1,33 @@
+# Quilt Stack Configuration as Code
+# demo-stack example
+
+bucket_policies:
+
+  public:
+    read:
+      - quilt-example
+
+  internal:
+    read_write:
+      - quilt-bake
+      - quilt-dev
+    read:
+      - quilt-leadership
+
+roles:
+
+  visitor:
+    bucket_policies: [public]
+
+  member:
+    bucket_policies: [public, internal]
+
+sso:
+  - match:
+      groups: Everyone
+    roles: [visitor]
+
+  - match:
+      groups: Employees
+    roles: [member]
+    admin: true

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -132,6 +132,15 @@ def test_build_sso_config_omits_default_role() -> None:
     )
 
 
+def test_build_sso_config_includes_default_role() -> None:
+    text = acl.build_sso_config(
+        [acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["visitor"])],
+        default_role_name="visitor",
+    )
+    payload = yaml.safe_load(text)
+    assert payload["default_role"] == "visitor"
+
+
 def test_compute_diff_handles_updates_deletes_and_unmanaged_collisions() -> None:
     desired = acl.AclConfig(
         bucket_policies={
@@ -236,13 +245,12 @@ mappings:
     assert [role.name for role in diff.roles_to_update] == ["visitor"]
     assert diff.roles_to_create == []
     assert diff.roles_to_delete == []
-    assert diff.default_role_name == "visitor"
-    assert diff.default_role_needs_update is True
     assert diff.sso_needs_update is True
     assert diff.sso_is_create is False
     assert any("unmanaged" in warning for warning in diff.warnings)
     assert any("protected" in warning for warning in diff.warnings)
     assert any("current default role" in warning for warning in diff.warnings)
+    assert "default_role: visitor" in (diff.sso_config_text or "")
 
 
 def test_compute_diff_sso_create_when_no_existing_config() -> None:
@@ -288,7 +296,6 @@ def test_compute_diff_sso_create_when_no_existing_config() -> None:
     diff = acl.compute_diff(desired, current)
     assert diff.sso_needs_update is True
     assert diff.sso_is_create is True
-    assert diff.default_role_needs_update is True
 
 
 def test_with_default_role_returns_updated_copy() -> None:
@@ -310,13 +317,6 @@ def test_print_diff_sso_create_vs_update(capsys) -> None:
     )
     acl.print_diff(update_diff)
     assert "~ sso config" in capsys.readouterr().out
-
-
-def test_print_diff_shows_default_role(capsys) -> None:
-    acl.print_diff(
-        acl.AclDiff(default_role_name="visitor", default_role_needs_update=True)
-    )
-    assert "~ default role visitor" in capsys.readouterr().out
 
 
 def test_compute_diff_does_not_remove_existing_sso_when_desired_is_empty() -> None:
@@ -398,7 +398,6 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
         SimpleNamespace(
             create_managed=role_create,
             update_managed=role_update,
-            set_default=lambda name: calls.append(("set_default", name)),
             delete=lambda name: calls.append(("role_delete", name)),
         ),
     )
@@ -423,10 +422,9 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
             acl.RoleUpdate(name="old-role", policy_titles=["existing-policy"])
         ],
         roles_to_delete=["gone-role"],
-        default_role_name="new-role",
-        default_role_needs_update=True,
         sso_config_text=acl.build_sso_config(
-            [acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["new-role"])]
+            [acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["new-role"])],
+            default_role_name="new-role",
         ),
         sso_needs_update=True,
     )
@@ -457,11 +455,11 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
         ("policy_update", "old-policy", "old-policy", []),
         ("role_create", "new-role", ["id-new-policy"]),
         ("role_update", "old-role", "old-role", ["id-existing-policy"]),
-        ("set_default", "new-role"),
         (
             "sso_set",
             {
                 "version": "1.0",
+                "default_role": "new-role",
                 "mappings": [
                     {
                         "schema": {
@@ -484,6 +482,53 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
         ("policy_delete", "gone-policy"),
     ]
     assert any("bucket-bad" in warning for warning in warnings)
+
+
+def test_apply_acl_verbose_shows_operation_steps(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        acl,
+        "admin_roles",
+        SimpleNamespace(
+            create_managed=lambda name, policies: None,
+            update_managed=lambda id_or_name, *, name, policies: None,
+            delete=lambda name: None,
+        ),
+    )
+    monkeypatch.setattr(
+        acl,
+        "admin_policies",
+        SimpleNamespace(
+            create_managed=lambda title, *, permissions: SimpleNamespace(
+                id="policy-id"
+            ),
+            update_managed=lambda id_or_title, *, title, permissions, roles: None,
+            delete=lambda title: None,
+        ),
+    )
+    monkeypatch.setattr(
+        acl, "admin_buckets", SimpleNamespace(add=lambda name, title: None)
+    )
+    monkeypatch.setattr(acl, "admin_sso_config", SimpleNamespace(set=lambda text: None))
+
+    diff = acl.AclDiff(
+        sso_config_text="version: '1.0'\ndefault_role: visitor\nmappings: []\n",
+        sso_needs_update=True,
+    )
+    current = acl.CurrentState(
+        buckets={},
+        managed_policies={},
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+
+    acl.apply_acl(diff, current, verbose=True)
+    out = capsys.readouterr().out
+    assert "-> update sso config" in out
 
 
 def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:
@@ -555,7 +600,7 @@ def test_print_diff_verbose(capsys) -> None:
         roles_to_create=[
             acl.RoleUpdate(name="my-role", policy_titles=["my-policy"]),
         ],
-        sso_config_text="version: '1.0'\nmappings: []\n",
+        sso_config_text="version: '1.0'\ndefault_role: my-role\nmappings: []\n",
         sso_is_create=True,
         sso_needs_update=True,
     )
@@ -564,7 +609,7 @@ def test_print_diff_verbose(capsys) -> None:
     assert "Desired ACL:" in out
     assert "bucket-a" in out
     assert "policies: my-policy" in out
-    assert "default role my-role" in out
+    assert "default_role: my-role" in out
     assert "version:" in out
 
 
@@ -610,7 +655,7 @@ def test_print_diff_verbose_shows_unchanged_entries(capsys) -> None:
     assert "= bucket bucket-a" in out
     assert "= policy public" in out
     assert "= role visitor" in out
-    assert "= default role visitor" in out
+    assert "Stack ACL is up to date" in out
 
 
 def test_acl_tool_missing_file(capsys) -> None:
@@ -651,7 +696,7 @@ def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
     monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
     monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda computed, **kw: None)
 
-    def _apply_acl(computed, state):
+    def _apply_acl(computed, state, *, verbose=False):
         applied.append("applied")
         return []
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,0 +1,431 @@
+"""Tests for declarative stack ACL reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from quiltx import acl
+from quiltx.tools.stack import acl as acl_tool
+
+
+@dataclass
+class FakePolicySummary:
+    id: str
+    title: str
+
+
+@dataclass
+class FakePolicy:
+    id: str
+    title: str
+    managed: bool
+    permissions: list
+    roles: list
+
+
+@dataclass
+class FakeRole:
+    id: str
+    name: str
+    policies: list
+    permissions: list
+    typename__: str = "ManagedRole"
+
+
+@dataclass
+class FakeBucket:
+    name: str
+    title: str
+
+
+def test_parse_acl_config_valid(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+bucket_policies:
+  public:
+    read: [bucket-a]
+  internal:
+    read_write: [bucket-b]
+roles:
+  visitor:
+    bucket_policies: [public]
+sso:
+  - match:
+      groups: Everyone
+    roles: [visitor]
+    admin: true
+""")
+
+    config = acl.parse_acl_config(config_path)
+    assert sorted(config.bucket_policies) == ["internal", "public"]
+    assert config.roles["visitor"].bucket_policies == ["public"]
+    assert config.sso[0].match == {"groups": "Everyone"}
+    assert config.sso[0].admin is True
+
+
+def test_parse_acl_config_rejects_unknown_role_reference(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+bucket_policies: {}
+roles: {}
+sso:
+  - match:
+      groups: Everyone
+    roles: [visitor]
+""")
+
+    try:
+        acl.parse_acl_config(config_path)
+    except ValueError as exc:
+        assert "unknown roles" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Expected ValueError")
+
+
+def test_build_sso_config_omits_default_role() -> None:
+    text = acl.build_sso_config(
+        [
+            acl.AclSsoMapping(
+                match={"groups": "Employees"}, roles=["member"], admin=True
+            ),
+            acl.AclSsoMapping(match={"email": "[email protected]"}, roles=["admin"]),
+        ]
+    )
+
+    payload = yaml.safe_load(text)
+    assert payload["version"] == "1.0"
+    assert "default_role" not in payload
+    assert (
+        payload["mappings"][0]["schema"]["properties"]["groups"]["contains"]["const"]
+        == "Employees"
+    )
+    assert (
+        payload["mappings"][1]["schema"]["properties"]["email"]["const"]
+        == "[email protected]"
+    )
+
+
+def test_compute_diff_handles_updates_deletes_and_unmanaged_collisions() -> None:
+    desired = acl.AclConfig(
+        bucket_policies={
+            "public": acl.AclBucketPolicy(name="public", read=["bucket-a"]),
+            "internal": acl.AclBucketPolicy(name="internal", read_write=["bucket-b"]),
+            "external": acl.AclBucketPolicy(name="external", read=["bucket-z"]),
+        },
+        roles={
+            "visitor": acl.AclRole(
+                name="visitor", bucket_policies=["public", "internal"]
+            ),
+            "member": acl.AclRole(name="member", bucket_policies=["public"]),
+        },
+        sso=[acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["visitor"])],
+    )
+
+    current = acl.CurrentState(
+        buckets={"bucket-a": FakeBucket("bucket-a", "bucket-a")},
+        managed_policies={
+            "public": FakePolicy(
+                id="policy-public",
+                title="public",
+                managed=True,
+                permissions=[acl.Permission.read("bucket-a")],
+                roles=[],
+            ),
+            "legacy": FakePolicy(
+                id="policy-legacy",
+                title="legacy",
+                managed=True,
+                permissions=[acl.Permission.read("bucket-old")],
+                roles=[],
+            ),
+        },
+        unmanaged_policies={
+            "external": FakePolicy(
+                id="policy-external",
+                title="external",
+                managed=False,
+                permissions=[acl.Permission.read("bucket-z")],
+                roles=[],
+            )
+        },
+        all_policies={},
+        managed_roles={
+            "visitor": FakeRole(
+                id="role-visitor",
+                name="visitor",
+                policies=[FakePolicySummary(id="policy-public", title="public")],
+                permissions=[],
+            ),
+            "legacy": FakeRole(
+                id="role-legacy",
+                name="legacy",
+                policies=[FakePolicySummary(id="policy-legacy", title="legacy")],
+                permissions=[],
+            ),
+            "protected": FakeRole(
+                id="role-protected",
+                name="protected",
+                policies=[],
+                permissions=[],
+            ),
+        },
+        unmanaged_roles={
+            "member": FakeRole(
+                id="role-member",
+                name="member",
+                policies=[],
+                permissions=[],
+                typename__="UnmanagedRole",
+            )
+        },
+        all_roles={},
+        sso_config_text="""
+version: "1.0"
+mappings:
+  - schema:
+      type: object
+      properties:
+        groups:
+          type: array
+          contains:
+            const: Legacy
+      required: [groups]
+    roles: [protected]
+    admin: false
+""",
+        default_role_name=None,
+    )
+    current.all_policies.update(current.unmanaged_policies)
+    current.all_policies.update(current.managed_policies)
+    current.all_roles.update(current.unmanaged_roles)
+    current.all_roles.update(current.managed_roles)
+
+    diff = acl.compute_diff(desired, current)
+
+    assert diff.buckets_to_add == ["bucket-b", "bucket-z"]
+    assert [policy.title for policy in diff.policies_to_create] == ["internal"]
+    assert diff.policies_to_delete == ["legacy"]
+    assert [role.name for role in diff.roles_to_update] == ["visitor"]
+    assert diff.roles_to_create == []
+    assert diff.roles_to_delete == ["legacy"]
+    assert diff.sso_needs_update is True
+    assert any("unmanaged" in warning for warning in diff.warnings)
+    assert any("protected" in warning for warning in diff.warnings)
+
+
+def test_compute_diff_does_not_remove_existing_sso_when_desired_is_empty() -> None:
+    desired = acl.AclConfig(bucket_policies={}, roles={}, sso=[])
+    current = acl.CurrentState(
+        buckets={},
+        managed_policies={},
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text='version: "1.0"\nmappings: []\n',
+        default_role_name=None,
+    )
+
+    diff = acl.compute_diff(desired, current)
+    assert diff.sso_needs_update is False
+
+
+def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
+    monkeypatch,
+) -> None:
+    calls: list[tuple] = []
+
+    def bucket_add(name: str, title: str):
+        calls.append(("bucket_add", name, title))
+        if name == "bucket-bad":
+            raise RuntimeError("missing bucket")
+        return FakeBucket(name=name, title=title)
+
+    def policy_create(title: str, *, permissions):
+        calls.append(
+            ("policy_create", title, [permission.bucket for permission in permissions])
+        )
+        return FakePolicy(
+            id=f"id-{title}",
+            title=title,
+            managed=True,
+            permissions=permissions,
+            roles=[],
+        )
+
+    def policy_update(id_or_title: str, *, title: str, permissions, roles):
+        calls.append(("policy_update", id_or_title, title, roles))
+        return FakePolicy(
+            id=f"id-{title}",
+            title=title,
+            managed=True,
+            permissions=permissions,
+            roles=[],
+        )
+
+    def role_create(name: str, policies):
+        calls.append(("role_create", name, list(policies)))
+        return FakeRole(id=f"id-{name}", name=name, policies=[], permissions=[])
+
+    def role_update(id_or_name: str, *, name: str, policies):
+        calls.append(("role_update", id_or_name, name, list(policies)))
+        return FakeRole(id=f"id-{name}", name=name, policies=[], permissions=[])
+
+    def sso_set(text: str):
+        calls.append(("sso_set", yaml.safe_load(text)))
+        return SimpleNamespace(text=text)
+
+    monkeypatch.setattr(acl, "admin_buckets", SimpleNamespace(add=bucket_add))
+    monkeypatch.setattr(
+        acl,
+        "admin_policies",
+        SimpleNamespace(
+            create_managed=policy_create,
+            update_managed=policy_update,
+            delete=lambda title: calls.append(("policy_delete", title)),
+        ),
+    )
+    monkeypatch.setattr(
+        acl,
+        "admin_roles",
+        SimpleNamespace(
+            create_managed=role_create,
+            update_managed=role_update,
+            delete=lambda name: calls.append(("role_delete", name)),
+        ),
+    )
+    monkeypatch.setattr(acl, "admin_sso_config", SimpleNamespace(set=sso_set))
+
+    diff = acl.AclDiff(
+        buckets_to_add=["bucket-good", "bucket-bad"],
+        policies_to_create=[
+            acl.PolicyUpdate(
+                title="new-policy", permissions=[acl.Permission.read("bucket-good")]
+            )
+        ],
+        policies_to_update=[
+            acl.PolicyUpdate(
+                title="old-policy",
+                permissions=[acl.Permission.read_write("bucket-good")],
+            )
+        ],
+        policies_to_delete=["gone-policy"],
+        roles_to_create=[acl.RoleUpdate(name="new-role", policy_titles=["new-policy"])],
+        roles_to_update=[
+            acl.RoleUpdate(name="old-role", policy_titles=["existing-policy"])
+        ],
+        roles_to_delete=["gone-role"],
+        sso_config_text=acl.build_sso_config(
+            [acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["new-role"])]
+        ),
+        sso_needs_update=True,
+    )
+    current = acl.CurrentState(
+        buckets={},
+        managed_policies={
+            "old-policy": FakePolicy("id-old-policy", "old-policy", True, [], [])
+        },
+        unmanaged_policies={},
+        all_policies={
+            "existing-policy": FakePolicy(
+                "id-existing-policy", "existing-policy", True, [], []
+            )
+        },
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+
+    warnings = acl.apply_acl(diff, current)
+
+    assert calls == [
+        ("bucket_add", "bucket-good", "bucket-good"),
+        ("bucket_add", "bucket-bad", "bucket-bad"),
+        ("policy_create", "new-policy", ["bucket-good"]),
+        ("policy_update", "old-policy", "old-policy", []),
+        ("role_create", "new-role", ["id-new-policy"]),
+        ("role_update", "old-role", "old-role", ["id-existing-policy"]),
+        (
+            "sso_set",
+            {
+                "version": "1.0",
+                "mappings": [
+                    {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "groups": {
+                                    "type": "array",
+                                    "contains": {"const": "Everyone"},
+                                }
+                            },
+                            "required": ["groups"],
+                        },
+                        "roles": ["new-role"],
+                        "admin": False,
+                    }
+                ],
+            },
+        ),
+        ("role_delete", "gone-role"),
+        ("policy_delete", "gone-policy"),
+    ]
+    assert any("bucket-bad" in warning for warning in warnings)
+
+
+def test_acl_tool_missing_file(capsys) -> None:
+    result = acl_tool.main(["/tmp/does-not-exist.yml"])
+    assert result == 1
+
+    captured = capsys.readouterr()
+    assert "Error:" in captured.err
+
+
+def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
+    applied: list[str] = []
+    diff = acl.AclDiff(buckets_to_add=["bucket-a"])
+    current = acl.CurrentState(
+        buckets={},
+        managed_policies={},
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib, "parse_acl_config", lambda path: SimpleNamespace(path=path)
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
+    monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
+    monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda computed: None)
+
+    def _apply_acl(computed, state):
+        applied.append("applied")
+        return []
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "apply_acl",
+        _apply_acl,
+    )
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt: (_ for _ in ()).throw(
+            AssertionError("input should not be called")
+        ),
+    )
+
+    result = acl_tool.main(["config.yml", "--yes"])
+    assert result == 0
+    assert applied == ["applied"]

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -213,8 +213,65 @@ mappings:
     assert diff.roles_to_create == []
     assert diff.roles_to_delete == ["legacy"]
     assert diff.sso_needs_update is True
+    assert diff.sso_is_create is False
     assert any("unmanaged" in warning for warning in diff.warnings)
     assert any("protected" in warning for warning in diff.warnings)
+
+
+def test_compute_diff_sso_create_when_no_existing_config() -> None:
+    desired = acl.AclConfig(
+        bucket_policies={
+            "public": acl.AclBucketPolicy(name="public", read=["bucket-a"]),
+        },
+        roles={
+            "visitor": acl.AclRole(name="visitor", bucket_policies=["public"]),
+        },
+        sso=[acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["visitor"])],
+    )
+    current = acl.CurrentState(
+        buckets={"bucket-a": FakeBucket("bucket-a", "bucket-a")},
+        managed_policies={
+            "public": FakePolicy(
+                id="policy-public",
+                title="public",
+                managed=True,
+                permissions=[acl.Permission.read("bucket-a")],
+                roles=[],
+            ),
+        },
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={
+            "visitor": FakeRole(
+                id="role-visitor",
+                name="visitor",
+                policies=[FakePolicySummary(id="policy-public", title="public")],
+                permissions=[],
+            ),
+        },
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+
+    diff = acl.compute_diff(desired, current)
+    assert diff.sso_needs_update is True
+    assert diff.sso_is_create is True
+
+
+def test_print_diff_sso_create_vs_update(capsys) -> None:
+    create_diff = acl.AclDiff(
+        sso_config_text="test", sso_is_create=True, sso_needs_update=True
+    )
+    acl.print_diff(create_diff)
+    assert "+ sso config" in capsys.readouterr().out
+
+    update_diff = acl.AclDiff(
+        sso_config_text="test", sso_is_create=False, sso_needs_update=True
+    )
+    acl.print_diff(update_diff)
+    assert "~ sso config" in capsys.readouterr().out
 
 
 def test_compute_diff_does_not_remove_existing_sso_when_desired_is_empty() -> None:
@@ -380,6 +437,68 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
     assert any("bucket-bad" in warning for warning in warnings)
 
 
+def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:
+    diff = acl.AclDiff(buckets_to_add=["bucket-a"])
+    current = acl.CurrentState(
+        buckets={},
+        managed_policies={},
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib, "parse_acl_config", lambda path: SimpleNamespace(path=path)
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
+    monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "apply_acl",
+        lambda *_: (_ for _ in ()).throw(
+            AssertionError("apply_acl should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt: (_ for _ in ()).throw(
+            AssertionError("input should not be called")
+        ),
+    )
+
+    result = acl_tool.main(["config.yml", "--dry-run"])
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "+ bucket bucket-a" in captured.out
+    assert "Applying" not in captured.out
+
+
+def test_print_diff_verbose(capsys) -> None:
+    diff = acl.AclDiff(
+        policies_to_create=[
+            acl.PolicyUpdate(
+                title="my-policy",
+                permissions=[acl.Permission.read("bucket-a")],
+            )
+        ],
+        roles_to_create=[
+            acl.RoleUpdate(name="my-role", policy_titles=["my-policy"]),
+        ],
+        sso_config_text="version: '1.0'\nmappings: []\n",
+        sso_is_create=True,
+        sso_needs_update=True,
+    )
+    acl.print_diff(diff, verbose=True)
+    out = capsys.readouterr().out
+    assert "bucket-a" in out
+    assert "policies: my-policy" in out
+    assert "version:" in out
+
+
 def test_acl_tool_missing_file(capsys) -> None:
     result = acl_tool.main(["/tmp/does-not-exist.yml"])
     assert result == 1
@@ -408,7 +527,7 @@ def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
     )
     monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
     monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
-    monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda computed: None)
+    monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda computed, **kw: None)
 
     def _apply_acl(computed, state):
         applied.append("applied")

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -32,7 +32,7 @@ class FakePolicy:
 class FakeRole:
     id: str
     name: str
-    policies: list
+    policies: list | None
     permissions: list
     typename__: str = "ManagedRole"
 
@@ -656,6 +656,98 @@ def test_print_diff_verbose_shows_unchanged_entries(capsys) -> None:
     assert "= policy public" in out
     assert "= role visitor" in out
     assert "Stack ACL is up to date" in out
+
+
+def test_print_current_state(capsys) -> None:
+    current = acl.CurrentState(
+        buckets={
+            "bucket-a": FakeBucket("bucket-a", "bucket-a"),
+            "bucket-b": FakeBucket("bucket-b", "bucket-b"),
+        },
+        managed_policies={
+            "my-policy": FakePolicy(
+                id="p1",
+                title="my-policy",
+                managed=True,
+                permissions=[
+                    acl.Permission.read("bucket-a"),
+                    acl.Permission.read_write("bucket-b"),
+                ],
+                roles=[],
+            ),
+        },
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={
+            "viewer": FakeRole(
+                id="r1",
+                name="viewer",
+                policies=[FakePolicySummary(id="p1", title="my-policy")],
+                permissions=[],
+            ),
+        },
+        unmanaged_roles={
+            "admin": FakeRole(
+                id="r2",
+                name="admin",
+                policies=None,
+                permissions=[],
+                typename__="UnmanagedRole",
+            ),
+        },
+        all_roles={},
+        sso_config_text=(
+            "version: '1.0'\n"
+            "default_role: viewer\n"
+            "mappings:\n"
+            "- schema:\n"
+            "    type: object\n"
+            "    properties:\n"
+            "      groups:\n"
+            "        type: array\n"
+            "        contains:\n"
+            "          const: Everyone\n"
+            "    required: [groups]\n"
+            "  roles: [viewer]\n"
+            "  admin: false\n"
+        ),
+        default_role_name="admin",
+    )
+
+    acl.print_current_state(current)
+    out = capsys.readouterr().out
+    assert "bucket bucket-a" in out
+    assert "bucket bucket-b" in out
+    assert "policy my-policy (managed)" in out
+    assert "READ: bucket-a" in out
+    assert "READ_WRITE: bucket-b" in out
+    assert "role viewer (managed)" in out
+    assert "policies: my-policy" in out
+    assert "role admin (default) (unmanaged)" in out
+    assert "policies: (n/a)" in out
+    assert "sso config" in out
+    assert "default_role: viewer" in out
+    assert "groups=Everyone -> [viewer]" in out
+
+
+def test_acl_tool_no_config_shows_state(monkeypatch, capsys) -> None:
+    current = acl.CurrentState(
+        buckets={"b1": FakeBucket("b1", "b1")},
+        managed_policies={},
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={},
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name=None,
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
+
+    result = acl_tool.main([])
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "bucket b1" in out
 
 
 def test_acl_tool_missing_file(capsys) -> None:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import yaml
 
 from quiltx import acl
@@ -53,6 +54,7 @@ bucket_policies:
 roles:
   visitor:
     bucket_policies: [public]
+    default: true
 sso:
   - match:
       groups: Everyone
@@ -63,8 +65,29 @@ sso:
     config = acl.parse_acl_config(config_path)
     assert sorted(config.bucket_policies) == ["internal", "public"]
     assert config.roles["visitor"].bucket_policies == ["public"]
+    assert config.roles["visitor"].default is True
+    assert config.default_role_name == "visitor"
     assert config.sso[0].match == {"groups": "Everyone"}
     assert config.sso[0].admin is True
+
+
+def test_parse_acl_config_rejects_multiple_default_roles(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+bucket_policies:
+  public:
+    read: [bucket-a]
+roles:
+  visitor:
+    bucket_policies: [public]
+    default: true
+  member:
+    bucket_policies: [public]
+    default: true
+""")
+
+    with pytest.raises(ValueError, match="Only one role may set default: true"):
+        acl.parse_acl_config(config_path)
 
 
 def test_parse_acl_config_rejects_unknown_role_reference(tmp_path: Path) -> None:
@@ -118,11 +141,12 @@ def test_compute_diff_handles_updates_deletes_and_unmanaged_collisions() -> None
         },
         roles={
             "visitor": acl.AclRole(
-                name="visitor", bucket_policies=["public", "internal"]
+                name="visitor", bucket_policies=["public", "internal"], default=True
             ),
             "member": acl.AclRole(name="member", bucket_policies=["public"]),
         },
         sso=[acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["visitor"])],
+        default_role_name="visitor",
     )
 
     current = acl.CurrentState(
@@ -197,7 +221,7 @@ mappings:
     roles: [protected]
     admin: false
 """,
-        default_role_name=None,
+        default_role_name="legacy",
     )
     current.all_policies.update(current.unmanaged_policies)
     current.all_policies.update(current.managed_policies)
@@ -211,11 +235,14 @@ mappings:
     assert diff.policies_to_delete == ["legacy"]
     assert [role.name for role in diff.roles_to_update] == ["visitor"]
     assert diff.roles_to_create == []
-    assert diff.roles_to_delete == ["legacy"]
+    assert diff.roles_to_delete == []
+    assert diff.default_role_name == "visitor"
+    assert diff.default_role_needs_update is True
     assert diff.sso_needs_update is True
     assert diff.sso_is_create is False
     assert any("unmanaged" in warning for warning in diff.warnings)
     assert any("protected" in warning for warning in diff.warnings)
+    assert any("current default role" in warning for warning in diff.warnings)
 
 
 def test_compute_diff_sso_create_when_no_existing_config() -> None:
@@ -224,9 +251,12 @@ def test_compute_diff_sso_create_when_no_existing_config() -> None:
             "public": acl.AclBucketPolicy(name="public", read=["bucket-a"]),
         },
         roles={
-            "visitor": acl.AclRole(name="visitor", bucket_policies=["public"]),
+            "visitor": acl.AclRole(
+                name="visitor", bucket_policies=["public"], default=True
+            ),
         },
         sso=[acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["visitor"])],
+        default_role_name="visitor",
     )
     current = acl.CurrentState(
         buckets={"bucket-a": FakeBucket("bucket-a", "bucket-a")},
@@ -258,6 +288,14 @@ def test_compute_diff_sso_create_when_no_existing_config() -> None:
     diff = acl.compute_diff(desired, current)
     assert diff.sso_needs_update is True
     assert diff.sso_is_create is True
+    assert diff.default_role_needs_update is True
+
+
+def test_with_default_role_returns_updated_copy() -> None:
+    config = acl.AclConfig(bucket_policies={}, roles={}, sso=[])
+    updated = acl.with_default_role(config, "visitor")
+    assert updated.default_role_name == "visitor"
+    assert config.default_role_name is None
 
 
 def test_print_diff_sso_create_vs_update(capsys) -> None:
@@ -272,6 +310,13 @@ def test_print_diff_sso_create_vs_update(capsys) -> None:
     )
     acl.print_diff(update_diff)
     assert "~ sso config" in capsys.readouterr().out
+
+
+def test_print_diff_shows_default_role(capsys) -> None:
+    acl.print_diff(
+        acl.AclDiff(default_role_name="visitor", default_role_needs_update=True)
+    )
+    assert "~ default role visitor" in capsys.readouterr().out
 
 
 def test_compute_diff_does_not_remove_existing_sso_when_desired_is_empty() -> None:
@@ -353,6 +398,7 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
         SimpleNamespace(
             create_managed=role_create,
             update_managed=role_update,
+            set_default=lambda name: calls.append(("set_default", name)),
             delete=lambda name: calls.append(("role_delete", name)),
         ),
     )
@@ -377,6 +423,8 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
             acl.RoleUpdate(name="old-role", policy_titles=["existing-policy"])
         ],
         roles_to_delete=["gone-role"],
+        default_role_name="new-role",
+        default_role_needs_update=True,
         sso_config_text=acl.build_sso_config(
             [acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["new-role"])]
         ),
@@ -409,6 +457,7 @@ def test_apply_acl_orders_operations_and_continues_after_bucket_warning(
         ("policy_update", "old-policy", "old-policy", []),
         ("role_create", "new-role", ["id-new-policy"]),
         ("role_update", "old-role", "old-role", ["id-existing-policy"]),
+        ("set_default", "new-role"),
         (
             "sso_set",
             {
@@ -454,6 +503,12 @@ def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         acl_tool.acl_lib, "parse_acl_config", lambda path: SimpleNamespace(path=path)
     )
+    monkeypatch.setattr(
+        acl_tool, "_resolve_default_role_name", lambda config, prompt_for_choice: None
+    )
+    monkeypatch.setattr(
+        acl_tool.acl_lib, "with_default_role", lambda config, name: config
+    )
     monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
     monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
     monkeypatch.setattr(
@@ -478,6 +533,18 @@ def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:
 
 
 def test_print_diff_verbose(capsys) -> None:
+    desired = acl.AclConfig(
+        bucket_policies={
+            "my-policy": acl.AclBucketPolicy(name="my-policy", read=["bucket-a"])
+        },
+        roles={
+            "my-role": acl.AclRole(
+                name="my-role", bucket_policies=["my-policy"], default=True
+            )
+        },
+        sso=[acl.AclSsoMapping(match={"groups": "Everyone"}, roles=["my-role"])],
+        default_role_name="my-role",
+    )
     diff = acl.AclDiff(
         policies_to_create=[
             acl.PolicyUpdate(
@@ -492,11 +559,58 @@ def test_print_diff_verbose(capsys) -> None:
         sso_is_create=True,
         sso_needs_update=True,
     )
-    acl.print_diff(diff, verbose=True)
+    acl.print_diff(diff, verbose=True, desired=desired)
     out = capsys.readouterr().out
+    assert "Desired ACL:" in out
     assert "bucket-a" in out
     assert "policies: my-policy" in out
+    assert "default role my-role" in out
     assert "version:" in out
+
+
+def test_print_diff_verbose_shows_unchanged_entries(capsys) -> None:
+    desired = acl.AclConfig(
+        bucket_policies={
+            "public": acl.AclBucketPolicy(name="public", read=["bucket-a"])
+        },
+        roles={"visitor": acl.AclRole(name="visitor", bucket_policies=["public"])},
+        sso=[],
+        default_role_name="visitor",
+    )
+    current = acl.CurrentState(
+        buckets={"bucket-a": FakeBucket("bucket-a", "bucket-a")},
+        managed_policies={
+            "public": FakePolicy(
+                id="policy-public",
+                title="public",
+                managed=True,
+                permissions=[acl.Permission.read("bucket-a")],
+                roles=[],
+            )
+        },
+        unmanaged_policies={},
+        all_policies={},
+        managed_roles={
+            "visitor": FakeRole(
+                id="role-visitor",
+                name="visitor",
+                policies=[FakePolicySummary(id="policy-public", title="public")],
+                permissions=[],
+            )
+        },
+        unmanaged_roles={},
+        all_roles={},
+        sso_config_text=None,
+        default_role_name="visitor",
+    )
+    diff = acl.compute_diff(desired, current)
+
+    acl.print_diff(diff, verbose=True, desired=desired, current=current)
+    out = capsys.readouterr().out
+    assert "= bucket bucket-a" in out
+    assert "= policy public" in out
+    assert "= role visitor" in out
+    assert "= default role visitor" in out
 
 
 def test_acl_tool_missing_file(capsys) -> None:
@@ -525,6 +639,14 @@ def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
     monkeypatch.setattr(
         acl_tool.acl_lib, "parse_acl_config", lambda path: SimpleNamespace(path=path)
     )
+    monkeypatch.setattr(
+        acl_tool,
+        "_resolve_default_role_name",
+        lambda config, prompt_for_choice: "visitor",
+    )
+    monkeypatch.setattr(
+        acl_tool.acl_lib, "with_default_role", lambda config, name: config
+    )
     monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda: current)
     monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
     monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda computed, **kw: None)
@@ -548,3 +670,69 @@ def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
     result = acl_tool.main(["config.yml", "--yes"])
     assert result == 0
     assert applied == ["applied"]
+
+
+def test_resolve_default_role_name_prefers_declared_default() -> None:
+    config = acl.AclConfig(
+        bucket_policies={},
+        roles={
+            "visitor": acl.AclRole(name="visitor", bucket_policies=[], default=True),
+            "member": acl.AclRole(name="member", bucket_policies=[]),
+        },
+        sso=[],
+        default_role_name="visitor",
+    )
+    assert (
+        acl_tool._resolve_default_role_name(config, prompt_for_choice=True) == "visitor"
+    )
+
+
+def test_resolve_default_role_name_prompts_by_number(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(acl_tool.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "2")
+    config = acl.AclConfig(
+        bucket_policies={},
+        roles={
+            "visitor": acl.AclRole(name="visitor", bucket_policies=[]),
+            "member": acl.AclRole(name="member", bucket_policies=[]),
+        },
+        sso=[],
+    )
+
+    selected = acl_tool._resolve_default_role_name(config, prompt_for_choice=True)
+    assert selected == "member"
+    out = capsys.readouterr().out
+    assert "1. visitor" in out
+    assert "2. member" in out
+
+
+def test_resolve_default_role_name_defaults_to_first_without_prompt() -> None:
+    config = acl.AclConfig(
+        bucket_policies={},
+        roles={
+            "visitor": acl.AclRole(name="visitor", bucket_policies=[]),
+            "member": acl.AclRole(name="member", bucket_policies=[]),
+        },
+        sso=[],
+    )
+    assert (
+        acl_tool._resolve_default_role_name(config, prompt_for_choice=False)
+        == "visitor"
+    )
+
+
+def test_resolve_default_role_name_defaults_to_first_when_stdin_not_tty(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(acl_tool.sys.stdin, "isatty", lambda: False)
+    config = acl.AclConfig(
+        bucket_policies={},
+        roles={
+            "visitor": acl.AclRole(name="visitor", bucket_policies=[]),
+            "member": acl.AclRole(name="member", bucket_policies=[]),
+        },
+        sso=[],
+    )
+    assert (
+        acl_tool._resolve_default_role_name(config, prompt_for_choice=True) == "visitor"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,8 +62,16 @@ def test_stack_no_subcommand(capsys) -> None:
     assert result == 1
 
     captured = capsys.readouterr()
+    assert "acl" in captured.out
     assert "catalog" in captured.out
     assert "cfn" in captured.out
+
+
+def test_stack_acl_help() -> None:
+    """Test that 'quiltx stack acl --help' works."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["stack", "acl", "--help"])
+    assert exc_info.value.code == 0
 
 
 def test_stack_catalog_help() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -99,3 +99,75 @@ def test_set_catalog_url(monkeypatch) -> None:
         "kwargs": {"token": "abc123"},
     }
     assert config["navigator_url"] == "https://example.test"
+
+
+def test_set_catalog_url_bare_hostname(monkeypatch) -> None:
+    """Test set_catalog_url normalizes bare DNS names to https://."""
+    called = {}
+
+    def _config(*args, **kwargs):
+        called["args"] = args
+        called["kwargs"] = kwargs
+        return {"navigator_url": args[0] if args else None}
+
+    fake_quilt3 = types.SimpleNamespace(config=_config)
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+
+    config = quiltx.set_catalog_url("unstable.dev.quilttest.com")
+
+    assert called["args"] == ("https://unstable.dev.quilttest.com",)
+    assert config["navigator_url"] == "https://unstable.dev.quilttest.com"
+
+
+def test_set_catalog_url_strips_trailing_slash(monkeypatch) -> None:
+    """Test set_catalog_url strips trailing slash."""
+    called = {}
+
+    def _config(*args, **kwargs):
+        called["args"] = args
+        return {"navigator_url": args[0] if args else None}
+
+    fake_quilt3 = types.SimpleNamespace(config=_config)
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+
+    quiltx.set_catalog_url("https://example.test/")
+
+    assert called["args"] == ("https://example.test",)
+
+
+def test_auto_login_retries_after_auth_failure(monkeypatch) -> None:
+    """Test auto_login catches auth errors, calls quilt3.login(), and retries."""
+    call_count = 0
+    login_called = False
+
+    @quiltx.auto_login
+    def guarded():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise Exception("Authentication failed. Check your credentials or API key.")
+        return "ok"
+
+    def _fake_login():
+        nonlocal login_called
+        login_called = True
+
+    fake_quilt3 = types.SimpleNamespace(login=_fake_login)
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+
+    result = guarded()
+
+    assert result == "ok"
+    assert call_count == 2
+    assert login_called
+
+
+def test_auto_login_does_not_catch_other_errors() -> None:
+    """Test auto_login re-raises non-auth errors."""
+
+    @quiltx.auto_login
+    def guarded():
+        raise ValueError("something else")
+
+    with pytest.raises(ValueError, match="something else"):
+        guarded()

--- a/uv.lock
+++ b/uv.lock
@@ -1604,7 +1604,7 @@ wheels = [
 
 [[package]]
 name = "quilt3"
-version = "7.2.0"
+version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "awscrt" },
@@ -1621,9 +1621,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/38/88fdc3af768f201e26988a7596a1a94e6657c08efe5ee8829a774a14a7a6/quilt3-7.2.0.tar.gz", hash = "sha256:5518017ffd7409dc781655a3cb0561c12739ba6e6dc9f8da3cdbb49289d4a108", size = 94563, upload-time = "2026-01-28T12:46:00.637Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/59/1f1706ef37aece70fa174ebf0d2119d741cebf49bf104a1a733e22a63277/quilt3-7.3.0.tar.gz", hash = "sha256:34553cfefa4cf1ac5cdb10af9144248a8018db720541b7f3e819402ed0e15fca", size = 101821, upload-time = "2026-04-07T21:15:30.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/64/27741a8cb8ea46a1f6997773c13fa9823f9555d05f00057c3dc042668785/quilt3-7.2.0-py3-none-any.whl", hash = "sha256:74c23dcfcb887f911669581cc14d84330594b248f6c3ef41c0e9b369c77dd87c", size = 121988, upload-time = "2026-01-28T12:45:58.598Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/25/4511e114e3f8420a0edd9febd12de1a4a56b3259a779d7ce5d92c5dfd6ac/quilt3-7.3.0-py3-none-any.whl", hash = "sha256:585245b73ad40586af6fc5be689e1113d3e44bcb75e198b3ee9a03a036b79d07", size = 136740, upload-time = "2026-04-07T21:15:31.782Z" },
 ]
 
 [[package]]
@@ -1631,6 +1631,7 @@ name = "quiltx"
 version = "0.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pyyaml" },
     { name = "quilt3" },
     { name = "rich" },
 ]
@@ -1646,6 +1647,8 @@ dev = [
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "types-pyyaml", version = "6.0.12.20250915", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-pyyaml", version = "6.0.12.20260408", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1666,8 +1669,10 @@ requires-dist = [
     { name = "poethepoet", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "quilt3" },
+    { name = "pyyaml" },
+    { name = "quilt3", specifier = ">=7.3.0" },
     { name = "rich" },
+    { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "docs"]
 
@@ -2140,6 +2145,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/89/4b0001b2dab8df0a5ee2787dcbe771de75ded01f18f1f8d53dedeea2882b/tqdm-4.67.2.tar.gz", hash = "sha256:649aac53964b2cb8dec76a14b405a4c0d13612cb8933aae547dd144eacc99653", size = 169514, upload-time = "2026-01-30T23:12:06.555Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/e2/31eac96de2915cf20ccaed0225035db149dfb9165a9ed28d4b252ef3f7f7/tqdm-4.67.2-py3-none-any.whl", hash = "sha256:9a12abcbbff58b6036b2167d9d3853042b9d436fe7330f06ae047867f2f8e0a7", size = 78354, upload-time = "2026-01-30T23:12:04.368Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "quilt3" },


### PR DESCRIPTION
## Summary
- Add `quiltx stack acl <config.yml>` — declarative reconciliation of Quilt buckets, managed policies, managed roles, and SSO mappings from a single YAML file
- `quiltx stack acl` (no args) dumps the current server ACL state for inspection
- `--dry-run` to preview changes, `--verbose` for detailed diff output, `--yes` to skip confirmation
- Progress output during apply; SSO create-vs-update detection; default role in SSO config
- `auto_login` decorator for automatic session refresh on auth failure
- Public Python API: `AclConfig`, `AclDiff`, `CurrentState`, `compute_diff`, `apply_acl`, etc. exported from `quiltx`
- New dependency: `pyyaml`; bumped `quilt3>=7.3.0` for admin policies API
- Version bumped to 0.6.0

## Files changed
- `quiltx/acl.py` — core ACL parsing, diffing, and apply logic (new)
- `quiltx/tools/stack/acl.py` — CLI subcommand (new)
- `quiltx/__init__.py` — export ACL public API
- `quiltx/config.py` — `auto_login`, `normalize_catalog_url`
- `tests/test_acl.py` — comprehensive ACL unit tests (new)
- `tests/test_init.py` — init export tests (new)
- `spec/060-stack-acl/` — plan and demo YAML

## Test plan
- [x] `./poe test` passes
- [x] `./poe lint-check` passes
- [x] Manual: `quiltx stack acl` shows current state
- [x] Manual: `quiltx stack acl demo.yml --dry-run --verbose` previews changes
- [x] Manual: `quiltx stack acl demo.yml --yes` applies changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)