### PR TITLE
Add confirmation prompt to ecs run-migration (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-04-11
+
+### Added
+
+- Confirmation prompt for `quiltx ecs run-migration` showing stack, cluster, and task definition before execution; skip with `--yes`
+
 ## [0.7.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ uv tool install -U quiltx
 quiltx --list
 ```
 
-
 ## Stack ACL
 
 `quiltx stack acl` declaratively manages a Quilt stack's access control lists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.7.0"
+version = "0.7.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/quiltx/tools/ecs/run_migration.py
+++ b/quiltx/tools/ecs/run_migration.py
@@ -26,6 +26,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="AWS region override (defaults to stack payload).",
     )
     parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Run migration without prompting for confirmation.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print run_task parameters as JSON without starting the task.",
@@ -95,6 +100,17 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
             return 0
+
+        print(f"Stack:           {stack_name}")
+        print(f"Cluster:         {cluster}")
+        print(f"Task definition: {task_def}")
+        if region:
+            print(f"Region:          {region}")
+        if not args.yes:
+            response = input("\nRun migration? [y/N]: ").strip().lower()
+            if response not in {"y", "yes"}:
+                print("Aborted.")
+                return 1
 
         task = ecs_lib.run_migration(ecs_client, cluster, task_def, network_config)
         task_arn = task.get("taskArn")

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- Add confirmation prompt to `quiltx ecs run-migration` that displays stack, cluster, and task definition before execution
- Add `--yes` flag to skip the prompt for scripted/CI use
- Minor README whitespace cleanup

## Test plan
- [ ] Run `quiltx ecs run-migration` and verify confirmation prompt appears
- [ ] Run `quiltx ecs run-migration --yes` and verify it skips the prompt
- [ ] Run `quiltx ecs run-migration --dry-run` and verify it still skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)