### PR TITLE
Auto-login for bucket commands, Quilt-session CFN discovery, TLS flags (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - Unreleased
+## [0.9.0] - 2026-04-17
 
 ### Added
 
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `quiltx stack acl` now synthesizes cumulative managed roles from policy order, generates inline managed policies for static-role bucket grants, and derives SSO mappings directly from policy and role audiences
 - `quiltx stack acl` no longer prompts for a default role; `config.default_role: true` on a policy controls the emitted SSO default role
 - Stack ACL docs now use `spec/060-stack-acl/simpler-stack-acl.yml` as the canonical example and explain the order-sensitive synthetic role model
+- CloudFormation discovery now uses `quilt3.session.get_boto3_session()` when available, so `quiltx bucket` and stack discovery work for users who have run `quilt3 login` without needing CFN permissions on their own AWS identity
+- `quiltx bucket` commands are wrapped with `@auto_login`, re-prompting for `quilt3 login` on auth errors
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `quiltx bucket add --stack-only` flag to restrict the bucket policy principal to the stack's RegistryRoleARN instead of the entire control account
 - Direct-ACL specification (`spec/060-stack-acl/08-direct-acl.md`) and example YAML files (`dynamic-roles.yaml`, `static-policies.yaml`)
+- `quiltx stack catalog --ca-bundle PATH` and `--insecure` flags for catalogs behind corporate TLS-inspection proxies or with self-signed certificates
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ uvx quiltx stack acl config.yml
 uvx quiltx stack acl config.yml --yes
 ```
 
+## Catalogs behind corporate TLS proxies
+
+If `quiltx stack catalog <url>` fails with `CERTIFICATE_VERIFY_FAILED` (common
+on networks with TLS-inspection proxies or self-signed catalog certs), point
+Python at your organization's CA bundle:
+
+```bash
+# Preferred: trust your corporate root CA
+uvx quiltx stack catalog https://quilt.example.com --ca-bundle /path/to/corp-root.pem
+
+# Escape hatch: skip TLS verification (trusted networks only)
+uvx quiltx stack catalog https://quilt.example.com --insecure
+```
+
+`--ca-bundle` also exports `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` for the
+current process. To make the override stick across other `quiltx` subcommands,
+export `SSL_CERT_FILE=/path/to/corp-root.pem` in your shell profile.
+
 ## ECS
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.8.0"
+version = "0.9.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/quiltx/stack.py
+++ b/quiltx/stack.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import ssl
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
@@ -30,11 +32,36 @@ def extract_catalog_name(config: Mapping[str, Any]) -> str:
     return parsed.hostname
 
 
+def _quilt_cfn_client(region: str | None) -> Any:
+    """Return a CloudFormation client using Quilt-issued stack credentials.
+
+    Falls back to the default boto3 session if quilt3 is not logged in.
+    """
+    try:
+        from quilt3.session import get_boto3_session
+
+        return get_boto3_session().client("cloudformation", region_name=region)
+    except Exception:
+        import boto3
+
+        return boto3.client("cloudformation", region_name=region)
+
+
+def _default_ssl_context() -> ssl.SSLContext | None:
+    """Build an SSL context honoring SSL_CERT_FILE/REQUESTS_CA_BUNDLE if set."""
+    ca_bundle = os.environ.get("SSL_CERT_FILE") or os.environ.get("REQUESTS_CA_BUNDLE")
+    if ca_bundle and os.path.isfile(ca_bundle):
+        return ssl.create_default_context(cafile=ca_bundle)
+    return None
+
+
 def fetch_catalog_config(
-    catalog_url: str, opener: Callable[[str], Any] = urllib.request.urlopen
+    catalog_url: str, opener: Callable[..., Any] = urllib.request.urlopen
 ) -> Mapping[str, Any]:
     config_url = catalog_url.rstrip("/") + "/config.json"
-    with opener(config_url) as response:
+    context = _default_ssl_context()
+    kwargs = {"context": context} if context is not None else {}
+    with opener(config_url, **kwargs) as response:
         return json.load(response)
 
 
@@ -89,9 +116,7 @@ def find_matching_stack(
 
     # Create CloudFormation client if not provided
     if cfn_client is None:
-        import boto3
-
-        cfn_client = boto3.client("cloudformation", region_name=region)
+        cfn_client = _quilt_cfn_client(region)
 
     expected_host = get_hostname(catalog_url)
     paginator = cfn_client.get_paginator("describe_stacks")
@@ -133,9 +158,7 @@ def list_log_group_resources(
     if cfn_client is None:
         if region is None:
             raise ValueError("Either region or cfn_client must be provided")
-        import boto3
-
-        cfn_client = boto3.client("cloudformation", region_name=region)
+        cfn_client = _quilt_cfn_client(region)
 
     paginator = cfn_client.get_paginator("list_stack_resources")
     log_groups = []
@@ -172,9 +195,7 @@ def list_ecs_resources(
     if cfn_client is None:
         if region is None:
             raise ValueError("Either region or cfn_client must be provided")
-        import boto3
-
-        cfn_client = boto3.client("cloudformation", region_name=region)
+        cfn_client = _quilt_cfn_client(region)
 
     paginator = cfn_client.get_paginator("list_stack_resources")
     ecs_resources: list[dict[str, str]] = []

--- a/quiltx/tls.py
+++ b/quiltx/tls.py
@@ -1,0 +1,53 @@
+"""TLS configuration overrides for environments with corporate proxies or self-signed certs."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def apply_tls_overrides(ca_bundle: str | None = None, insecure: bool = False) -> None:
+    """Apply process-wide TLS settings before HTTP clients are initialized.
+
+    Args:
+        ca_bundle: Path to a PEM file with additional trusted CAs (e.g. a corporate root).
+        insecure: If True, disable TLS certificate verification entirely. Use only on
+            trusted networks; a loud warning is printed to stderr.
+    """
+    if ca_bundle:
+        if not os.path.isfile(ca_bundle):
+            raise FileNotFoundError(f"CA bundle not found: {ca_bundle}")
+        os.environ["SSL_CERT_FILE"] = ca_bundle
+        os.environ["REQUESTS_CA_BUNDLE"] = ca_bundle
+        os.environ["CURL_CA_BUNDLE"] = ca_bundle
+
+    if insecure:
+        import ssl
+
+        print(
+            "WARNING: TLS certificate verification disabled (--insecure). "
+            "Only use on trusted networks.",
+            file=sys.stderr,
+        )
+        ssl._create_default_https_context = ssl._create_unverified_context  # type: ignore[assignment]
+
+        try:
+            import urllib3
+
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
+        try:
+            import requests  # type: ignore
+
+            _orig = requests.Session.merge_environment_settings
+
+            def _merge(self, url, proxies, stream, verify, cert):
+                settings = _orig(self, url, proxies, stream, verify, cert)
+                settings["verify"] = False
+                return settings
+
+            requests.Session.merge_environment_settings = _merge
+        except ImportError:
+            pass

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -14,7 +14,7 @@ from rich.table import Table
 
 from quiltx import bucket as bucket_lib
 from quiltx import stack as stack_lib
-from quiltx.config import get_catalog_config
+from quiltx.config import auto_login, get_catalog_config
 from quiltx.utils import get_bucket_region
 
 
@@ -129,6 +129,7 @@ def _ensure_stack_payload(
     return payload
 
 
+@auto_login
 def _cmd_add(args: argparse.Namespace) -> int:
     try:
         config = get_catalog_config()
@@ -257,10 +258,13 @@ def _cmd_add(args: argparse.Namespace) -> int:
         print()
         return _verify_bucket_registration_and_access(args.bucket_name)
     except Exception as exc:
+        if "Authentication failed" in str(exc):
+            raise
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
 
+@auto_login
 def _cmd_list() -> int:
     try:
         from quilt3.admin import buckets as admin_buckets
@@ -282,6 +286,8 @@ def _cmd_list() -> int:
         console.print(table)
         return 0
     except Exception as exc:
+        if "Authentication failed" in str(exc):
+            raise
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
@@ -290,6 +296,7 @@ def _cmd_test(args: argparse.Namespace) -> int:
     return _verify_bucket_registration_and_access(args.bucket_name)
 
 
+@auto_login
 def _verify_bucket_registration_and_access(bucket_name: str) -> int:
     import quilt3
     from quilt3.admin import buckets as admin_buckets
@@ -311,6 +318,8 @@ def _verify_bucket_registration_and_access(bucket_name: str) -> int:
         print(f"OK: control account can read {bucket_uri}")
         return 0
     except Exception as exc:
+        if "Authentication failed" in str(exc):
+            raise
         print(
             f"Control account cannot read {bucket_uri}: {exc}",
             file=sys.stderr,

--- a/quiltx/tools/stack/catalog.py
+++ b/quiltx/tools/stack/catalog.py
@@ -7,6 +7,7 @@ import sys
 
 import quiltx
 from quiltx import stack as stack_lib
+from quiltx.tls import apply_tls_overrides
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -23,12 +24,31 @@ def build_parser() -> argparse.ArgumentParser:
         "--token",
         help="API token for authentication",
     )
+    parser.add_argument(
+        "--ca-bundle",
+        metavar="PATH",
+        help=(
+            "Path to a PEM file of trusted CA certificates (e.g. a corporate root). "
+            "Also exported as SSL_CERT_FILE/REQUESTS_CA_BUNDLE for this process."
+        ),
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification. Use only on trusted networks.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    try:
+        apply_tls_overrides(ca_bundle=args.ca_bundle, insecure=args.insecure)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
     try:
         if not args.catalog_url:

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `quiltx bucket` commands now wrapped with `@auto_login` so auth failures re-prompt `quilt3 login` and retry
- CloudFormation discovery routes through `quilt3.session.get_boto3_session()` when logged in, letting users without direct CFN permissions run `quiltx bucket` / stack discovery; falls back to plain boto3 otherwise
- `quiltx stack catalog --ca-bundle PATH` and `--insecure` flags for catalogs behind corporate TLS-inspection proxies or self-signed certs
- Version bump to 0.9.0

## Test plan

- [ ] `./poe test-all`
- [ ] `quiltx bucket` against a stack where the caller lacks CFN perms but has `quilt3 login`
- [ ] `quiltx stack catalog <url> --ca-bundle ./corp-root.pem`
- [ ] `quiltx stack catalog <url> --insecure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)