### PR TITLE
Drop CloudFormation requirement from bucket add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `quiltx bucket add` no longer requires CloudFormation access in any account: when the Quilt stack role lacks `cloudformation:DescribeStacks`, it derives `account_id` from `sts:GetCallerIdentity` on the Quilt session and reads `region` from the catalog `config.json`. `--stack-only` still needs CFN to read `RegistryRoleARN`.
+
 ## [0.9.0] - 2026-04-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.9.0"
+version = "0.9.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/quiltx/tls.py
+++ b/quiltx/tls.py
@@ -39,7 +39,7 @@ def apply_tls_overrides(ca_bundle: str | None = None, insecure: bool = False) ->
             pass
 
         try:
-            import requests  # type: ignore
+            import requests  # type: ignore[import-untyped,unused-ignore]
 
             _orig = requests.Session.merge_environment_settings
 

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -101,7 +101,7 @@ def main(argv: list[str] | None = None) -> int:
 def _ensure_stack_payload(
     config: Mapping[str, Any], catalog_name: str
 ) -> Mapping[str, Any]:
-    """Load cached stack payload, discovering and caching it if missing."""
+    """Load cached stack payload, or derive a lightweight one from the Quilt session."""
     payload = stack_lib.load_stack_payload(catalog_name)
     if payload is not None:
         return payload
@@ -111,22 +111,58 @@ def _ensure_stack_payload(
     region = stack_lib.resolve_region(config, catalog_config)
 
     print(f"Discovering stack for {catalog_name}...")
-    stack_info = stack_lib.find_matching_stack(catalog_url, region=region)
-    log_groups = stack_lib.list_log_group_resources(
-        stack_info["StackName"], region=region
-    )
-    stack_lib.write_stack_payload(
-        catalog_name,
-        catalog_url,
-        region,
-        stack_info,
-        log_groups,
-        catalog_config=catalog_config,
-    )
-    payload = stack_lib.load_stack_payload(catalog_name)
-    if payload is None:
-        raise ValueError("Failed to cache stack metadata.")
-    return payload
+    try:
+        stack_info = stack_lib.find_matching_stack(catalog_url, region=region)
+        log_groups = stack_lib.list_log_group_resources(
+            stack_info["StackName"], region=region
+        )
+        stack_lib.write_stack_payload(
+            catalog_name,
+            catalog_url,
+            region,
+            stack_info,
+            log_groups,
+            catalog_config=catalog_config,
+        )
+        cached = stack_lib.load_stack_payload(catalog_name)
+        if cached is not None:
+            return cached
+    except Exception as exc:
+        print(
+            f"CloudFormation discovery unavailable ({exc}); "
+            "using Quilt session identity for account/region.",
+            file=sys.stderr,
+        )
+
+    return _lightweight_stack_payload(catalog_name, catalog_url, region, catalog_config)
+
+
+def _lightweight_stack_payload(
+    catalog_name: str,
+    catalog_url: str,
+    region: str,
+    catalog_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Build an in-memory stack payload from the Quilt session (no CFN calls)."""
+    from quilt3.session import get_boto3_session
+
+    session = get_boto3_session()
+    account_id = session.client("sts").get_caller_identity()["Account"]
+
+    return {
+        "catalog_name": catalog_name,
+        "catalog_url": catalog_url,
+        "web_url": catalog_url,
+        "region": region,
+        "account_id": account_id,
+        "stack_name": None,
+        "stack_id": None,
+        "outputs": [],
+        "parameters": [],
+        "log_groups": [],
+        "ecs_resources": [],
+        "catalog_config": dict(catalog_config),
+    }
 
 
 @auto_login
@@ -144,8 +180,9 @@ def _cmd_add(args: argparse.Namespace) -> int:
             and control_principal_arn == f"arn:aws:iam::{control_account_id}:root"
         ):
             print(
-                "Error: --stack-only requires a RegistryRoleARN in stack outputs, "
-                "but none was found.",
+                "Error: --stack-only requires a RegistryRoleARN from stack outputs, "
+                "which needs CloudFormation access. Run 'quiltx stack' from a shell "
+                "with cloudformation:DescribeStacks in the catalog account first.",
                 file=sys.stderr,
             )
             return 1

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `quiltx bucket add` now works from any shell with `quilt3 login`, without needing `cloudformation:DescribeStacks` in the catalog account
- Falls back to `sts:GetCallerIdentity` on the Quilt-issued session for `account_id`, and reads `region` from the catalog `config.json`
- `--stack-only` still requires CFN (to read `RegistryRoleARN`); error message now tells the user to run `quiltx stack` from a shell with CFN access

## Background

In the field this surfaced as:

\`\`\`
Error: No stack found with QuiltWebHost matching https://quilt.incyteaws.com
\`\`\`

and after switching to the Quilt session:

\`\`\`
AccessDenied: ... not authorized to perform: cloudformation:ListStacks
\`\`\`

The Quilt-issued read/write role doesn't have CFN describe perms, so the fix is to skip CFN entirely in the common path.

## Test plan

- [x] \`./poe test\` — 131 passed, 1 skipped
- [ ] Manual: \`quiltx bucket add --dry-run <bucket>\` against a catalog without granting the caller CFN perms