### PR TITLE
Replace bucket add --stack-only with --principal (v0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `quiltx bucket add --principal ARN` flag to set the IAM principal(s) granted cross-account access in the bucket policy. Repeatable or comma-separated. Bare `--principal` prints guidance on choosing Quilt service role ARNs.
+
+### Removed
+
+- `quiltx bucket add --stack-only` flag. It restricted the bucket policy to the stack's `RegistryRoleARN`, which is the ECS task execution role — not a role Quilt uses to access data buckets. Quilt does not publish an official list of roles for the bucket policy; the documented principal is the control account root. Use `--principal ARN` if you want to narrow access yourself.
+
 ### Changed
 
-- `quiltx bucket add` no longer requires CloudFormation access in any account: when the Quilt stack role lacks `cloudformation:DescribeStacks`, it derives `account_id` from `sts:GetCallerIdentity` on the Quilt session and reads `region` from the catalog `config.json`. `--stack-only` still needs CFN to read `RegistryRoleARN`.
+- `quiltx bucket add` no longer requires CloudFormation access in any account: when the Quilt stack role lacks `cloudformation:DescribeStacks`, it derives `account_id` from `sts:GetCallerIdentity` on the Quilt session and reads `region` from the catalog `config.json`.
 
 ## [0.9.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-17
+
 ### Added
 
 - `quiltx bucket add --principal ARN` flag to set the IAM principal(s) granted cross-account access in the bucket policy. Repeatable or comma-separated. Bare `--principal` prints guidance on choosing Quilt service role ARNs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.9.1"
+version = "0.9.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from botocore.exceptions import ClientError
 
@@ -57,19 +57,24 @@ def build_quilt_policy_statement(
     bucket: str,
     control_account_id: str,
     *,
-    principal_arn: str | None = None,
+    principals: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Build the cross-account bucket policy statement for Quilt infrastructure.
 
-    When *principal_arn* is supplied (e.g. a specific RegistryRoleARN), only that
-    principal is granted access.  Otherwise the entire control account
-    (``arn:aws:iam::{control_account_id}:root``) is used.
+    When *principals* is supplied, only those principals are granted access.
+    Otherwise the entire control account (``arn:aws:iam::{control_account_id}:root``)
+    is used.
     """
-    principal = principal_arn or f"arn:aws:iam::{control_account_id}:root"
+    if principals:
+        principal_value: str | list[str] = (
+            list(principals) if len(principals) > 1 else principals[0]
+        )
+    else:
+        principal_value = f"arn:aws:iam::{control_account_id}:root"
     return {
         "Sid": QUILT_POLICY_SID,
         "Effect": "Allow",
-        "Principal": {"AWS": principal},
+        "Principal": {"AWS": principal_value},
         "Action": list(QUILT_POLICY_ACTIONS),
         "Resource": [
             f"arn:aws:s3:::{bucket}",
@@ -140,7 +145,7 @@ def configure_sns_topic_policy(
     bucket: str,
     sns_topic_arn: str,
     data_account_id: str,
-    control_principal_arn: str,
+    control_principal_arn: str | Sequence[str],
     sns_client: Any = None,
 ) -> None:
     """Ensure the SNS topic policy allows S3 publish and Quilt subscribe access."""
@@ -233,7 +238,7 @@ def add_bucket(
     *,
     title: str | None = None,
     profile: str | None = None,
-    stack_only: bool = False,
+    principals: Sequence[str] | None = None,
 ) -> AddBucketResult:
     """Register an S3 bucket with the configured Quilt catalog.
 
@@ -247,15 +252,14 @@ def add_bucket(
         bucket: S3 bucket name.
         title: Display title in the catalog (defaults to bucket name).
         profile: AWS profile for the data account that owns the bucket.
-        stack_only: When True, restrict the bucket policy to the stack's
-            RegistryRoleARN instead of the entire control account.
+        principals: IAM principal ARNs granted access in the bucket policy.
+            Defaults to the control account root.
 
     Returns:
         AddBucketResult with bucket details and registration status.
 
     Raises:
-        ValueError: If no catalog is configured or stack metadata is missing,
-            or if *stack_only* is True but the stack has no RegistryRoleARN.
+        ValueError: If no catalog is configured or stack metadata is missing.
     """
     import boto3
     from quilt3.admin import buckets as admin_buckets
@@ -271,23 +275,9 @@ def add_bucket(
         raise ValueError("Stack metadata missing account_id. Run 'quiltx stack' first.")
     control_account_id = str(control_account_id)
 
-    # Find RegistryRoleARN from stack outputs, fall back to account root
-    registry_role_arn: str | None = None
-    for output in payload.get("outputs") or []:
-        if isinstance(output, Mapping):
-            if output.get("OutputKey") == "RegistryRoleARN" and output.get(
-                "OutputValue"
-            ):
-                registry_role_arn = str(output["OutputValue"])
-                break
-
-    if stack_only and not registry_role_arn:
-        raise ValueError(
-            "--stack-only requires a RegistryRoleARN in stack outputs, but none was found."
-        )
-
-    control_principal_arn = (
-        registry_role_arn or f"arn:aws:iam::{control_account_id}:root"
+    principal_list = list(principals) if principals else []
+    sns_principal: str | list[str] = (
+        principal_list if principal_list else f"arn:aws:iam::{control_account_id}:root"
     )
 
     bucket_title = title or bucket
@@ -308,11 +298,9 @@ def add_bucket(
     sns_client = session.client("sns", region_name=bucket_region)
     data_account_id = str(session.client("sts").get_caller_identity()["Account"])
 
-    # Bucket policy — when stack_only, restrict to the specific role ARN
-    bucket_principal_arn = control_principal_arn if stack_only else None
     existing_policy = get_bucket_policy(bucket, s3_client=s3_client)
     statement = build_quilt_policy_statement(
-        bucket, control_account_id, principal_arn=bucket_principal_arn
+        bucket, control_account_id, principals=principal_list or None
     )
     merged = merge_bucket_policy(existing_policy, statement)
     apply_bucket_policy(bucket, merged, s3_client=s3_client)
@@ -326,7 +314,7 @@ def add_bucket(
         bucket,
         sns_topic_arn,
         data_account_id,
-        control_principal_arn,
+        sns_principal,
         sns_client=sns_client,
     )
 
@@ -404,12 +392,17 @@ def _build_sns_topic_publish_policy_statement(
 
 
 def _build_sns_topic_subscribe_policy_statement(
-    sns_topic_arn: str, control_principal_arn: str
+    sns_topic_arn: str, control_principals: str | Sequence[str]
 ) -> dict[str, Any]:
+    if isinstance(control_principals, str):
+        principal_value: str | list[str] = control_principals
+    else:
+        principals = list(control_principals)
+        principal_value = principals[0] if len(principals) == 1 else principals
     return {
         "Sid": SNS_SUBSCRIBE_POLICY_SID,
         "Effect": "Allow",
-        "Principal": {"AWS": control_principal_arn},
+        "Principal": {"AWS": principal_value},
         "Action": [
             "sns:GetTopicAttributes",
             "sns:Subscribe",

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -59,11 +59,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Skip the post-add registration/read verification.",
     )
     add_parser.add_argument(
-        "--stack-only",
-        action="store_true",
+        "--principal",
+        metavar="ARN",
+        action="append",
+        nargs="?",
+        const="",
         help=(
-            "Restrict the bucket policy principal to the stack's RegistryRoleARN "
-            "instead of the entire control account."
+            "IAM role ARN(s) granted cross-account access in the bucket policy. "
+            "Repeatable or comma-separated. Defaults to the control account root. "
+            "Use the bare flag (no value) to print guidance on choosing principals."
         ),
     )
 
@@ -168,25 +172,25 @@ def _lightweight_stack_payload(
 @auto_login
 def _cmd_add(args: argparse.Namespace) -> int:
     try:
+        principals, show_guidance = _resolve_principals_arg(args.principal)
+        if show_guidance:
+            _print_principal_guidance()
+            return 0
+        for principal in principals:
+            if not principal.startswith("arn:aws:iam::"):
+                print(
+                    f"Error: --principal must be an IAM role ARN, got {principal!r}",
+                    file=sys.stderr,
+                )
+                return 1
+
         config = get_catalog_config()
         catalog_name = stack_lib.extract_catalog_name(config)
         stack_payload = _ensure_stack_payload(config, catalog_name)
         control_account_id = _load_control_account_id(stack_payload)
-        control_principal_arn = _load_control_principal_arn(
-            stack_payload, control_account_id
-        )
-        if (
-            args.stack_only
-            and control_principal_arn == f"arn:aws:iam::{control_account_id}:root"
-        ):
-            print(
-                "Error: --stack-only requires a RegistryRoleARN from stack outputs, "
-                "which needs CloudFormation access. Run 'quiltx stack' from a shell "
-                "with cloudformation:DescribeStacks in the catalog account first.",
-                file=sys.stderr,
-            )
-            return 1
-        stack_name = _stack_payload_value(stack_payload, "stack_name", "unknown")
+        effective_principals = principals or [f"arn:aws:iam::{control_account_id}:root"]
+        principal_source = "--principal" if principals else "account root (default)"
+        stack_name = _stack_payload_value(stack_payload, "stack_name", "") or None
         control_region = _stack_payload_value(stack_payload, "region", "unknown")
         catalog_url = str(config.get("navigator_url") or catalog_name)
 
@@ -207,9 +211,10 @@ def _cmd_add(args: argparse.Namespace) -> int:
         bucket_policy = bucket_lib.get_bucket_policy(
             args.bucket_name, s3_client=s3_client
         )
-        bucket_principal_arn = control_principal_arn if args.stack_only else None
         quilt_statement = bucket_lib.build_quilt_policy_statement(
-            args.bucket_name, control_account_id, principal_arn=bucket_principal_arn
+            args.bucket_name,
+            control_account_id,
+            principals=principals or None,
         )
         merged_policy = bucket_lib.merge_bucket_policy(bucket_policy, quilt_statement)
 
@@ -225,7 +230,8 @@ def _cmd_add(args: argparse.Namespace) -> int:
                 catalog_url,
                 stack_name,
                 control_account_id,
-                control_principal_arn,
+                effective_principals,
+                principal_source,
                 control_region,
                 args.bucket_name,
                 bucket_region,
@@ -241,7 +247,8 @@ def _cmd_add(args: argparse.Namespace) -> int:
             catalog_url,
             stack_name,
             control_account_id,
-            control_principal_arn,
+            effective_principals,
+            principal_source,
             control_region,
             args.bucket_name,
             bucket_region,
@@ -263,7 +270,7 @@ def _cmd_add(args: argparse.Namespace) -> int:
             args.bucket_name,
             sns_topic_arn,
             data_account_id,
-            control_principal_arn,
+            effective_principals,
             sns_client=sns_client,
         )
 
@@ -375,15 +382,6 @@ def _load_control_account_id(stack_payload: Mapping[str, Any] | None) -> str:
     return str(account_id)
 
 
-def _load_control_principal_arn(
-    stack_payload: Mapping[str, Any] | None, control_account_id: str
-) -> str:
-    role_arn = _stack_output_value(stack_payload, "RegistryRoleARN")
-    if role_arn:
-        return role_arn
-    return f"arn:aws:iam::{control_account_id}:root"
-
-
 def _stack_payload_value(
     stack_payload: Mapping[str, Any] | None, key: str, default: str
 ) -> str:
@@ -395,17 +393,48 @@ def _stack_payload_value(
     return str(value)
 
 
-def _stack_output_value(
-    stack_payload: Mapping[str, Any] | None, output_key: str
-) -> str | None:
-    if not stack_payload:
-        return None
-    for output in stack_payload.get("outputs") or []:
-        if not isinstance(output, Mapping):
+def _resolve_principals_arg(
+    raw: list[str] | None,
+) -> tuple[list[str], bool]:
+    """Parse --principal values into a list of ARNs.
+
+    Returns (principals, show_guidance). show_guidance is True when the user
+    passed a bare --principal with no value.
+    """
+    if not raw:
+        return [], False
+    principals: list[str] = []
+    show_guidance = False
+    for item in raw:
+        if item == "":
+            show_guidance = True
             continue
-        if output.get("OutputKey") == output_key and output.get("OutputValue"):
-            return str(output["OutputValue"])
-    return None
+        for part in item.split(","):
+            part = part.strip()
+            if part:
+                principals.append(part)
+    return principals, show_guidance
+
+
+def _print_principal_guidance() -> None:
+    print(
+        "The --principal flag sets the IAM ARN(s) granted cross-account access in "
+        "the bucket policy.\n"
+        "\n"
+        "Default (flag omitted): the entire control account root\n"
+        "  arn:aws:iam::<CONTROL-ACCOUNT-ID>:root\n"
+        "\n"
+        "To narrow access, pass one or more role ARNs (repeatable, or comma-\n"
+        "separated). Quilt does not publish an official list of roles for the\n"
+        "bucket policy; the documented principal is the control account root.\n"
+        "If you choose to restrict, inspect your Quilt CloudFormation stack's\n"
+        "IAM resources and select the roles appropriate for your use case.\n"
+        "See: https://docs.quilt.bio/quilt-platform-administrator/crossaccount\n"
+        "\n"
+        "Example:\n"
+        "  quiltx bucket add my-bucket \\\n"
+        "      --principal arn:aws:iam::123:role/<stack>-SomeRole-XXXX"
+    )
 
 
 def _get_session_account_id(session: boto3.Session) -> str:
@@ -415,9 +444,10 @@ def _get_session_account_id(session: boto3.Session) -> str:
 def _confirm_bucket_add(
     catalog_name: str,
     catalog_url: str,
-    stack_name: str,
+    stack_name: str | None,
     control_account_id: str,
-    control_principal_arn: str,
+    principals: list[str],
+    principal_source: str,
     control_region: str,
     bucket_name: str,
     bucket_region: str,
@@ -433,7 +463,8 @@ def _confirm_bucket_add(
         catalog_url,
         stack_name,
         control_account_id,
-        control_principal_arn,
+        principals,
+        principal_source,
         control_region,
         bucket_name,
         bucket_region,
@@ -441,6 +472,15 @@ def _confirm_bucket_add(
         profile,
         sns_topic_arn,
     )
+    if sns_topic_arn is None:
+        planned_topic_arn = (
+            f"arn:aws:sns:{bucket_region}:{data_account_id}:"
+            f"{bucket_lib._sns_topic_name(bucket_name)}"
+        )
+        console.print(
+            f"\n[yellow]WARNING:[/yellow] no existing SNS topic found; "
+            f"a new topic will be created: {planned_topic_arn}"
+        )
     response = input("Continue? [y/N]: ").strip().lower()
     return response in {"y", "yes"}
 
@@ -448,9 +488,10 @@ def _confirm_bucket_add(
 def _print_dry_run_plan(
     catalog_name: str,
     catalog_url: str,
-    stack_name: str,
+    stack_name: str | None,
     control_account_id: str,
-    control_principal_arn: str,
+    principals: list[str],
+    principal_source: str,
     control_region: str,
     bucket_name: str,
     bucket_region: str,
@@ -467,7 +508,8 @@ def _print_dry_run_plan(
         catalog_url,
         stack_name,
         control_account_id,
-        control_principal_arn,
+        principals,
+        principal_source,
         control_region,
         bucket_name,
         bucket_region,
@@ -483,6 +525,11 @@ def _print_dry_run_plan(
         f"arn:aws:sns:{bucket_region}:{data_account_id}:"
         f"{bucket_lib._sns_topic_name(bucket_name)}"
     )
+    if sns_topic_arn is None:
+        console.print(
+            f"\n[yellow]WARNING:[/yellow] no existing SNS topic found; "
+            f"a new topic will be created: {planned_topic_arn}"
+        )
     print("\nPlanned SNS topic policy statement:")
     _print_json(
         console,
@@ -496,7 +543,7 @@ def _print_dry_run_plan(
                 ),
                 bucket_lib._build_sns_topic_subscribe_policy_statement(
                     planned_topic_arn,
-                    control_principal_arn,
+                    principals,
                 ),
             ],
         },
@@ -508,9 +555,10 @@ def _print_context_table(
     title: str,
     catalog_name: str,
     catalog_url: str,
-    stack_name: str,
+    stack_name: str | None,
     control_account_id: str,
-    control_principal_arn: str,
+    principals: list[str],
+    principal_source: str,
     control_region: str,
     bucket_name: str,
     bucket_region: str,
@@ -535,18 +583,20 @@ def _print_context_table(
         control_region,
         catalog_url,
     )
-    context_table.add_row(
-        stack_name,
-        control_account_id,
-        control_region,
-        "cached stack.json",
-    )
-    context_table.add_row(
-        control_principal_arn,
-        control_account_id,
-        control_region,
-        "RegistryRoleARN",
-    )
+    if stack_name:
+        context_table.add_row(
+            stack_name,
+            control_account_id,
+            control_region,
+            "cached stack.json",
+        )
+    for principal in principals:
+        context_table.add_row(
+            principal,
+            control_account_id,
+            control_region,
+            principal_source,
+        )
     context_table.add_row(
         f"s3://{bucket_name}",
         data_account_id,

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -461,8 +461,8 @@ def test_add_dry_run(monkeypatch, capsys) -> None:
     assert "cached stack.json" in captured.out
     assert "s3://bucket" in captured.out
     assert "quilt-demo-stack" in captured.out
-    assert "arn:aws:iam::123456789012:role/quilt-registry" in captured.out
-    assert "RegistryRoleARN" in captured.out
+    assert "arn:aws:iam::123456789012:root" in captured.out
+    assert "account root (default)" in captured.out
     assert "123456789012" in captured.out
     assert "111122223333" in captured.out
     assert "us-west-2" in captured.out
@@ -708,9 +708,7 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
                         {
                             "Sid": "QuiltCrossAccountSNSAccess",
                             "Effect": "Allow",
-                            "Principal": {
-                                "AWS": "arn:aws:iam::123456789012:role/quilt-registry"
-                            },
+                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
                             "Action": [
                                 "sns:GetTopicAttributes",
                                 "sns:Subscribe",
@@ -871,9 +869,7 @@ def test_add_creates_sns(monkeypatch) -> None:
                         {
                             "Sid": "QuiltCrossAccountSNSAccess",
                             "Effect": "Allow",
-                            "Principal": {
-                                "AWS": "arn:aws:iam::123456789012:role/quilt-registry"
-                            },
+                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
                             "Action": [
                                 "sns:GetTopicAttributes",
                                 "sns:Subscribe",
@@ -997,7 +993,8 @@ def test_confirm_bucket_add_renders_context_table(monkeypatch, capsys) -> None:
         "https://demo.example.com",
         "quilt-demo-stack",
         "123456789012",
-        "arn:aws:iam::123456789012:role/quilt-registry",
+        ["arn:aws:iam::123456789012:role/quilt-registry"],
+        "--principal",
         "us-east-1",
         "bucket",
         "us-west-2",
@@ -1009,7 +1006,7 @@ def test_confirm_bucket_add_renders_context_table(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     assert "Bucket add confirmation" in captured.out
     assert "arn:aws:iam::123456789012:role/quilt-registry" in captured.out
-    assert "RegistryRoleARN" in captured.out
+    assert "--principal" in captured.out
     assert "s3://bucket" in captured.out
     assert "reuse existing SNS topic" in captured.out
     assert "AWS profile open" in captured.out
@@ -1175,9 +1172,7 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
                         {
                             "Sid": "QuiltCrossAccountSNSAccess",
                             "Effect": "Allow",
-                            "Principal": {
-                                "AWS": "arn:aws:iam::123456789012:role/quilt-registry"
-                            },
+                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
                             "Action": [
                                 "sns:GetTopicAttributes",
                                 "sns:Subscribe",
@@ -1261,131 +1256,60 @@ def test_add_bucket_defaults_title_to_bucket_name(monkeypatch) -> None:
     assert result.already_registered is True
 
 
-# -- Tests for --stack-only / principal_arn --
+# -- Tests for --principal --
 
 
-def test_build_quilt_policy_statement_with_principal_arn() -> None:
-    """When principal_arn is given, the statement uses it instead of account root."""
-    role_arn = "arn:aws:iam::123456789012:role/quilt-registry"
+def test_build_quilt_policy_statement_with_single_principal() -> None:
+    role_arn = "arn:aws:iam::123456789012:role/quilt-lambda"
     statement = bucket_lib.build_quilt_policy_statement(
-        "demo-bucket", "123456789012", principal_arn=role_arn
+        "demo-bucket", "123456789012", principals=[role_arn]
     )
     assert statement["Principal"] == {"AWS": role_arn}
-    assert statement["Resource"] == [
-        "arn:aws:s3:::demo-bucket",
-        "arn:aws:s3:::demo-bucket/*",
+
+
+def test_build_quilt_policy_statement_with_multiple_principals() -> None:
+    arns = [
+        "arn:aws:iam::123456789012:role/quilt-lambda",
+        "arn:aws:iam::123456789012:role/quilt-indexer",
     ]
+    statement = bucket_lib.build_quilt_policy_statement(
+        "demo-bucket", "123456789012", principals=arns
+    )
+    assert statement["Principal"] == {"AWS": arns}
 
 
-def test_build_quilt_policy_statement_without_principal_arn_uses_root() -> None:
-    """Without principal_arn, falls back to account root (existing behavior)."""
+def test_build_quilt_policy_statement_without_principals_uses_root() -> None:
     statement = bucket_lib.build_quilt_policy_statement("demo-bucket", "123456789012")
     assert statement["Principal"] == {"AWS": "arn:aws:iam::123456789012:root"}
 
 
-def test_add_bucket_stack_only_no_registry_role(monkeypatch) -> None:
-    """stack_only=True errors when stack has no RegistryRoleARN."""
-    _stub_stack_and_config(
-        monkeypatch, payload={"account_id": "123456789012", "outputs": []}
+def test_resolve_principals_arg_bare_flag_requests_guidance() -> None:
+    principals, show_guidance = bucket_tool._resolve_principals_arg([""])
+    assert principals == []
+    assert show_guidance is True
+
+
+def test_resolve_principals_arg_splits_comma_separated() -> None:
+    principals, show_guidance = bucket_tool._resolve_principals_arg(
+        ["arn:aws:iam::1:role/A,arn:aws:iam::1:role/B", "arn:aws:iam::1:role/C"]
     )
-    _install_fake_quilt3(monkeypatch)
-
-    try:
-        add_bucket("bucket", stack_only=True)
-    except ValueError as exc:
-        assert "RegistryRoleARN" in str(exc)
-    else:
-        raise AssertionError("expected ValueError for missing RegistryRoleARN")
+    assert principals == [
+        "arn:aws:iam::1:role/A",
+        "arn:aws:iam::1:role/B",
+        "arn:aws:iam::1:role/C",
+    ]
+    assert show_guidance is False
 
 
-def test_cmd_add_stack_only_no_registry_role(monkeypatch, capsys) -> None:
-    """CLI --stack-only exits 1 when stack has no RegistryRoleARN."""
-    s3_client = _client("s3", region_name="us-west-2")
-    s3_stubber = Stubber(s3_client)
-    s3_stubber.add_response(
-        "get_bucket_location",
-        {"LocationConstraint": "us-west-2"},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.activate()
-
-    session = FakeSession(s3_client, _client("sns", "us-west-2"), _client("sts"))
-    monkeypatch.setattr(bucket_tool.boto3, "Session", lambda profile_name=None: session)
-    monkeypatch.setattr(bucket_tool, "get_catalog_config", lambda: {"catalog": "demo"})
-    monkeypatch.setattr(
-        bucket_tool.stack_lib,
-        "load_stack_payload",
-        lambda catalog_name: {"account_id": "123456789012", "outputs": []},
-    )
-    _install_fake_quilt3(monkeypatch, get_result=None)
-
-    assert bucket_tool.main(["add", "bucket", "--stack-only", "--yes"]) == 1
+def test_cmd_add_principal_bare_flag_prints_guidance(monkeypatch, capsys) -> None:
+    assert bucket_tool.main(["add", "bucket", "--principal"]) == 0
     captured = capsys.readouterr()
-    assert "RegistryRoleARN" in captured.err
+    assert "--principal" in captured.out
+    assert "control account root" in captured.out
+    assert "docs.quilt.bio" in captured.out
 
-    s3_stubber.deactivate()
 
-
-def test_cmd_add_stack_only_dry_run(monkeypatch, capsys) -> None:
-    """--stack-only --dry-run shows the role ARN as the bucket policy principal."""
-    s3_client = _client("s3", region_name="us-west-2")
-    s3_stubber = Stubber(s3_client)
-    s3_stubber.add_response(
-        "get_bucket_location",
-        {"LocationConstraint": "us-west-2"},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_client_error(
-        "get_bucket_policy",
-        service_error_code="NoSuchBucketPolicy",
-        service_message="No bucket policy",
-        expected_params={"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.activate()
-
-    sts_client = _client("sts", region_name="us-west-2")
-    sts_stubber = Stubber(sts_client)
-    sts_stubber.add_response(
-        "get_caller_identity",
-        {
-            "Account": "111122223333",
-            "Arn": "arn:aws:iam::111122223333:user/test",
-            "UserId": "test",
-        },
-        {},
-    )
-    sts_stubber.activate()
-
-    session = FakeSession(s3_client, _client("sns", "us-west-2"), sts_client)
-    monkeypatch.setattr(bucket_tool.boto3, "Session", lambda profile_name=None: session)
-    monkeypatch.setattr(bucket_tool, "get_catalog_config", lambda: {"catalog": "demo"})
-    monkeypatch.setattr(
-        bucket_tool.stack_lib,
-        "load_stack_payload",
-        lambda catalog_name: {
-            "account_id": "123456789012",
-            "stack_name": "quilt-demo-stack",
-            "region": "us-east-1",
-            "outputs": [
-                {
-                    "OutputKey": "RegistryRoleARN",
-                    "OutputValue": "arn:aws:iam::123456789012:role/quilt-registry",
-                }
-            ],
-        },
-    )
-    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
-
-    assert bucket_tool.main(["add", "bucket", "--stack-only", "--dry-run"]) == 0
+def test_cmd_add_principal_rejects_non_arn(monkeypatch, capsys) -> None:
+    assert bucket_tool.main(["add", "bucket", "--principal", "not-an-arn"]) == 1
     captured = capsys.readouterr()
-    # The bucket policy principal should be the role, NOT account root
-    assert "arn:aws:iam::123456789012:role/quilt-registry" in captured.out
-    assert "arn:aws:iam::123456789012:root" not in captured.out
-
-    s3_stubber.deactivate()
-    sts_stubber.deactivate()
+    assert "must be an IAM role ARN" in captured.err

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Replace `quiltx bucket add --stack-only` with `--principal ARN` (repeatable/comma-separated; bare flag prints guidance). The old `--stack-only` pointed at the stack's `RegistryRoleARN` (ECS task execution role), which is not a role Quilt uses to access data buckets.
- `quiltx bucket add` no longer requires CloudFormation access anywhere: falls back to `sts:GetCallerIdentity` for `account_id` and catalog `config.json` for `region` when the Quilt stack role lacks `cloudformation:DescribeStacks`.
- Bump version to 0.9.2 and promote the Unreleased CHANGELOG entries to [0.9.2].

## Test plan

- [ ] `./poe test`
- [ ] `quiltx bucket add --principal <arn>` against a sandbox bucket
- [ ] `quiltx bucket add` on a session without CFN permissions