### PR TITLE
Add quiltx cross-account bucket bootstrap flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-18
+
+### Added
+
+- `quiltx bucket bootstrap-role` to create or update a bucket-owner-side data-access role for cross-account Quilt onboarding
+- `quiltx bucket add --external-role-arn ARN` to register the bucket's assumed role with Quilt while also granting that role access in the bucket and SNS topic policies
+
+### Changed
+
+- `quiltx bucket bootstrap-role` now attaches an inline `QuiltDataAccessPolicy` so the bootstrapped role is immediately usable for S3 permission checks
+- `quiltx bucket add` and `quiltx bucket test` now support the assume-role chokepoint flow required by cross-account bucket onboarding
+
 ## [0.9.2] - 2026-04-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.9.2"
+version = "0.10.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.9.2"
+__version__ = "0.10.0"

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -47,6 +47,7 @@ mutation BucketAdd($input: BucketAddInput!) {
         snsNotificationArn
         externalRoleArn
         externalId
+        athenaAccessRoleArn
       }
     }
     ... on InsufficientPermissions {
@@ -67,6 +68,7 @@ mutation BucketUpdate($name: String!, $input: BucketUpdateInput!) {
         snsNotificationArn
         externalRoleArn
         externalId
+        athenaAccessRoleArn
       }
     }
     ... on InsufficientPermissions {
@@ -84,6 +86,7 @@ query BucketConfig($name: String!) {
     snsNotificationArn
     externalRoleArn
     externalId
+    athenaAccessRoleArn
   }
 }
 """
@@ -285,6 +288,7 @@ class AddBucketResult:
     title: str
     sns_topic_arn: str
     external_id: str | None
+    athena_access_role_arn: str | None
     already_registered: bool
 
 
@@ -343,8 +347,9 @@ def add_bucket(
         raise ValueError("Stack metadata missing account_id. Run 'quiltx stack' first.")
     control_account_id = str(control_account_id)
 
+    requested_principals = list(principals) if principals else []
     principal_list = _effective_principals(
-        principals,
+        requested_principals,
         external_role_arn=external_role_arn,
     )
     sns_principal: str | list[str] = (
@@ -370,6 +375,37 @@ def add_bucket(
             bucket_config = _get_bucket_config(bucket)
         else:
             bucket_config = None
+        athena_access_role_arn = _get_athena_access_role_arn(bucket_config)
+        if bucket_config is not None:
+            final_external_role_arn = (
+                external_role_arn
+                or bucket_config.get("externalRoleArn")
+                or existing_external_role_arn
+            )
+            final_principals = _effective_principals(
+                requested_principals,
+                external_role_arn=(
+                    str(final_external_role_arn) if final_external_role_arn else None
+                ),
+                athena_access_role_arn=athena_access_role_arn,
+            )
+            if final_principals:
+                session = boto3.Session(profile_name=profile)
+                s3_client = session.client("s3")
+                bucket_region = get_bucket_region(bucket, s3_client=s3_client)
+                sns_client = session.client("sns", region_name=bucket_region)
+                data_account_id = str(
+                    session.client("sts").get_caller_identity()["Account"]
+                )
+                _apply_quilt_access_configuration(
+                    bucket=bucket,
+                    control_account_id=control_account_id,
+                    data_account_id=data_account_id,
+                    sns_topic_arn=getattr(existing, "sns_notification_arn", None),
+                    principals=final_principals,
+                    s3_client=s3_client,
+                    sns_client=sns_client,
+                )
         return AddBucketResult(
             bucket=bucket,
             title=getattr(existing, "title", bucket_title),
@@ -377,6 +413,7 @@ def add_bucket(
             external_id=(
                 None if bucket_config is None else bucket_config.get("externalId")
             ),
+            athena_access_role_arn=athena_access_role_arn,
             already_registered=True,
         )
 
@@ -386,12 +423,15 @@ def add_bucket(
     sns_client = session.client("sns", region_name=bucket_region)
     data_account_id = str(session.client("sts").get_caller_identity()["Account"])
 
-    existing_policy = get_bucket_policy(bucket, s3_client=s3_client)
-    statement = build_quilt_policy_statement(
-        bucket, control_account_id, principals=principal_list or None
+    _apply_quilt_access_configuration(
+        bucket=bucket,
+        control_account_id=control_account_id,
+        data_account_id=data_account_id,
+        sns_topic_arn=None,
+        principals=principal_list,
+        s3_client=s3_client,
+        sns_client=sns_client,
     )
-    merged = merge_bucket_policy(existing_policy, statement)
-    apply_bucket_policy(bucket, merged, s3_client=s3_client)
 
     # SNS topic
     sns_topic_arn = get_bucket_notification_sns(bucket, s3_client=s3_client)
@@ -416,12 +456,29 @@ def add_bucket(
         sns_notification_arn=sns_topic_arn,
         external_role_arn=external_role_arn,
     )
+    athena_access_role_arn = _get_athena_access_role_arn(bucket_config)
+    final_principals = _effective_principals(
+        requested_principals,
+        external_role_arn=external_role_arn,
+        athena_access_role_arn=athena_access_role_arn,
+    )
+    if final_principals != principal_list:
+        _apply_quilt_access_configuration(
+            bucket=bucket,
+            control_account_id=control_account_id,
+            data_account_id=data_account_id,
+            sns_topic_arn=sns_topic_arn,
+            principals=final_principals,
+            s3_client=s3_client,
+            sns_client=sns_client,
+        )
 
     return AddBucketResult(
         bucket=bucket,
         title=bucket_title,
         sns_topic_arn=sns_topic_arn,
         external_id=None if bucket_config is None else bucket_config.get("externalId"),
+        athena_access_role_arn=athena_access_role_arn,
         already_registered=False,
     )
 
@@ -486,11 +543,49 @@ def _effective_principals(
     principals: Sequence[str] | None,
     *,
     external_role_arn: str | None = None,
+    athena_access_role_arn: str | None = None,
 ) -> list[str]:
     result = list(principals) if principals else []
     if external_role_arn and external_role_arn not in result:
         result.append(external_role_arn)
+    if athena_access_role_arn and athena_access_role_arn not in result:
+        result.append(athena_access_role_arn)
     return result
+
+
+def _get_athena_access_role_arn(bucket_config: Mapping[str, Any] | None) -> str | None:
+    if not bucket_config:
+        return None
+    value = bucket_config.get("athenaAccessRoleArn")
+    return str(value) if value else None
+
+
+def _apply_quilt_access_configuration(
+    *,
+    bucket: str,
+    control_account_id: str,
+    data_account_id: str,
+    sns_topic_arn: str | None,
+    principals: Sequence[str],
+    s3_client: Any,
+    sns_client: Any,
+) -> None:
+    existing_policy = get_bucket_policy(bucket, s3_client=s3_client)
+    statement = build_quilt_policy_statement(
+        bucket,
+        control_account_id,
+        principals=list(principals) or None,
+    )
+    merged = merge_bucket_policy(existing_policy, statement)
+    apply_bucket_policy(bucket, merged, s3_client=s3_client)
+    if sns_topic_arn:
+        configure_sns_topic_policy(
+            bucket,
+            sns_topic_arn,
+            data_account_id,
+            list(principals) or f"arn:aws:iam::{control_account_id}:root",
+            sns_client=sns_client,
+        )
 
 
 def _register_bucket_with_catalog(

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -46,6 +46,7 @@ mutation BucketAdd($input: BucketAddInput!) {
         title
         snsNotificationArn
         externalRoleArn
+        externalId
       }
     }
     ... on InsufficientPermissions {
@@ -65,11 +66,24 @@ mutation BucketUpdate($name: String!, $input: BucketUpdateInput!) {
         title
         snsNotificationArn
         externalRoleArn
+        externalId
       }
     }
     ... on InsufficientPermissions {
       message
     }
+  }
+}
+"""
+
+_BUCKET_CONFIG_QUERY = """
+query BucketConfig($name: String!) {
+  bucketConfig(name: $name) {
+    name
+    title
+    snsNotificationArn
+    externalRoleArn
+    externalId
   }
 }
 """
@@ -270,6 +284,7 @@ class AddBucketResult:
     bucket: str
     title: str
     sns_topic_arn: str
+    external_id: str | None
     already_registered: bool
 
 
@@ -344,17 +359,24 @@ def add_bucket(
         existing_external_role_arn = getattr(existing, "external_role_arn", None)
         if external_role_arn and existing_external_role_arn != external_role_arn:
             existing_title = getattr(existing, "title", None) or bucket_title
-            _register_bucket_with_catalog(
+            bucket_config = _register_bucket_with_catalog(
                 bucket=bucket,
                 title=existing_title,
                 sns_notification_arn=getattr(existing, "sns_notification_arn", None),
                 external_role_arn=external_role_arn,
                 update=True,
             )
+        elif external_role_arn or existing_external_role_arn:
+            bucket_config = _get_bucket_config(bucket)
+        else:
+            bucket_config = None
         return AddBucketResult(
             bucket=bucket,
             title=getattr(existing, "title", bucket_title),
             sns_topic_arn=getattr(existing, "sns_notification_arn", "") or "",
+            external_id=(
+                None if bucket_config is None else bucket_config.get("externalId")
+            ),
             already_registered=True,
         )
 
@@ -388,7 +410,7 @@ def add_bucket(
     configure_bucket_notifications(bucket, sns_topic_arn, s3_client=s3_client)
 
     # Register in Quilt catalog
-    _register_bucket_with_catalog(
+    bucket_config = _register_bucket_with_catalog(
         bucket=bucket,
         title=bucket_title,
         sns_notification_arn=sns_topic_arn,
@@ -399,6 +421,7 @@ def add_bucket(
         bucket=bucket,
         title=bucket_title,
         sns_topic_arn=sns_topic_arn,
+        external_id=None if bucket_config is None else bucket_config.get("externalId"),
         already_registered=False,
     )
 
@@ -477,7 +500,7 @@ def _register_bucket_with_catalog(
     sns_notification_arn: str | None,
     external_role_arn: str | None = None,
     update: bool = False,
-) -> None:
+) -> dict[str, Any] | None:
     if external_role_arn is None:
         from quilt3.admin import buckets as admin_buckets
 
@@ -493,7 +516,7 @@ def _register_bucket_with_catalog(
                 title=title,
                 sns_notification_arn=sns_notification_arn,
             )
-        return
+        return None
 
     input_payload = {
         "title": title,
@@ -515,10 +538,25 @@ def _register_bucket_with_catalog(
     result = data[result_key]
     typename = result.get("__typename")
     if typename in {"BucketAddSuccess", "BucketUpdateSuccess"}:
-        return
+        bucket_config = result.get("bucketConfig")
+        if bucket_config is None:
+            return None
+        if not isinstance(bucket_config, dict):
+            raise ValueError("invalid GraphQL bucketConfig payload")
+        return bucket_config
     if typename == "InsufficientPermissions":
         raise ValueError(result.get("message") or "insufficient permissions")
     raise ValueError(f"bucket registration failed: {typename}")
+
+
+def _get_bucket_config(bucket: str) -> dict[str, Any] | None:
+    data = _graphql_request(_BUCKET_CONFIG_QUERY, {"name": bucket})
+    bucket_config = data.get("bucketConfig")
+    if bucket_config is None:
+        return None
+    if not isinstance(bucket_config, dict):
+        raise ValueError("invalid GraphQL bucketConfig payload")
+    return bucket_config
 
 
 def _graphql_request(query: str, variables: Mapping[str, Any]) -> dict[str, Any]:

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -17,6 +17,7 @@ SNS_PUBLISH_POLICY_SID = "QuiltBucketNotifications"
 SNS_SUBSCRIBE_POLICY_SID = "QuiltCrossAccountSNSAccess"
 SNS_TOPIC_CONFIG_ID = "QuiltBucketNotifications"
 DATA_ACCESS_ROLE_NAME = "QuiltDataAccessRole"
+DATA_ACCESS_ROLE_POLICY_NAME = "QuiltDataAccessPolicy"
 
 QUILT_POLICY_ACTIONS = [
     "s3:GetObject",
@@ -430,6 +431,11 @@ def ensure_data_access_role(
             AssumeRolePolicyDocument=json.dumps(assume_role_policy),
             Description="Quilt cross-account data access role",
         )["Role"]
+        iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName=DATA_ACCESS_ROLE_POLICY_NAME,
+            PolicyDocument=json.dumps(_build_data_access_role_policy()),
+        )
         return BootstrapRoleResult(
             role_arn=str(created["Arn"]),
             role_name=role_name,
@@ -439,6 +445,11 @@ def ensure_data_access_role(
     iam_client.update_assume_role_policy(
         RoleName=role_name,
         PolicyDocument=json.dumps(assume_role_policy),
+    )
+    iam_client.put_role_policy(
+        RoleName=role_name,
+        PolicyName=DATA_ACCESS_ROLE_POLICY_NAME,
+        PolicyDocument=json.dumps(_build_data_access_role_policy()),
     )
     role = response["Role"]
     return BootstrapRoleResult(
@@ -548,6 +559,20 @@ def _build_data_access_trust_policy(
     return {
         "Version": "2012-10-17",
         "Statement": [statement],
+    }
+
+
+def _build_data_access_role_policy() -> dict[str, Any]:
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "QuiltDataAccessS3Access",
+                "Effect": "Allow",
+                "Action": list(QUILT_POLICY_ACTIONS),
+                "Resource": "*",
+            }
+        ],
     }
 
 

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -1,4 +1,4 @@
-"""Bucket policy and notification helpers for quiltx."""
+"""Bucket policy, registration, and notification helpers for quiltx."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ QUILT_POLICY_SID = "QuiltCrossAccountAccess"
 SNS_PUBLISH_POLICY_SID = "QuiltBucketNotifications"
 SNS_SUBSCRIBE_POLICY_SID = "QuiltCrossAccountSNSAccess"
 SNS_TOPIC_CONFIG_ID = "QuiltBucketNotifications"
+DATA_ACCESS_ROLE_NAME = "QuiltDataAccessRole"
 
 QUILT_POLICY_ACTIONS = [
     "s3:GetObject",
@@ -33,6 +34,44 @@ QUILT_POLICY_ACTIONS = [
 ]
 
 BUCKET_NOTIFICATION_EVENTS = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+
+_BUCKET_ADD_MUTATION = """
+mutation BucketAdd($input: BucketAddInput!) {
+  bucketAdd(input: $input) {
+    __typename
+    ... on BucketAddSuccess {
+      bucketConfig {
+        name
+        title
+        snsNotificationArn
+        externalRoleArn
+      }
+    }
+    ... on InsufficientPermissions {
+      message
+    }
+  }
+}
+"""
+
+_BUCKET_UPDATE_MUTATION = """
+mutation BucketUpdate($name: String!, $input: BucketUpdateInput!) {
+  bucketUpdate(name: $name, input: $input) {
+    __typename
+    ... on BucketUpdateSuccess {
+      bucketConfig {
+        name
+        title
+        snsNotificationArn
+        externalRoleArn
+      }
+    }
+    ... on InsufficientPermissions {
+      message
+    }
+  }
+}
+"""
 
 
 def get_bucket_policy(bucket: str, s3_client: Any = None) -> dict[str, Any] | None:
@@ -233,12 +272,22 @@ class AddBucketResult:
     already_registered: bool
 
 
+@dataclass
+class BootstrapRoleResult:
+    """Result of ensuring the shared data-account role exists."""
+
+    role_arn: str
+    role_name: str
+    created: bool
+
+
 def add_bucket(
     bucket: str,
     *,
     title: str | None = None,
     profile: str | None = None,
     principals: Sequence[str] | None = None,
+    external_role_arn: str | None = None,
 ) -> AddBucketResult:
     """Register an S3 bucket with the configured Quilt catalog.
 
@@ -253,7 +302,10 @@ def add_bucket(
         title: Display title in the catalog (defaults to bucket name).
         profile: AWS profile for the data account that owns the bucket.
         principals: IAM principal ARNs granted access in the bucket policy.
-            Defaults to the control account root.
+            Defaults to the control account root unless *external_role_arn* is
+            supplied, in which case that role ARN is granted by default.
+        external_role_arn: Optional data-account role ARN to store in Quilt as
+            the cross-account assume-role target.
 
     Returns:
         AddBucketResult with bucket details and registration status.
@@ -275,7 +327,10 @@ def add_bucket(
         raise ValueError("Stack metadata missing account_id. Run 'quiltx stack' first.")
     control_account_id = str(control_account_id)
 
-    principal_list = list(principals) if principals else []
+    principal_list = _effective_principals(
+        principals,
+        external_role_arn=external_role_arn,
+    )
     sns_principal: str | list[str] = (
         principal_list if principal_list else f"arn:aws:iam::{control_account_id}:root"
     )
@@ -285,6 +340,16 @@ def add_bucket(
     # Check if already registered
     existing = admin_buckets.get(bucket)
     if existing is not None:
+        existing_external_role_arn = getattr(existing, "external_role_arn", None)
+        if external_role_arn and existing_external_role_arn != external_role_arn:
+            existing_title = getattr(existing, "title", None) or bucket_title
+            _register_bucket_with_catalog(
+                bucket=bucket,
+                title=existing_title,
+                sns_notification_arn=getattr(existing, "sns_notification_arn", None),
+                external_role_arn=external_role_arn,
+                update=True,
+            )
         return AddBucketResult(
             bucket=bucket,
             title=getattr(existing, "title", bucket_title),
@@ -322,10 +387,11 @@ def add_bucket(
     configure_bucket_notifications(bucket, sns_topic_arn, s3_client=s3_client)
 
     # Register in Quilt catalog
-    admin_buckets.add(
-        name=bucket,
+    _register_bucket_with_catalog(
+        bucket=bucket,
         title=bucket_title,
         sns_notification_arn=sns_topic_arn,
+        external_role_arn=external_role_arn,
     )
 
     return AddBucketResult(
@@ -334,6 +400,155 @@ def add_bucket(
         sns_topic_arn=sns_topic_arn,
         already_registered=False,
     )
+
+
+def ensure_data_access_role(
+    *,
+    control_principals: Sequence[str],
+    profile: str | None = None,
+    role_name: str = DATA_ACCESS_ROLE_NAME,
+    external_id: str | None = None,
+) -> BootstrapRoleResult:
+    """Create or update the bucket-owner-side role used for assume-role access."""
+    import boto3
+
+    session = boto3.Session(profile_name=profile)
+    iam_client = session.client("iam")
+
+    assume_role_policy = _build_data_access_trust_policy(
+        control_principals,
+        external_id=external_id,
+    )
+
+    try:
+        response = iam_client.get_role(RoleName=role_name)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") != "NoSuchEntity":
+            raise
+        created = iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(assume_role_policy),
+            Description="Quilt cross-account data access role",
+        )["Role"]
+        return BootstrapRoleResult(
+            role_arn=str(created["Arn"]),
+            role_name=role_name,
+            created=True,
+        )
+
+    iam_client.update_assume_role_policy(
+        RoleName=role_name,
+        PolicyDocument=json.dumps(assume_role_policy),
+    )
+    role = response["Role"]
+    return BootstrapRoleResult(
+        role_arn=str(role["Arn"]),
+        role_name=role_name,
+        created=False,
+    )
+
+
+def _effective_principals(
+    principals: Sequence[str] | None,
+    *,
+    external_role_arn: str | None = None,
+) -> list[str]:
+    result = list(principals) if principals else []
+    if external_role_arn and external_role_arn not in result:
+        result.append(external_role_arn)
+    return result
+
+
+def _register_bucket_with_catalog(
+    *,
+    bucket: str,
+    title: str,
+    sns_notification_arn: str | None,
+    external_role_arn: str | None = None,
+    update: bool = False,
+) -> None:
+    if external_role_arn is None:
+        from quilt3.admin import buckets as admin_buckets
+
+        if update:
+            admin_buckets.update(
+                bucket,
+                title=title,
+                sns_notification_arn=sns_notification_arn,
+            )
+        else:
+            admin_buckets.add(
+                name=bucket,
+                title=title,
+                sns_notification_arn=sns_notification_arn,
+            )
+        return
+
+    input_payload = {
+        "title": title,
+        "snsNotificationArn": sns_notification_arn,
+        "externalRoleArn": external_role_arn,
+    }
+    if not update:
+        input_payload["name"] = bucket
+
+    data = _graphql_request(
+        _BUCKET_UPDATE_MUTATION if update else _BUCKET_ADD_MUTATION,
+        (
+            {"name": bucket, "input": input_payload}
+            if update
+            else {"input": input_payload}
+        ),
+    )
+    result_key = "bucketUpdate" if update else "bucketAdd"
+    result = data[result_key]
+    typename = result.get("__typename")
+    if typename in {"BucketAddSuccess", "BucketUpdateSuccess"}:
+        return
+    if typename == "InsufficientPermissions":
+        raise ValueError(result.get("message") or "insufficient permissions")
+    raise ValueError(f"bucket registration failed: {typename}")
+
+
+def _graphql_request(query: str, variables: Mapping[str, Any]) -> dict[str, Any]:
+    from quilt3 import session as quilt_session
+
+    response = quilt_session.get_session().post(
+        quilt_session.get_registry_url().rstrip("/") + "/graphql",
+        json={"query": query, "variables": dict(variables)},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    errors = payload.get("errors")
+    if errors:
+        messages = [error.get("message", "unknown GraphQL error") for error in errors]
+        raise ValueError("; ".join(messages))
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("invalid GraphQL response")
+    return data
+
+
+def _build_data_access_trust_policy(
+    control_principals: Sequence[str],
+    *,
+    external_id: str | None = None,
+) -> dict[str, Any]:
+    principal_value: str | list[str]
+    principals = list(control_principals)
+    principal_value = principals[0] if len(principals) == 1 else principals
+    statement: dict[str, Any] = {
+        "Sid": "QuiltControlAssumeRole",
+        "Effect": "Allow",
+        "Principal": {"AWS": principal_value},
+        "Action": "sts:AssumeRole",
+    }
+    if external_id:
+        statement["Condition"] = {"StringEquals": {"sts:ExternalId": external_id}}
+    return {
+        "Version": "2012-10-17",
+        "Statement": [statement],
+    }
 
 
 def _merge_policy_statements(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -70,6 +70,53 @@ def build_parser() -> argparse.ArgumentParser:
             "Use the bare flag (no value) to print guidance on choosing principals."
         ),
     )
+    add_parser.add_argument(
+        "--external-role-arn",
+        help=(
+            "Data-account role ARN to store as external_role_arn when registering "
+            "the bucket. When set, that ARN is also added to the bucket/SNS policy "
+            "principals unless already present."
+        ),
+    )
+
+    bootstrap_role_parser = subparsers.add_parser(
+        "bootstrap-role",
+        prog="quiltx bucket bootstrap-role",
+        help="Create or update the bucket-owner-side QuiltDataAccessRole.",
+    )
+    bootstrap_role_parser.add_argument(
+        "--profile",
+        help="AWS profile for the data account that owns the bucket.",
+    )
+    bootstrap_role_parser.add_argument(
+        "--role-name",
+        default=bucket_lib.DATA_ACCESS_ROLE_NAME,
+        help=(
+            "IAM role name to create/update "
+            f"(default: {bucket_lib.DATA_ACCESS_ROLE_NAME})."
+        ),
+    )
+    bootstrap_role_parser.add_argument(
+        "--trust-principal",
+        metavar="ARN",
+        action="append",
+        help=(
+            "IAM principal ARN(s) allowed to assume the role. Repeatable or "
+            "comma-separated. Defaults to the control account root."
+        ),
+    )
+    bootstrap_role_parser.add_argument(
+        "--external-id",
+        help=(
+            "Optional sts:ExternalId condition to require in the trust policy. "
+            "Leave unset unless the stack is configured to send one."
+        ),
+    )
+    bootstrap_role_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Apply changes without prompting for confirmation.",
+    )
 
     subparsers.add_parser(
         "list",
@@ -93,6 +140,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.action == "add":
         return _cmd_add(args)
+    if args.action == "bootstrap-role":
+        return _cmd_bootstrap_role(args)
     if args.action == "list":
         return _cmd_list()
     if args.action == "test":
@@ -176,6 +225,16 @@ def _cmd_add(args: argparse.Namespace) -> int:
         if show_guidance:
             _print_principal_guidance()
             return 0
+        external_role_arn = args.external_role_arn
+        if external_role_arn and not external_role_arn.startswith("arn:aws:iam::"):
+            print(
+                (
+                    "Error: --external-role-arn must be an IAM role ARN, "
+                    f"got {external_role_arn!r}"
+                ),
+                file=sys.stderr,
+            )
+            return 1
         for principal in principals:
             if not principal.startswith("arn:aws:iam::"):
                 print(
@@ -188,8 +247,11 @@ def _cmd_add(args: argparse.Namespace) -> int:
         catalog_name = stack_lib.extract_catalog_name(config)
         stack_payload = _ensure_stack_payload(config, catalog_name)
         control_account_id = _load_control_account_id(stack_payload)
-        effective_principals = principals or [f"arn:aws:iam::{control_account_id}:root"]
-        principal_source = "--principal" if principals else "account root (default)"
+        effective_principals, principal_source = _effective_principals(
+            control_account_id,
+            principals,
+            external_role_arn=external_role_arn,
+        )
         stack_name = _stack_payload_value(stack_payload, "stack_name", "") or None
         control_region = _stack_payload_value(stack_payload, "region", "unknown")
         catalog_url = str(config.get("navigator_url") or catalog_name)
@@ -203,6 +265,32 @@ def _cmd_add(args: argparse.Namespace) -> int:
 
         existing_bucket = admin_buckets.get(args.bucket_name)
         if existing_bucket is not None:
+            existing_external_role_arn = getattr(
+                existing_bucket, "external_role_arn", None
+            )
+            if external_role_arn and existing_external_role_arn != external_role_arn:
+                bucket_title = args.title or getattr(
+                    existing_bucket,
+                    "title",
+                    args.bucket_name,
+                )
+                bucket_lib._register_bucket_with_catalog(
+                    bucket=args.bucket_name,
+                    title=bucket_title,
+                    sns_notification_arn=getattr(
+                        existing_bucket,
+                        "sns_notification_arn",
+                        None,
+                    ),
+                    external_role_arn=external_role_arn,
+                    update=True,
+                )
+                print(
+                    f"Updated bucket {args.bucket_name} with external_role_arn {external_role_arn}."
+                )
+                if args.no_test:
+                    return 0
+                return _verify_bucket_registration_and_access(args.bucket_name)
             print(f"Bucket {args.bucket_name} is already registered.")
             if args.no_test:
                 return 0
@@ -214,7 +302,7 @@ def _cmd_add(args: argparse.Namespace) -> int:
         quilt_statement = bucket_lib.build_quilt_policy_statement(
             args.bucket_name,
             control_account_id,
-            principals=principals or None,
+            principals=effective_principals or None,
         )
         merged_policy = bucket_lib.merge_bucket_policy(bucket_policy, quilt_statement)
 
@@ -286,14 +374,17 @@ def _cmd_add(args: argparse.Namespace) -> int:
         )
 
         bucket_title = args.title or args.bucket_name
-        admin_buckets.add(
-            name=args.bucket_name,
+        bucket_lib._register_bucket_with_catalog(
+            bucket=args.bucket_name,
             title=bucket_title,
             sns_notification_arn=sns_topic_arn,
+            external_role_arn=external_role_arn,
         )
 
         print(f"Registered bucket {args.bucket_name} as {bucket_title}.")
         print(f"SNS notifications: {sns_topic_arn}")
+        if external_role_arn:
+            print(f"external_role_arn: {external_role_arn}")
         if args.no_test:
             print(
                 f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
@@ -301,6 +392,54 @@ def _cmd_add(args: argparse.Namespace) -> int:
             return 0
         print()
         return _verify_bucket_registration_and_access(args.bucket_name)
+    except Exception as exc:
+        if "Authentication failed" in str(exc):
+            raise
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+@auto_login
+def _cmd_bootstrap_role(args: argparse.Namespace) -> int:
+    try:
+        trust_principals, _ = _resolve_principals_arg(args.trust_principal)
+        for principal in trust_principals:
+            if not principal.startswith("arn:aws:iam::"):
+                print(
+                    (
+                        "Error: --trust-principal must be an IAM ARN, "
+                        f"got {principal!r}"
+                    ),
+                    file=sys.stderr,
+                )
+                return 1
+
+        config = get_catalog_config()
+        catalog_name = stack_lib.extract_catalog_name(config)
+        stack_payload = _ensure_stack_payload(config, catalog_name)
+        control_account_id = _load_control_account_id(stack_payload)
+        effective_trust_principals = trust_principals or [
+            f"arn:aws:iam::{control_account_id}:root"
+        ]
+        if not args.yes and not _confirm_role_bootstrap(
+            role_name=args.role_name,
+            trust_principals=effective_trust_principals,
+            external_id=args.external_id,
+            profile=args.profile,
+        ):
+            print("Aborted.")
+            return 1
+
+        result = bucket_lib.ensure_data_access_role(
+            control_principals=effective_trust_principals,
+            profile=args.profile,
+            role_name=args.role_name,
+            external_id=args.external_id,
+        )
+        action = "Created" if result.created else "Updated"
+        print(f"{action} role {result.role_name}.")
+        print(f"Role ARN: {result.role_arn}")
+        return 0
     except Exception as exc:
         if "Authentication failed" in str(exc):
             raise
@@ -416,6 +555,25 @@ def _resolve_principals_arg(
     return principals, show_guidance
 
 
+def _effective_principals(
+    control_account_id: str,
+    principals: list[str],
+    *,
+    external_role_arn: str | None = None,
+) -> tuple[list[str], str]:
+    effective_principals = bucket_lib._effective_principals(
+        principals,
+        external_role_arn=external_role_arn,
+    )
+    if principals and external_role_arn and external_role_arn not in principals:
+        return effective_principals, "--principal + --external-role-arn"
+    if principals:
+        return effective_principals, "--principal"
+    if external_role_arn:
+        return effective_principals, "--external-role-arn"
+    return [f"arn:aws:iam::{control_account_id}:root"], "account root (default)"
+
+
 def _print_principal_guidance() -> None:
     print(
         "The --principal flag sets the IAM ARN(s) granted cross-account access in "
@@ -435,6 +593,32 @@ def _print_principal_guidance() -> None:
         "  quiltx bucket add my-bucket \\\n"
         "      --principal arn:aws:iam::123:role/<stack>-SomeRole-XXXX"
     )
+
+
+def _confirm_role_bootstrap(
+    *,
+    role_name: str,
+    trust_principals: list[str],
+    external_id: str | None,
+    profile: str | None,
+) -> bool:
+    console = Console(width=120)
+    table = Table(
+        title="Bucket role bootstrap",
+        show_header=True,
+        header_style="bold cyan",
+        border_style="cyan",
+        expand=False,
+    )
+    table.add_column("Setting", style="green", no_wrap=True)
+    table.add_column("Value", overflow="fold")
+    table.add_row("Role name", role_name)
+    table.add_row("AWS profile", profile or "<default>")
+    table.add_row("Trust principals", "\n".join(trust_principals))
+    table.add_row("ExternalId", external_id or "<none>")
+    console.print(table)
+    response = input("Continue? [y/N]: ").strip().lower()
+    return response in {"y", "yes"}
 
 
 def _get_session_account_id(session: boto3.Session) -> str:

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -261,48 +261,39 @@ def _cmd_add(args: argparse.Namespace) -> int:
         control_region = _stack_payload_value(stack_payload, "region", "unknown")
         catalog_url = str(config.get("navigator_url") or catalog_name)
 
+        def _run_add_bucket() -> bucket_lib.AddBucketResult:
+            original_get_catalog_config = bucket_lib.get_catalog_config
+            bucket_lib.get_catalog_config = lambda: config
+            try:
+                return bucket_lib.add_bucket(
+                    args.bucket_name,
+                    title=args.title,
+                    profile=args.profile,
+                    principals=principals or None,
+                    external_role_arn=external_role_arn,
+                )
+            finally:
+                bucket_lib.get_catalog_config = original_get_catalog_config
+
         session = boto3.Session(profile_name=args.profile)
         s3_client = session.client("s3")
         bucket_region = get_bucket_region(args.bucket_name, s3_client=s3_client)
-        sns_client = session.client("sns", region_name=bucket_region)
+        if not args.dry_run:
+            from quilt3.admin import buckets as admin_buckets
 
-        from quilt3.admin import buckets as admin_buckets
-
-        existing_bucket = admin_buckets.get(args.bucket_name)
-        if existing_bucket is not None:
-            existing_external_role_arn = getattr(
-                existing_bucket, "external_role_arn", None
-            )
-            if external_role_arn and existing_external_role_arn != external_role_arn:
-                bucket_title = args.title or getattr(
-                    existing_bucket,
-                    "title",
-                    args.bucket_name,
-                )
-                bucket_config = bucket_lib._register_bucket_with_catalog(
-                    bucket=args.bucket_name,
-                    title=bucket_title,
-                    sns_notification_arn=getattr(
-                        existing_bucket,
-                        "sns_notification_arn",
-                        None,
-                    ),
-                    external_role_arn=external_role_arn,
-                    update=True,
-                )
-                print(
-                    f"Updated bucket {args.bucket_name} with external_role_arn {external_role_arn}."
-                )
-                if bucket_config and bucket_config.get("externalId"):
-                    print(f"external_id: {bucket_config['externalId']}")
+            existing_bucket = admin_buckets.get(args.bucket_name)
+            if existing_bucket is not None:
+                result = _run_add_bucket()
+                print(f"Bucket {args.bucket_name} is already registered.")
+                if external_role_arn:
+                    print(f"external_role_arn: {external_role_arn}")
+                if result.athena_access_role_arn:
+                    print(f"athena_access_role_arn: {result.athena_access_role_arn}")
+                if result.external_id:
+                    print(f"external_id: {result.external_id}")
                 if args.no_test:
                     return 0
                 return _verify_bucket_registration_and_access(args.bucket_name)
-            print(f"Bucket {args.bucket_name} is already registered.")
-            if args.no_test:
-                return 0
-            return _verify_bucket_registration_and_access(args.bucket_name)
-
         bucket_policy = bucket_lib.get_bucket_policy(
             args.bucket_name, s3_client=s3_client
         )
@@ -354,46 +345,18 @@ def _cmd_add(args: argparse.Namespace) -> int:
             print("Aborted.")
             return 1
 
-        if sns_topic_arn is None:
-            sns_topic_arn = bucket_lib.ensure_sns_topic(
-                args.bucket_name,
-                bucket_region,
-                sns_client=sns_client,
-            )
-
-        bucket_lib.configure_sns_topic_policy(
-            args.bucket_name,
-            sns_topic_arn,
-            data_account_id,
-            effective_principals,
-            sns_client=sns_client,
-        )
-
-        bucket_lib.apply_bucket_policy(
-            args.bucket_name,
-            merged_policy,
-            s3_client=s3_client,
-        )
-        bucket_lib.configure_bucket_notifications(
-            args.bucket_name,
-            sns_topic_arn,
-            s3_client=s3_client,
-        )
-
-        bucket_title = args.title or args.bucket_name
-        bucket_config = bucket_lib._register_bucket_with_catalog(
-            bucket=args.bucket_name,
-            title=bucket_title,
-            sns_notification_arn=sns_topic_arn,
-            external_role_arn=external_role_arn,
-        )
-
-        print(f"Registered bucket {args.bucket_name} as {bucket_title}.")
-        print(f"SNS notifications: {sns_topic_arn}")
+        result = _run_add_bucket()
+        if result.already_registered:
+            print(f"Bucket {args.bucket_name} is already registered.")
+        else:
+            print(f"Registered bucket {args.bucket_name} as {result.title}.")
+        print(f"SNS notifications: {result.sns_topic_arn}")
         if external_role_arn:
             print(f"external_role_arn: {external_role_arn}")
-        if bucket_config and bucket_config.get("externalId"):
-            print(f"external_id: {bucket_config['externalId']}")
+        if result.athena_access_role_arn:
+            print(f"athena_access_role_arn: {result.athena_access_role_arn}")
+        if result.external_id:
+            print(f"external_id: {result.external_id}")
         if args.no_test:
             print(
                 f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
@@ -577,10 +540,12 @@ def _effective_principals(
     principals: list[str],
     *,
     external_role_arn: str | None = None,
+    athena_access_role_arn: str | None = None,
 ) -> tuple[list[str], str]:
     effective_principals = bucket_lib._effective_principals(
         principals,
         external_role_arn=external_role_arn,
+        athena_access_role_arn=athena_access_role_arn,
     )
     if principals and external_role_arn and external_role_arn not in principals:
         return effective_principals, "--principal + --external-role-arn"

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -85,6 +85,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Create or update the bucket-owner-side QuiltDataAccessRole.",
     )
     bootstrap_role_parser.add_argument(
+        "bucket_name",
+        nargs="?",
+        help="Registered bucket name to read the registry-managed ExternalId from.",
+    )
+    bootstrap_role_parser.add_argument(
         "--profile",
         help="AWS profile for the data account that owns the bucket.",
     )
@@ -109,7 +114,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--external-id",
         help=(
             "Optional sts:ExternalId condition to require in the trust policy. "
-            "Leave unset unless the stack is configured to send one."
+            "Defaults to the registry-managed value for BUCKET_NAME when provided."
         ),
     )
     bootstrap_role_parser.add_argument(
@@ -274,7 +279,7 @@ def _cmd_add(args: argparse.Namespace) -> int:
                     "title",
                     args.bucket_name,
                 )
-                bucket_lib._register_bucket_with_catalog(
+                bucket_config = bucket_lib._register_bucket_with_catalog(
                     bucket=args.bucket_name,
                     title=bucket_title,
                     sns_notification_arn=getattr(
@@ -288,6 +293,8 @@ def _cmd_add(args: argparse.Namespace) -> int:
                 print(
                     f"Updated bucket {args.bucket_name} with external_role_arn {external_role_arn}."
                 )
+                if bucket_config and bucket_config.get("externalId"):
+                    print(f"external_id: {bucket_config['externalId']}")
                 if args.no_test:
                     return 0
                 return _verify_bucket_registration_and_access(args.bucket_name)
@@ -374,7 +381,7 @@ def _cmd_add(args: argparse.Namespace) -> int:
         )
 
         bucket_title = args.title or args.bucket_name
-        bucket_lib._register_bucket_with_catalog(
+        bucket_config = bucket_lib._register_bucket_with_catalog(
             bucket=args.bucket_name,
             title=bucket_title,
             sns_notification_arn=sns_topic_arn,
@@ -385,6 +392,8 @@ def _cmd_add(args: argparse.Namespace) -> int:
         print(f"SNS notifications: {sns_topic_arn}")
         if external_role_arn:
             print(f"external_role_arn: {external_role_arn}")
+        if bucket_config and bucket_config.get("externalId"):
+            print(f"external_id: {bucket_config['externalId']}")
         if args.no_test:
             print(
                 f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
@@ -421,10 +430,16 @@ def _cmd_bootstrap_role(args: argparse.Namespace) -> int:
         effective_trust_principals = trust_principals or [
             f"arn:aws:iam::{control_account_id}:root"
         ]
+        external_id = args.external_id
+        if external_id is None and args.bucket_name:
+            bucket_config = bucket_lib._get_bucket_config(args.bucket_name)
+            if bucket_config is None:
+                raise ValueError(f"bucket {args.bucket_name!r} is not registered")
+            external_id = bucket_config.get("externalId")
         if not args.yes and not _confirm_role_bootstrap(
             role_name=args.role_name,
             trust_principals=effective_trust_principals,
-            external_id=args.external_id,
+            external_id=external_id,
             profile=args.profile,
         ):
             print("Aborted.")
@@ -434,11 +449,13 @@ def _cmd_bootstrap_role(args: argparse.Namespace) -> int:
             control_principals=effective_trust_principals,
             profile=args.profile,
             role_name=args.role_name,
-            external_id=args.external_id,
+            external_id=external_id,
         )
         action = "Created" if result.created else "Updated"
         print(f"{action} role {result.role_name}.")
         print(f"Role ARN: {result.role_arn}")
+        if external_id:
+            print(f"ExternalId: {external_id}")
         return 0
     except Exception as exc:
         if "Authentication failed" in str(exc):

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1095,6 +1095,33 @@ def test_add_bucket_already_registered(monkeypatch) -> None:
         bucket="bucket",
         title="My Bucket",
         sns_topic_arn="",
+        external_id=None,
+        already_registered=True,
+    )
+
+
+def test_add_bucket_already_registered_cross_account(monkeypatch) -> None:
+    _stub_stack_and_config(monkeypatch)
+    _install_fake_quilt3(
+        monkeypatch,
+        get_result=FakeBucket(
+            "bucket",
+            "My Bucket",
+            external_role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+        ),
+    )
+    monkeypatch.setattr(
+        bucket_lib,
+        "_get_bucket_config",
+        lambda bucket: {"externalId": "registry-external-id"},
+    )
+
+    result = add_bucket("bucket")
+    assert result == AddBucketResult(
+        bucket="bucket",
+        title="My Bucket",
+        sns_topic_arn="",
+        external_id="registry-external-id",
         already_registered=True,
     )
 
@@ -1235,6 +1262,7 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
         bucket="bucket",
         title="Demo Bucket",
         sns_topic_arn=topic_arn,
+        external_id=None,
         already_registered=False,
     )
     assert add_calls == [
@@ -1382,7 +1410,18 @@ def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
 
     def _graphql_request(query, variables):
         graphql_calls.append({"query": query, "variables": variables})
-        return {"bucketAdd": {"__typename": "BucketAddSuccess"}}
+        return {
+            "bucketAdd": {
+                "__typename": "BucketAddSuccess",
+                "bucketConfig": {
+                    "name": "bucket",
+                    "title": "Demo Bucket",
+                    "snsNotificationArn": topic_arn,
+                    "externalRoleArn": role_arn,
+                    "externalId": "registry-external-id",
+                },
+            }
+        }
 
     monkeypatch.setattr(
         bucket_lib,
@@ -1406,6 +1445,7 @@ def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
         bucket="bucket",
         title="Demo Bucket",
         sns_topic_arn=topic_arn,
+        external_id="registry-external-id",
         already_registered=False,
     )
     assert graphql_calls == [
@@ -1509,6 +1549,30 @@ def test_build_data_access_trust_policy_with_external_id() -> None:
                 "Condition": {"StringEquals": {"sts:ExternalId": "shared-external-id"}},
             }
         ],
+    }
+
+
+def test_get_bucket_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        bucket_lib,
+        "_graphql_request",
+        lambda query, variables: {
+            "bucketConfig": {
+                "name": variables["name"],
+                "title": "Demo Bucket",
+                "snsNotificationArn": "arn:aws:sns:us-east-1:111122223333:bucket",
+                "externalRoleArn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+                "externalId": "registry-external-id",
+            }
+        },
+    )
+
+    assert bucket_lib._get_bucket_config("bucket") == {
+        "name": "bucket",
+        "title": "Demo Bucket",
+        "snsNotificationArn": "arn:aws:sns:us-east-1:111122223333:bucket",
+        "externalRoleArn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+        "externalId": "registry-external-id",
     }
 
 
@@ -1769,3 +1833,46 @@ def test_cmd_bootstrap_role(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     assert "Created role QuiltDataAccessRole." in captured.out
     assert "arn:aws:iam::111122223333:role/QuiltDataAccessRole" in captured.out
+
+
+def test_cmd_bootstrap_role_uses_registry_external_id(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(bucket_tool, "get_catalog_config", lambda: {"catalog": "demo"})
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "load_stack_payload",
+        lambda catalog_name: {"account_id": "123456789012"},
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "_get_bucket_config",
+        lambda bucket_name: {"externalId": "registry-external-id"},
+    )
+    ensure_calls: list[dict[str, object]] = []
+
+    def fake_ensure_data_access_role(
+        **kwargs: object,
+    ) -> bucket_lib.BootstrapRoleResult:
+        ensure_calls.append(kwargs)
+        return bucket_lib.BootstrapRoleResult(
+            role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+            role_name="QuiltDataAccessRole",
+            created=False,
+        )
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "ensure_data_access_role",
+        fake_ensure_data_access_role,
+    )
+
+    assert bucket_tool.main(["bootstrap-role", "bucket", "--yes"]) == 0
+    assert ensure_calls == [
+        {
+            "control_principals": ["arn:aws:iam::123456789012:root"],
+            "profile": None,
+            "role_name": "QuiltDataAccessRole",
+            "external_id": "registry-external-id",
+        }
+    ]
+    captured = capsys.readouterr()
+    assert "ExternalId: registry-external-id" in captured.out

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from types import ModuleType, SimpleNamespace
 
 import boto3
+from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
 from quiltx import bucket as bucket_lib
@@ -336,6 +337,7 @@ class FakeBucket:
     title: str
     sns_notification_arn: str | None = None
     prefixes: list[str] | None = None
+    external_role_arn: str | None = None
 
 
 class FakeSession:
@@ -377,12 +379,32 @@ def _install_fake_quilt3(monkeypatch, *, get_result=None, listed=None, add_calls
         if add_calls is not None:
             add_calls.append(kwargs)
         bucket = FakeBucket(
-            kwargs["name"], kwargs["title"], kwargs.get("sns_notification_arn"), []
+            kwargs["name"],
+            kwargs["title"],
+            kwargs.get("sns_notification_arn"),
+            [],
+            kwargs.get("external_role_arn"),
         )
         bucket_list.append(bucket)
         return bucket
 
+    def update(name, **kwargs):
+        if add_calls is not None:
+            add_calls.append({"name": name, **kwargs, "_update": True})
+        for index, bucket in enumerate(bucket_list):
+            if bucket.name == name:
+                bucket_list[index] = FakeBucket(
+                    name,
+                    kwargs.get("title", bucket.title),
+                    kwargs.get("sns_notification_arn", bucket.sns_notification_arn),
+                    bucket.prefixes,
+                    kwargs.get("external_role_arn", bucket.external_role_arn),
+                )
+                return bucket_list[index]
+        raise AssertionError(f"bucket {name} not found")
+
     admin_buckets.add = add
+    admin_buckets.update = update
 
     admin_module = ModuleType("quilt3.admin")
     admin_module.buckets = admin_buckets
@@ -1231,6 +1253,183 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
     sts_stubber.deactivate()
 
 
+def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
+    role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "put_bucket_policy",
+        {},
+        {
+            "Bucket": "bucket",
+            "Policy": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        bucket_lib.build_quilt_policy_statement(
+                            "bucket",
+                            "123456789012",
+                            principals=[role_arn],
+                        )
+                    ],
+                }
+            ),
+        },
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "put_bucket_notification_configuration",
+        {},
+        {
+            "Bucket": "bucket",
+            "NotificationConfiguration": {
+                "TopicConfigurations": [
+                    {
+                        "Id": "QuiltBucketNotifications",
+                        "TopicArn": "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications",
+                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+                    }
+                ]
+            },
+        },
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    sns_stubber.add_response(
+        "create_topic",
+        {"TopicArn": topic_arn},
+        {"Name": "quilt-bucket-notifications"},
+    )
+    sns_stubber.add_response(
+        "get_topic_attributes",
+        {"Attributes": {}},
+        {"TopicArn": topic_arn},
+    )
+    sns_stubber.add_response(
+        "set_topic_attributes",
+        {},
+        {
+            "TopicArn": topic_arn,
+            "AttributeName": "Policy",
+            "AttributeValue": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "QuiltBucketNotifications",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "s3.amazonaws.com"},
+                            "Action": "sns:Publish",
+                            "Resource": topic_arn,
+                            "Condition": {
+                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
+                                "StringEquals": {"aws:SourceAccount": "111122223333"},
+                            },
+                        },
+                        {
+                            "Sid": "QuiltCrossAccountSNSAccess",
+                            "Effect": "Allow",
+                            "Principal": {"AWS": role_arn},
+                            "Action": [
+                                "sns:GetTopicAttributes",
+                                "sns:Subscribe",
+                            ],
+                            "Resource": topic_arn,
+                        },
+                    ],
+                }
+            ),
+        },
+    )
+    sns_stubber.activate()
+
+    sts_client = _client("sts")
+    sts_stubber = Stubber(sts_client)
+    sts_stubber.add_response(
+        "get_caller_identity",
+        {
+            "Account": "111122223333",
+            "Arn": "arn:aws:iam::111122223333:user/test",
+            "UserId": "test",
+        },
+        {},
+    )
+    sts_stubber.activate()
+
+    graphql_calls: list[dict[str, object]] = []
+
+    def _graphql_request(query, variables):
+        graphql_calls.append({"query": query, "variables": variables})
+        return {"bucketAdd": {"__typename": "BucketAddSuccess"}}
+
+    monkeypatch.setattr(
+        bucket_lib,
+        "_graphql_request",
+        _graphql_request,
+    )
+    _install_fake_quilt3(monkeypatch)
+    _stub_stack_and_config(monkeypatch)
+
+    session = FakeSession(s3_client, sns_client, sts_client)
+    import boto3 as _boto3
+
+    monkeypatch.setattr(_boto3, "Session", lambda profile_name=None: session)
+
+    result = add_bucket(
+        "bucket",
+        title="Demo Bucket",
+        external_role_arn=role_arn,
+    )
+    assert result == AddBucketResult(
+        bucket="bucket",
+        title="Demo Bucket",
+        sns_topic_arn=topic_arn,
+        already_registered=False,
+    )
+    assert graphql_calls == [
+        {
+            "query": bucket_lib._BUCKET_ADD_MUTATION,
+            "variables": {
+                "input": {
+                    "name": "bucket",
+                    "title": "Demo Bucket",
+                    "snsNotificationArn": topic_arn,
+                    "externalRoleArn": role_arn,
+                }
+            },
+        }
+    ]
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    sts_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+    sts_stubber.deactivate()
+
+
 def test_add_bucket_no_stack_payload(monkeypatch) -> None:
     _stub_stack_and_config(monkeypatch, payload=None)
     monkeypatch.setattr(
@@ -1283,6 +1482,128 @@ def test_build_quilt_policy_statement_without_principals_uses_root() -> None:
     assert statement["Principal"] == {"AWS": "arn:aws:iam::123456789012:root"}
 
 
+def test_effective_principals_adds_external_role_arn() -> None:
+    role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
+    assert bucket_lib._effective_principals([], external_role_arn=role_arn) == [
+        role_arn
+    ]
+    assert bucket_lib._effective_principals(
+        [role_arn],
+        external_role_arn=role_arn,
+    ) == [role_arn]
+
+
+def test_build_data_access_trust_policy_with_external_id() -> None:
+    policy = bucket_lib._build_data_access_trust_policy(
+        ["arn:aws:iam::123456789012:root"],
+        external_id="shared-external-id",
+    )
+    assert policy == {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "QuiltControlAssumeRole",
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+                "Action": "sts:AssumeRole",
+                "Condition": {"StringEquals": {"sts:ExternalId": "shared-external-id"}},
+            }
+        ],
+    }
+
+
+def test_ensure_data_access_role_creates(monkeypatch) -> None:
+    class FakeIamClient:
+        class exceptions:
+            class NoSuchEntityException(Exception):
+                pass
+
+        def get_role(self, *, RoleName):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "NoSuchEntity",
+                        "Message": "missing",
+                    }
+                },
+                "GetRole",
+            )
+
+        def create_role(self, **kwargs):
+            assert kwargs["RoleName"] == bucket_lib.DATA_ACCESS_ROLE_NAME
+            policy = json.loads(kwargs["AssumeRolePolicyDocument"])
+            assert (
+                policy["Statement"][0]["Principal"]["AWS"]
+                == "arn:aws:iam::123456789012:root"
+            )
+            return {
+                "Role": {
+                    "Arn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+                }
+            }
+
+    class FakeSession:
+        def client(self, service_name: str, region_name: str | None = None):
+            assert service_name == "iam"
+            return FakeIamClient()
+
+    import boto3 as _boto3
+
+    monkeypatch.setattr(_boto3, "Session", lambda profile_name=None: FakeSession())
+    result = bucket_lib.ensure_data_access_role(
+        control_principals=["arn:aws:iam::123456789012:root"],
+    )
+    assert result == bucket_lib.BootstrapRoleResult(
+        role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+        role_name="QuiltDataAccessRole",
+        created=True,
+    )
+
+
+def test_ensure_data_access_role_updates(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeIamClient:
+        def get_role(self, *, RoleName):
+            calls.append(("get_role", RoleName))
+            return {
+                "Role": {
+                    "Arn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+                }
+            }
+
+        def update_assume_role_policy(self, **kwargs):
+            calls.append(("update", json.loads(kwargs["PolicyDocument"])))
+
+    class FakeSession:
+        def client(self, service_name: str, region_name: str | None = None):
+            assert service_name == "iam"
+            return FakeIamClient()
+
+    import boto3 as _boto3
+
+    monkeypatch.setattr(_boto3, "Session", lambda profile_name=None: FakeSession())
+    result = bucket_lib.ensure_data_access_role(
+        control_principals=["arn:aws:iam::123456789012:root"],
+        external_id="shared-external-id",
+    )
+    assert result == bucket_lib.BootstrapRoleResult(
+        role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+        role_name="QuiltDataAccessRole",
+        created=False,
+    )
+    assert calls == [
+        ("get_role", "QuiltDataAccessRole"),
+        (
+            "update",
+            bucket_lib._build_data_access_trust_policy(
+                ["arn:aws:iam::123456789012:root"],
+                external_id="shared-external-id",
+            ),
+        ),
+    ]
+
+
 def test_resolve_principals_arg_bare_flag_requests_guidance() -> None:
     principals, show_guidance = bucket_tool._resolve_principals_arg([""])
     assert principals == []
@@ -1313,3 +1634,98 @@ def test_cmd_add_principal_rejects_non_arn(monkeypatch, capsys) -> None:
     assert bucket_tool.main(["add", "bucket", "--principal", "not-an-arn"]) == 1
     captured = capsys.readouterr()
     assert "must be an IAM role ARN" in captured.err
+
+
+def test_cmd_add_external_role_arn_drives_principal_selection(
+    monkeypatch, capsys
+) -> None:
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {"TopicConfigurations": []},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.activate()
+
+    sts_client = _client("sts", region_name="us-west-2")
+    sts_stubber = Stubber(sts_client)
+    sts_stubber.add_response(
+        "get_caller_identity",
+        {
+            "Account": "111122223333",
+            "Arn": "arn:aws:iam::111122223333:user/test",
+            "UserId": "test",
+        },
+        {},
+    )
+    sts_stubber.activate()
+
+    role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
+    session = FakeSession(s3_client, sns_client, sts_client)
+    monkeypatch.setattr(bucket_tool.boto3, "Session", lambda profile_name=None: session)
+    monkeypatch.setattr(bucket_tool, "get_catalog_config", lambda: {"catalog": "demo"})
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "load_stack_payload",
+        lambda catalog_name: {
+            "account_id": "123456789012",
+            "stack_name": "quilt-demo-stack",
+            "region": "us-east-1",
+        },
+    )
+    _install_fake_quilt3(monkeypatch, add_calls=[])
+
+    assert (
+        bucket_tool.main(
+            ["add", "bucket", "--dry-run", "--external-role-arn", role_arn]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert role_arn in captured.out
+    assert "--external-role-arn" in captured.out
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    sts_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+    sts_stubber.deactivate()
+
+
+def test_cmd_bootstrap_role(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(bucket_tool, "get_catalog_config", lambda: {"catalog": "demo"})
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "load_stack_payload",
+        lambda catalog_name: {"account_id": "123456789012"},
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "ensure_data_access_role",
+        lambda **kwargs: bucket_lib.BootstrapRoleResult(
+            role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+            role_name="QuiltDataAccessRole",
+            created=True,
+        ),
+    )
+
+    assert bucket_tool.main(["bootstrap-role", "--yes"]) == 0
+    captured = capsys.readouterr()
+    assert "Created role QuiltDataAccessRole." in captured.out
+    assert "arn:aws:iam::111122223333:role/QuiltDataAccessRole" in captured.out

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1513,12 +1513,15 @@ def test_build_data_access_trust_policy_with_external_id() -> None:
 
 
 def test_ensure_data_access_role_creates(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+
     class FakeIamClient:
         class exceptions:
             class NoSuchEntityException(Exception):
                 pass
 
         def get_role(self, *, RoleName):
+            calls.append(("get_role", RoleName))
             raise ClientError(
                 {
                     "Error": {
@@ -1530,6 +1533,7 @@ def test_ensure_data_access_role_creates(monkeypatch) -> None:
             )
 
         def create_role(self, **kwargs):
+            calls.append(("create_role", kwargs["RoleName"]))
             assert kwargs["RoleName"] == bucket_lib.DATA_ACCESS_ROLE_NAME
             policy = json.loads(kwargs["AssumeRolePolicyDocument"])
             assert (
@@ -1541,6 +1545,16 @@ def test_ensure_data_access_role_creates(monkeypatch) -> None:
                     "Arn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
                 }
             }
+
+        def put_role_policy(self, **kwargs):
+            calls.append(
+                (
+                    "put_role_policy",
+                    kwargs["RoleName"],
+                    kwargs["PolicyName"],
+                    json.loads(kwargs["PolicyDocument"]),
+                )
+            )
 
     class FakeSession:
         def client(self, service_name: str, region_name: str | None = None):
@@ -1558,6 +1572,16 @@ def test_ensure_data_access_role_creates(monkeypatch) -> None:
         role_name="QuiltDataAccessRole",
         created=True,
     )
+    assert calls == [
+        ("get_role", "QuiltDataAccessRole"),
+        ("create_role", "QuiltDataAccessRole"),
+        (
+            "put_role_policy",
+            "QuiltDataAccessRole",
+            bucket_lib.DATA_ACCESS_ROLE_POLICY_NAME,
+            bucket_lib._build_data_access_role_policy(),
+        ),
+    ]
 
 
 def test_ensure_data_access_role_updates(monkeypatch) -> None:
@@ -1574,6 +1598,16 @@ def test_ensure_data_access_role_updates(monkeypatch) -> None:
 
         def update_assume_role_policy(self, **kwargs):
             calls.append(("update", json.loads(kwargs["PolicyDocument"])))
+
+        def put_role_policy(self, **kwargs):
+            calls.append(
+                (
+                    "put_role_policy",
+                    kwargs["RoleName"],
+                    kwargs["PolicyName"],
+                    json.loads(kwargs["PolicyDocument"]),
+                )
+            )
 
     class FakeSession:
         def client(self, service_name: str, region_name: str | None = None):
@@ -1600,6 +1634,12 @@ def test_ensure_data_access_role_updates(monkeypatch) -> None:
                 ["arn:aws:iam::123456789012:root"],
                 external_id="shared-external-id",
             ),
+        ),
+        (
+            "put_role_policy",
+            "QuiltDataAccessRole",
+            bucket_lib.DATA_ACCESS_ROLE_POLICY_NAME,
+            bucket_lib._build_data_access_role_policy(),
         ),
     ]
 

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -651,6 +651,16 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
         {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
         "put_bucket_policy",
         {},
         {
@@ -666,6 +676,19 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
                 }
             ),
         },
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {
+            "TopicConfigurations": [
+                {
+                    "Id": "existing",
+                    "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
+                    "Events": ["s3:ObjectCreated:*"],
+                }
+            ]
+        },
+        {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
         "get_bucket_notification_configuration",
@@ -755,6 +778,15 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
         },
         {},
     )
+    sts_stubber.add_response(
+        "get_caller_identity",
+        {
+            "Account": "111122223333",
+            "Arn": "arn:aws:iam::111122223333:user/test",
+            "UserId": "test",
+        },
+        {},
+    )
     sts_stubber.activate()
 
     add_calls: list[dict[str, str]] = []
@@ -815,6 +847,16 @@ def test_add_creates_sns(monkeypatch) -> None:
         {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
         "put_bucket_policy",
         {},
         {
@@ -830,6 +872,11 @@ def test_add_creates_sns(monkeypatch) -> None:
                 }
             ),
         },
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {},
+        {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
         "get_bucket_notification_configuration",
@@ -907,6 +954,15 @@ def test_add_creates_sns(monkeypatch) -> None:
 
     sts_client = _client("sts")
     sts_stubber = Stubber(sts_client)
+    sts_stubber.add_response(
+        "get_caller_identity",
+        {
+            "Account": "111122223333",
+            "Arn": "arn:aws:iam::111122223333:user/test",
+            "UserId": "test",
+        },
+        {},
+    )
     sts_stubber.add_response(
         "get_caller_identity",
         {
@@ -1096,25 +1152,64 @@ def test_add_bucket_already_registered(monkeypatch) -> None:
         title="My Bucket",
         sns_topic_arn="",
         external_id=None,
+        athena_access_role_arn=None,
         already_registered=True,
     )
 
 
 def test_add_bucket_already_registered_cross_account(monkeypatch) -> None:
     _stub_stack_and_config(monkeypatch)
+    role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
+    athena_role_arn = "arn:aws:iam::123456789012:role/QuiltAthenaAccessRole-quilt"
     _install_fake_quilt3(
         monkeypatch,
         get_result=FakeBucket(
             "bucket",
             "My Bucket",
-            external_role_arn="arn:aws:iam::111122223333:role/QuiltDataAccessRole",
+            external_role_arn=role_arn,
         ),
     )
     monkeypatch.setattr(
         bucket_lib,
         "_get_bucket_config",
-        lambda bucket: {"externalId": "registry-external-id"},
+        lambda bucket: {
+            "externalId": "registry-external-id",
+            "externalRoleArn": role_arn,
+            "athenaAccessRoleArn": athena_role_arn,
+        },
     )
+    applied: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        bucket_lib,
+        "_apply_quilt_access_configuration",
+        lambda **kwargs: applied.append(kwargs),
+    )
+
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+    sns_client = _client("sns", region_name="us-west-2")
+    sts_client = _client("sts")
+    sts_stubber = Stubber(sts_client)
+    sts_stubber.add_response(
+        "get_caller_identity",
+        {
+            "Account": "111122223333",
+            "Arn": "arn:aws:iam::111122223333:user/test",
+            "UserId": "test",
+        },
+        {},
+    )
+    sts_stubber.activate()
+    session = FakeSession(s3_client, sns_client, sts_client)
+    import boto3 as _boto3
+
+    monkeypatch.setattr(_boto3, "Session", lambda profile_name=None: session)
 
     result = add_bucket("bucket")
     assert result == AddBucketResult(
@@ -1122,8 +1217,24 @@ def test_add_bucket_already_registered_cross_account(monkeypatch) -> None:
         title="My Bucket",
         sns_topic_arn="",
         external_id="registry-external-id",
+        athena_access_role_arn=athena_role_arn,
         already_registered=True,
     )
+    assert applied == [
+        {
+            "bucket": "bucket",
+            "control_account_id": "123456789012",
+            "data_account_id": "111122223333",
+            "sns_topic_arn": None,
+            "principals": [role_arn, athena_role_arn],
+            "s3_client": s3_client,
+            "sns_client": sns_client,
+        }
+    ]
+    s3_stubber.assert_no_pending_responses()
+    sts_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sts_stubber.deactivate()
 
 
 def test_add_bucket_creates_new(monkeypatch) -> None:
@@ -1263,6 +1374,7 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
         title="Demo Bucket",
         sns_topic_arn=topic_arn,
         external_id=None,
+        athena_access_role_arn=None,
         already_registered=False,
     )
     assert add_calls == [
@@ -1283,6 +1395,7 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
 
 def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
     role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
+    athena_role_arn = "arn:aws:iam::123456789012:role/QuiltAthenaAccessRole-quilt"
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
     s3_stubber.add_response(
@@ -1391,6 +1504,119 @@ def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
             ),
         },
     )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {
+            "Policy": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        bucket_lib.build_quilt_policy_statement(
+                            "bucket",
+                            "123456789012",
+                            principals=[role_arn],
+                        )
+                    ],
+                }
+            )
+        },
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "put_bucket_policy",
+        {},
+        {
+            "Bucket": "bucket",
+            "Policy": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        bucket_lib.build_quilt_policy_statement(
+                            "bucket",
+                            "123456789012",
+                            principals=[role_arn, athena_role_arn],
+                        )
+                    ],
+                }
+            ),
+        },
+    )
+    sns_stubber.add_response(
+        "get_topic_attributes",
+        {
+            "Attributes": {
+                "Policy": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "QuiltBucketNotifications",
+                                "Effect": "Allow",
+                                "Principal": {"Service": "s3.amazonaws.com"},
+                                "Action": "sns:Publish",
+                                "Resource": topic_arn,
+                                "Condition": {
+                                    "ArnEquals": {
+                                        "aws:SourceArn": "arn:aws:s3:::bucket"
+                                    },
+                                    "StringEquals": {
+                                        "aws:SourceAccount": "111122223333"
+                                    },
+                                },
+                            },
+                            {
+                                "Sid": "QuiltCrossAccountSNSAccess",
+                                "Effect": "Allow",
+                                "Principal": {"AWS": role_arn},
+                                "Action": [
+                                    "sns:GetTopicAttributes",
+                                    "sns:Subscribe",
+                                ],
+                                "Resource": topic_arn,
+                            },
+                        ],
+                    }
+                )
+            }
+        },
+        {"TopicArn": topic_arn},
+    )
+    sns_stubber.add_response(
+        "set_topic_attributes",
+        {},
+        {
+            "TopicArn": topic_arn,
+            "AttributeName": "Policy",
+            "AttributeValue": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "QuiltBucketNotifications",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "s3.amazonaws.com"},
+                            "Action": "sns:Publish",
+                            "Resource": topic_arn,
+                            "Condition": {
+                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
+                                "StringEquals": {"aws:SourceAccount": "111122223333"},
+                            },
+                        },
+                        {
+                            "Sid": "QuiltCrossAccountSNSAccess",
+                            "Effect": "Allow",
+                            "Principal": {"AWS": [role_arn, athena_role_arn]},
+                            "Action": [
+                                "sns:GetTopicAttributes",
+                                "sns:Subscribe",
+                            ],
+                            "Resource": topic_arn,
+                        },
+                    ],
+                }
+            ),
+        },
+    )
     sns_stubber.activate()
 
     sts_client = _client("sts")
@@ -1419,6 +1645,7 @@ def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
                     "snsNotificationArn": topic_arn,
                     "externalRoleArn": role_arn,
                     "externalId": "registry-external-id",
+                    "athenaAccessRoleArn": athena_role_arn,
                 },
             }
         }
@@ -1446,6 +1673,7 @@ def test_add_bucket_creates_new_with_external_role_arn(monkeypatch) -> None:
         title="Demo Bucket",
         sns_topic_arn=topic_arn,
         external_id="registry-external-id",
+        athena_access_role_arn=athena_role_arn,
         already_registered=False,
     )
     assert graphql_calls == [
@@ -1524,13 +1752,17 @@ def test_build_quilt_policy_statement_without_principals_uses_root() -> None:
 
 def test_effective_principals_adds_external_role_arn() -> None:
     role_arn = "arn:aws:iam::111122223333:role/QuiltDataAccessRole"
-    assert bucket_lib._effective_principals([], external_role_arn=role_arn) == [
-        role_arn
-    ]
+    athena_role_arn = "arn:aws:iam::123456789012:role/QuiltAthenaAccessRole-quilt"
     assert bucket_lib._effective_principals(
-        [role_arn],
+        [],
         external_role_arn=role_arn,
-    ) == [role_arn]
+        athena_access_role_arn=athena_role_arn,
+    ) == [role_arn, athena_role_arn]
+    assert bucket_lib._effective_principals(
+        [role_arn, athena_role_arn],
+        external_role_arn=role_arn,
+        athena_access_role_arn=athena_role_arn,
+    ) == [role_arn, athena_role_arn]
 
 
 def test_build_data_access_trust_policy_with_external_id() -> None:
@@ -1563,6 +1795,7 @@ def test_get_bucket_config(monkeypatch) -> None:
                 "snsNotificationArn": "arn:aws:sns:us-east-1:111122223333:bucket",
                 "externalRoleArn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
                 "externalId": "registry-external-id",
+                "athenaAccessRoleArn": "arn:aws:iam::123456789012:role/QuiltAthenaAccessRole-quilt",
             }
         },
     )
@@ -1573,6 +1806,7 @@ def test_get_bucket_config(monkeypatch) -> None:
         "snsNotificationArn": "arn:aws:sns:us-east-1:111122223333:bucket",
         "externalRoleArn": "arn:aws:iam::111122223333:role/QuiltDataAccessRole",
         "externalId": "registry-external-id",
+        "athenaAccessRoleArn": "arn:aws:iam::123456789012:role/QuiltAthenaAccessRole-quilt",
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
### Role in the chokepoint

The bootstrap step that creates the named IAM role in the control account and installs the bucket-scoped inline policy, so that deployment#2372's narrowed templates have a role to reference. This branch also switches the bootstrap to consume the registry-issued `ExternalId` instead of generating one client-side, and now applies the full two-principal bucket policy contract. See [meta#84](https://github.com/quiltdata/meta/pull/84).

> **Scope expanded.** This branch now consumes the registry-managed `ExternalId` contract and the registry-surfaced Athena role ARN instead of treating the bucket policy as a single-principal concern. See the [scope-update comment](https://github.com/quiltdata/quiltx/pull/33#issuecomment-4283118120), [meta/20-actually-finish-all.md § Progress](https://github.com/quiltdata/meta/blob/251208-add-bucket/proj/251208-add-bucket/20-actually-finish-all.md#progress), and [meta/22g-two-principal-fix.md](https://github.com/quiltdata/meta/blob/251208-add-bucket/proj/251208-add-bucket/22g-two-principal-fix.md).

### What this PR completes

- New `quiltx` command to create/reuse `QuiltDataAccessRole` with an inline policy scoped to the named bucket (`quiltx/bucket.py`, `quiltx/tools/bucket.py`).
- Bootstrap flow now reads the registry-issued `ExternalId` from the bucket registration / bucket config response (surfaced by enterprise#1037) and reuses it for the `bootstrap-role` trust policy instead of generating one client-side. First-time registration in a new external account and repeat registration in the same external account both converge on the registry-managed value.
- Bucket add/update/query GraphQL calls now fetch `athenaAccessRoleArn`, and the final bucket/SNS policy principals are the deduped union of explicit `--principal` values, `external_role_arn`, and the stack-owned Athena role.
- New bucket bootstrap does an initial apply, registers with the catalog, then re-applies the bucket/SNS policy when the returned Athena role ARN expands the principal set.
- Already-registered cross-account buckets now idempotently re-apply the two-principal bucket/SNS policy on re-bootstrap instead of leaving the old single-principal policy in place.
- Registers the bucket via the admin API with `external_role_arn` set.
- `configure_bucket_notifications` still runs under bucket-owner credentials, unchanged.

Reference: `proj/251208-add-bucket/10-cross-account-grants.md` §role-scoped trust, `proj/251208-add-bucket/20-actually-finish-all.md`.

### How to verify

- Unit tests on the new role-bootstrap and bucket-registration code (`tests/test_bucket.py`) cover new registration, already-registered cross-account re-bootstrap, and SNS reuse/create flows under the delegated library path.
- End-to-end: run `quiltx` against a fresh data account; confirm role is created, inline policy matches the bucket scope, `ExternalId` in the trust policy matches the value the registry returns, bucket registers successfully, and the resulting bucket policy names both the data-access role and `QuiltAthenaAccessRole`.
- Repeat registration in the same external data account reuses the same registry-issued `ExternalId` and converges the bucket/SNS policies onto the two-principal shape.

### Risk & rollback

Coupled to enterprise#1037 (registry is now the source of truth for `ExternalId` and `athenaAccessRoleArn`) and deployment#2372 (named role contract). Safe to revert alone — the bootstrap is idempotent and does not delete existing roles on rollback. However, deployment#2372's generated templates expect this role to exist, and the bootstrap now expects the registry to supply the bucket-policy principals; if this PR is reverted after the upstream PRs merge, new bucket registrations will fall back to the stale single-principal shape until re-applied.