### PR TITLE
quiltx 0.10.0: surface silent ACL errors, detect & auto-recover policy drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.10.2"
+version = "0.10.3"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.9.2"
+version = "0.10.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.10.0"
+version = "0.10.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.10.1"
+version = "0.10.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.9.2"
+__version__ = "0.10.0"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -505,17 +505,79 @@ def print_current_state(current: CurrentState) -> None:
         print("  sso config: (none)")
 
 
+def _register_bucket_with_retry(
+    bucket: str, control_account_id: str, *, assume_yes: bool
+) -> None:
+    """Run the full cross-account bucket registration, probing profiles on failure."""
+    from quiltx import bucket as bucket_lib
+
+    session, s3_client, region, _profile = bucket_lib.resolve_bucket_session(
+        bucket, None, assume_yes=assume_yes
+    )
+    if session is None:
+        raise RuntimeError(f"no accessible AWS profile for bucket {bucket}")
+
+    sns_client = session.client("sns", region_name=region)
+    data_account_id = str(session.client("sts").get_caller_identity()["Account"])
+
+    existing_policy = bucket_lib.get_bucket_policy(bucket, s3_client=s3_client)
+    statement = bucket_lib.build_quilt_policy_statement(bucket, control_account_id)
+    merged = bucket_lib.merge_bucket_policy(existing_policy, statement)
+    bucket_lib.apply_bucket_policy(bucket, merged, s3_client=s3_client)
+
+    sns_topic_arn = bucket_lib.get_bucket_notification_sns(bucket, s3_client=s3_client)
+    if sns_topic_arn is None:
+        sns_topic_arn = bucket_lib.ensure_sns_topic(
+            bucket, region, sns_client=sns_client
+        )
+    bucket_lib.configure_sns_topic_policy(
+        bucket,
+        sns_topic_arn,
+        data_account_id,
+        f"arn:aws:iam::{control_account_id}:root",
+        sns_client=sns_client,
+    )
+    bucket_lib.configure_bucket_notifications(
+        bucket, sns_topic_arn, s3_client=s3_client
+    )
+    admin_buckets.add(name=bucket, title=bucket, sns_notification_arn=sns_topic_arn)
+
+
 def apply_acl(
-    diff: AclDiff, current: CurrentState, *, verbose: bool = False
+    diff: AclDiff,
+    current: CurrentState,
+    *,
+    verbose: bool = False,
+    assume_yes: bool = False,
 ) -> list[str]:
     """Apply ACL changes. Returns any runtime warnings."""
+    from quiltx import bucket as bucket_lib
+    from quiltx import stack as stack_lib
+    from quiltx.config import get_catalog_config
+
     warnings = list(diff.warnings)
     failed_buckets: set[str] = set()
+
+    control_account_id: str | None = None
+    if diff.buckets_to_add:
+        try:
+            config = get_catalog_config()
+            catalog_name = stack_lib.extract_catalog_name(config)
+            payload = stack_lib.load_stack_payload(catalog_name)
+            if payload and payload.get("account_id"):
+                control_account_id = str(payload["account_id"])
+        except Exception as exc:  # pragma: no cover - external API surface
+            warnings.append(f"Could not load control account for bucket add: {exc}")
 
     for bucket in diff.buckets_to_add:
         try:
             _print_apply_step(f"add bucket {bucket}", verbose=verbose)
-            admin_buckets.add(bucket, bucket)
+            if control_account_id is None:
+                admin_buckets.add(bucket, bucket)
+            else:
+                _register_bucket_with_retry(
+                    bucket, control_account_id, assume_yes=assume_yes
+                )
             print(f"  + bucket {bucket}")
         except Exception as exc:  # pragma: no cover - external API surface
             failed_buckets.add(bucket)

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -659,6 +659,103 @@ def apply_acl(
     return warnings
 
 
+@dataclass(frozen=True)
+class PolicyDrift:
+    """A managed policy whose server state diverges from the desired state."""
+
+    title: str
+    desired: list[Permission]
+    actual: list[Permission]
+
+    @property
+    def missing(self) -> list[str]:
+        desired = _canonical_permissions(self.desired)
+        actual = set(_canonical_permissions(self.actual))
+        return [
+            f"{level.split('.')[-1]}:{bucket}"
+            for bucket, level in desired
+            if (bucket, level) not in actual
+        ]
+
+    @property
+    def extra(self) -> list[str]:
+        actual = _canonical_permissions(self.actual)
+        desired = set(_canonical_permissions(self.desired))
+        return [
+            f"{level.split('.')[-1]}:{bucket}"
+            for bucket, level in actual
+            if (bucket, level) not in desired
+        ]
+
+
+def detect_policy_drift(desired: AclConfig, current: CurrentState) -> list[PolicyDrift]:
+    """Return managed policies where the server state diverges from desired.
+
+    Detection is always-on: the catalog's policyUpdateManaged mutation has
+    historically both silently dropped permissions and returned 500 while
+    partially persisting. This compares the desired permissions for each
+    managed policy against whatever the server currently holds.
+    """
+    desired_state = _build_desired_acl_state(desired)
+    drift: list[PolicyDrift] = []
+    for title, policy_update in desired_state.policy_updates.items():
+        current_policy = current.managed_policies.get(title)
+        if current_policy is None:
+            continue  # policy doesn't exist yet — apply_acl will create it
+        if _canonical_permissions(current_policy.permissions) == _canonical_permissions(
+            policy_update.permissions
+        ):
+            continue
+        drift.append(
+            PolicyDrift(
+                title=title,
+                desired=list(policy_update.permissions),
+                actual=list(current_policy.permissions),
+            )
+        )
+    return drift
+
+
+def managed_roles_using_policy(policy_title: str, current: CurrentState) -> list[str]:
+    """Return managed role names that reference the given policy."""
+    return sorted(
+        name
+        for name, role in current.managed_roles.items()
+        if any(p.title == policy_title for p in getattr(role, "policies", []) or [])
+    )
+
+
+def reset_policy(
+    title: str, current: CurrentState, *, verbose: bool = False
+) -> list[str]:
+    """Delete a managed policy and any managed roles referencing it.
+
+    After calling this, the caller should refetch state and re-run the normal
+    reconcile path, which will recreate the policy via policyCreateManaged and
+    the roles via roleCreateManaged — a different backend codepath than the
+    one that failed.
+    """
+    warnings: list[str] = []
+    for role_name in managed_roles_using_policy(title, current):
+        try:
+            _print_apply_step(f"delete role {role_name}", verbose=verbose)
+            admin_roles.delete(role_name)
+            print(f"  - role {role_name}")
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(f"Role '{role_name}' could not be deleted: {detail}")
+            print(f"  ! role {role_name}: {detail}", file=sys.stderr)
+    try:
+        _print_apply_step(f"delete policy {title}", verbose=verbose)
+        admin_policies.delete(title)
+        print(f"  - policy {title}")
+    except Exception as exc:
+        detail = format_exception(exc)
+        warnings.append(f"Policy '{title}' could not be deleted: {detail}")
+        print(f"  ! policy {title}: {detail}", file=sys.stderr)
+    return warnings
+
+
 def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
     policy_updates: dict[str, PolicyUpdate] = {}
     synthesized_roles: list[_SynthesizedRole] = []

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -14,6 +14,7 @@ from quilt3.admin import buckets as admin_buckets
 from quilt3.admin import policies as admin_policies
 from quilt3.admin import roles as admin_roles
 from quilt3.admin import sso_config as admin_sso_config
+from quilt3.admin import users as admin_users
 from quilt3.admin.types import Permission
 
 INLINE_POLICY_SUFFIX = "__inline"
@@ -785,24 +786,141 @@ def detach_sso_mappings_for_roles(
     return warnings
 
 
-def reset_policy(
-    title: str, current: CurrentState, *, verbose: bool = False
-) -> list[str]:
-    """Delete a managed policy and any managed roles referencing it.
+@dataclass(frozen=True)
+class UserRoleBinding:
+    """Snapshot of a user's role assignments for restore after role recreate."""
 
-    Removes SSO mappings to the affected roles first, since roleDeleteManaged
-    is rejected while those mappings exist. After calling this, the caller
-    should refetch state and re-run the normal reconcile path, which will
-    recreate the policy via policyCreateManaged and the roles via
-    roleCreateManaged — a different backend codepath than the one that
-    failed — and reattach SSO mappings from the desired config.
+    user_name: str
+    primary: str | None
+    extras: list[str]
+
+
+def detach_users_from_role(
+    role_name: str, *, verbose: bool = False
+) -> tuple[list[str], list[UserRoleBinding]]:
+    """Remove a role from every user that has it assigned.
+
+    The registry rejects roleDeleteManaged while a user still has the role
+    as their primary or extra role. Returns (warnings, snapshot) where
+    snapshot lets callers restore the original assignments once the role
+    has been recreated.
     """
     warnings: list[str] = []
+    snapshot: list[UserRoleBinding] = []
+    default_role = admin_roles.get_default()
+    fallback_name = default_role.name if default_role is not None else None
+    for user in admin_users.list():
+        primary = user.role.name if user.role else None
+        extras = [
+            r.name for r in (getattr(user, "extra_roles", None) or []) if r is not None
+        ]
+        if primary != role_name and role_name not in extras:
+            continue
+        snapshot.append(
+            UserRoleBinding(user_name=user.name, primary=primary, extras=extras)
+        )
+        _print_apply_step(
+            f"detach user {user.name} from role {role_name}", verbose=verbose
+        )
+        try:
+            admin_users.remove_roles(user.name, [role_name], fallback=fallback_name)
+            print(f"  ~ user {user.name} (detached {role_name})")
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(
+                f"User '{user.name}' could not be detached from "
+                f"role '{role_name}': {detail}"
+            )
+            print(f"  ! user {user.name}: {detail}", file=sys.stderr)
+    return warnings, snapshot
+
+
+def users_assigned_to_roles(role_names: set[str]) -> list[UserRoleBinding]:
+    """Snapshot user assignments for the given roles without modifying state."""
+    bindings: list[UserRoleBinding] = []
+    for user in admin_users.list():
+        primary = user.role.name if user.role else None
+        extras = [
+            r.name for r in (getattr(user, "extra_roles", None) or []) if r is not None
+        ]
+        if primary in role_names or any(e in role_names for e in extras):
+            bindings.append(
+                UserRoleBinding(user_name=user.name, primary=primary, extras=extras)
+            )
+    return bindings
+
+
+def restore_user_role_bindings(
+    bindings: list[UserRoleBinding], *, verbose: bool = False
+) -> list[str]:
+    """Reapply captured user role assignments after affected roles exist again."""
+    warnings: list[str] = []
+    for binding in bindings:
+        _print_apply_step(f"restore user {binding.user_name}", verbose=verbose)
+        try:
+            admin_users.set_role(
+                binding.user_name,
+                binding.primary or "",
+                extra_roles=binding.extras or None,
+            )
+            print(f"  ~ user {binding.user_name} (restored)")
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(
+                f"User '{binding.user_name}' role bindings could not be "
+                f"restored: {detail}"
+            )
+            print(f"  ! user {binding.user_name}: {detail}", file=sys.stderr)
+    return warnings
+
+
+def clear_sso_config(*, verbose: bool = False) -> list[str]:
+    """Clear the entire SSO config.
+
+    users.set_role and users.remove_roles are rejected while any SSO config
+    exists (SsoConfigConflict). Callers reset the config entirely, perform
+    the user/role mutations, then let the reapply step rebuild SSO from the
+    desired YAML.
+    """
+    warnings: list[str] = []
+    _print_apply_step("clear sso config", verbose=verbose)
+    try:
+        admin_sso_config.set(None)
+        print("  ~ sso config (cleared)")
+    except Exception as exc:
+        detail = format_exception(exc)
+        warnings.append(f"SSO config could not be cleared: {detail}")
+        print(f"  ! sso config: {detail}", file=sys.stderr)
+    return warnings
+
+
+def reset_policy(
+    title: str, current: CurrentState, *, verbose: bool = False
+) -> tuple[list[str], list[UserRoleBinding]]:
+    """Delete a managed policy and any managed roles referencing it.
+
+    Before the deletes, clear the full SSO config and detach user
+    assignments for the affected roles — the registry rejects
+    roleDeleteManaged while either references still exist, and rejects
+    user role mutations while any SSO config is present. Returns
+    (warnings, user_bindings_snapshot) so the caller can restore user
+    assignments once the new roles exist.
+    """
+    warnings: list[str] = []
+    user_snapshot: list[UserRoleBinding] = []
     roles_to_delete = managed_roles_using_policy(title, current)
     if roles_to_delete:
-        warnings.extend(
-            detach_sso_mappings_for_roles(set(roles_to_delete), verbose=verbose)
-        )
+        users_to_detach = users_assigned_to_roles(set(roles_to_delete))
+        if users_to_detach:
+            warnings.extend(clear_sso_config(verbose=verbose))
+        else:
+            warnings.extend(
+                detach_sso_mappings_for_roles(set(roles_to_delete), verbose=verbose)
+            )
+        for role_name in roles_to_delete:
+            w, snap = detach_users_from_role(role_name, verbose=verbose)
+            warnings.extend(w)
+            user_snapshot.extend(snap)
     for role_name in roles_to_delete:
         try:
             _print_apply_step(f"delete role {role_name}", verbose=verbose)
@@ -820,7 +938,7 @@ def reset_policy(
         detail = format_exception(exc)
         warnings.append(f"Policy '{title}' could not be deleted: {detail}")
         print(f"  ! policy {title}: {detail}", file=sys.stderr)
-    return warnings
+    return warnings, user_snapshot
 
 
 def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -701,17 +701,18 @@ def detect_policy_drift(desired: AclConfig, current: CurrentState) -> list[Polic
     drift: list[PolicyDrift] = []
     for title, policy_update in desired_state.policy_updates.items():
         current_policy = current.managed_policies.get(title)
-        if current_policy is None:
-            continue  # policy doesn't exist yet — apply_acl will create it
-        if _canonical_permissions(current_policy.permissions) == _canonical_permissions(
-            policy_update.permissions
-        ):
+        actual_permissions = (
+            list(current_policy.permissions) if current_policy is not None else []
+        )
+        if current_policy is not None and _canonical_permissions(
+            current_policy.permissions
+        ) == _canonical_permissions(policy_update.permissions):
             continue
         drift.append(
             PolicyDrift(
                 title=title,
                 desired=list(policy_update.permissions),
-                actual=list(current_policy.permissions),
+                actual=actual_permissions,
             )
         )
     return drift

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -18,9 +18,7 @@ from quilt3.admin import users as admin_users
 from quilt3.admin.types import Permission
 
 INLINE_POLICY_SUFFIX = "__inline"
-NEW_FORMAT_KEYS = {"policies", "roles", "store_last_login_context"}
-OLD_FORMAT_KEYS = {"bucket_policies", "sso"}
-NEW_FORMAT_EXAMPLE = "spec/060-stack-acl/simpler-stack-acl.yml"
+ACL_TOP_LEVEL_KEYS = {"policies", "roles", "store_last_login_context"}
 EVERYONE_GROUP = "Everyone"
 
 
@@ -1075,22 +1073,13 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
 
 
 def _validate_top_level_keys(raw: dict[str, Any]) -> None:
-    keys = set(raw)
-    old_keys = sorted(keys & OLD_FORMAT_KEYS)
-    if old_keys:
-        raise ValueError(
-            "The old stack ACL format is no longer supported. Replace "
-            f"{', '.join(old_keys)} with top-level 'policies' and 'roles'; see "
-            f"{NEW_FORMAT_EXAMPLE}."
-        )
-
-    unknown_keys = sorted(keys - NEW_FORMAT_KEYS)
+    unknown_keys = sorted(set(raw) - ACL_TOP_LEVEL_KEYS)
     if unknown_keys:
         raise ValueError(
             "Unknown top-level ACL keys: "
             + ", ".join(unknown_keys)
             + ". Supported keys: "
-            + ", ".join(sorted(NEW_FORMAT_KEYS))
+            + ", ".join(sorted(ACL_TOP_LEVEL_KEYS))
             + "."
         )
 

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -543,6 +543,14 @@ def apply_acl(
             continue
         known_policies[policy.title] = created
         print(f"  + policy {policy.title}")
+        dropped = _dropped_permissions(policy.permissions, created.permissions)
+        if dropped:
+            detail = (
+                f"server accepted create but dropped permissions: "
+                f"{', '.join(dropped)}"
+            )
+            warnings.append(f"Policy '{policy.title}' {detail}")
+            print(f"  ! policy {policy.title}: {detail}", file=sys.stderr)
     for policy in diff.policies_to_update:
         _print_apply_step(f"update policy {policy.title}", verbose=verbose)
         affected = _policy_uses_buckets(policy.permissions, failed_buckets)
@@ -567,6 +575,14 @@ def apply_acl(
             continue
         known_policies[policy.title] = updated
         print(f"  ~ policy {policy.title}")
+        dropped = _dropped_permissions(policy.permissions, updated.permissions)
+        if dropped:
+            detail = (
+                f"server accepted update but dropped permissions: "
+                f"{', '.join(dropped)}"
+            )
+            warnings.append(f"Policy '{policy.title}' {detail}")
+            print(f"  ! policy {policy.title}: {detail}", file=sys.stderr)
 
     for role in diff.roles_to_create:
         _print_apply_step(f"create role {role.name}", verbose=verbose)
@@ -918,6 +934,17 @@ def _canonical_permissions(permissions: list[Permission]) -> list[tuple[str, str
     return sorted(
         (permission.bucket, str(permission.level)) for permission in permissions
     )
+
+
+def _dropped_permissions(
+    sent: list[Permission], returned: list[Permission]
+) -> list[str]:
+    returned_set = set(_canonical_permissions(returned))
+    return [
+        f"{level.split('.')[-1]}:{bucket}"
+        for bucket, level in _canonical_permissions(sent)
+        if (bucket, level) not in returned_set
+    ]
 
 
 def _same_yaml(left: str | None, right: str | None) -> bool:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -725,18 +725,85 @@ def managed_roles_using_policy(policy_title: str, current: CurrentState) -> list
     )
 
 
+def detach_sso_mappings_for_roles(
+    role_names: set[str], *, verbose: bool = False
+) -> list[str]:
+    """Rewrite the live SSO config so it no longer references the given roles.
+
+    The registry rejects roleDeleteManaged while a role is still bound in the
+    SSO mapping, so callers that need to delete synthetic roles must clear
+    the mapping first. The recreate-and-reapply flow restores the mappings
+    when the new role IDs exist.
+    """
+    warnings: list[str] = []
+    current_sso = admin_sso_config.get()
+    if current_sso is None or not current_sso.text:
+        return warnings
+    try:
+        payload = yaml.safe_load(current_sso.text) or {}
+    except yaml.YAMLError as exc:
+        warnings.append(f"SSO config YAML could not be parsed: {exc}")
+        return warnings
+    if not isinstance(payload, dict):
+        return warnings
+
+    mappings = payload.get("mappings") or []
+    new_mappings: list[Any] = []
+    changed = False
+    for mapping in mappings:
+        if not isinstance(mapping, dict):
+            new_mappings.append(mapping)
+            continue
+        roles = mapping.get("roles") or []
+        remaining = [r for r in roles if r not in role_names]
+        if remaining != roles:
+            changed = True
+            if not remaining:
+                continue
+            mapping = {**mapping, "roles": remaining}
+        new_mappings.append(mapping)
+
+    if payload.get("default_role") in role_names:
+        payload.pop("default_role", None)
+        changed = True
+
+    if not changed:
+        return warnings
+
+    payload["mappings"] = new_mappings
+    new_text = yaml.safe_dump(payload, sort_keys=False)
+    _print_apply_step(
+        f"detach sso mappings for {', '.join(sorted(role_names))}", verbose=verbose
+    )
+    try:
+        admin_sso_config.set(new_text)
+        print(f"  ~ sso config (detached: {', '.join(sorted(role_names))})")
+    except Exception as exc:
+        detail = format_exception(exc)
+        warnings.append(f"SSO config could not be detached: {detail}")
+        print(f"  ! sso config: {detail}", file=sys.stderr)
+    return warnings
+
+
 def reset_policy(
     title: str, current: CurrentState, *, verbose: bool = False
 ) -> list[str]:
     """Delete a managed policy and any managed roles referencing it.
 
-    After calling this, the caller should refetch state and re-run the normal
-    reconcile path, which will recreate the policy via policyCreateManaged and
-    the roles via roleCreateManaged — a different backend codepath than the
-    one that failed.
+    Removes SSO mappings to the affected roles first, since roleDeleteManaged
+    is rejected while those mappings exist. After calling this, the caller
+    should refetch state and re-run the normal reconcile path, which will
+    recreate the policy via policyCreateManaged and the roles via
+    roleCreateManaged — a different backend codepath than the one that
+    failed — and reattach SSO mappings from the desired config.
     """
     warnings: list[str] = []
-    for role_name in managed_roles_using_policy(title, current):
+    roles_to_delete = managed_roles_using_policy(title, current)
+    if roles_to_delete:
+        warnings.extend(
+            detach_sso_mappings_for_roles(set(roles_to_delete), verbose=verbose)
+        )
+    for role_name in roles_to_delete:
         try:
             _print_apply_step(f"delete role {role_name}", verbose=verbose)
             admin_roles.delete(role_name)

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -956,7 +956,11 @@ def clear_sso_config(*, verbose: bool = False) -> list[str]:
 
 
 def reset_policy(
-    title: str, current: CurrentState, *, verbose: bool = False
+    title: str,
+    current: CurrentState,
+    *,
+    verbose: bool = False,
+    already_deleted_roles: set[str] | None = None,
 ) -> tuple[list[str], list[UserRoleBinding]]:
     """Delete a managed policy and any managed roles referencing it.
 
@@ -966,10 +970,20 @@ def reset_policy(
     user role mutations while any SSO config is present. Returns
     (warnings, user_bindings_snapshot) so the caller can restore user
     assignments once the new roles exist.
+
+    In the cumulative-role model a single managed role can reference
+    multiple policies, so resetting several drifted policies in one pass
+    can ask us to delete the same role twice. Pass ``already_deleted_roles``
+    (a mutable set shared across calls) to skip roles that a prior call
+    has already handled; this function mutates the set to record the
+    roles it processes.
     """
     warnings: list[str] = []
     user_snapshot: list[UserRoleBinding] = []
-    roles_to_delete = managed_roles_using_policy(title, current)
+    deleted = already_deleted_roles if already_deleted_roles is not None else set()
+    roles_to_delete = [
+        r for r in managed_roles_using_policy(title, current) if r not in deleted
+    ]
     if roles_to_delete:
         users_to_detach = users_assigned_to_roles(set(roles_to_delete))
         if users_to_detach:
@@ -991,6 +1005,8 @@ def reset_policy(
             detail = format_exception(exc)
             warnings.append(f"Role '{role_name}' could not be deleted: {detail}")
             print(f"  ! role {role_name}: {detail}", file=sys.stderr)
+        finally:
+            deleted.add(role_name)
     try:
         _print_apply_step(f"delete policy {title}", verbose=verbose)
         admin_policies.delete(title)

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -12,6 +12,76 @@ from quiltx import stack as stack_lib
 from quiltx.config import get_catalog_config
 from quiltx.utils import get_bucket_region
 
+
+def find_profile_for_bucket(bucket: str, profiles: Sequence[str]) -> str | None:
+    """Return the first profile whose GetBucketLocation succeeds for *bucket*."""
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    for name in profiles:
+        try:
+            session = boto3.Session(profile_name=name)
+            session.client("s3").get_bucket_location(Bucket=bucket)
+        except (ClientError, BotoCoreError):
+            continue
+        return name
+    return None
+
+
+def resolve_bucket_session(
+    bucket: str,
+    profile: str | None,
+    *,
+    assume_yes: bool,
+    prompt: Any = None,
+    output: Any = None,
+) -> tuple[Any, Any, str, str | None]:
+    """Open an S3 session for *bucket*, probing other profiles if the first fails.
+
+    Returns (session, s3_client, region, resolved_profile). Session is None if
+    the user declined or no profile could access the bucket.
+    """
+    import sys as _sys
+
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    err = output if output is not None else _sys.stderr
+    ask = prompt if prompt is not None else input
+
+    session = boto3.Session(profile_name=profile)
+    s3_client = session.client("s3")
+    try:
+        region = get_bucket_region(bucket, s3_client=s3_client)
+        return session, s3_client, region, profile
+    except (ClientError, BotoCoreError) as exc:
+        print(
+            f"Profile {profile or '<default>'} cannot access bucket {bucket}: {exc}",
+            file=err,
+        )
+
+    candidates = [
+        name for name in boto3.Session().available_profiles if name != (profile or "")
+    ]
+    match = find_profile_for_bucket(bucket, candidates)
+    if match is None:
+        print(f"No other configured profile can access bucket {bucket}.", file=err)
+        return None, None, "", profile
+
+    if assume_yes:
+        print(f"Retrying with profile {match}.")
+    else:
+        response = ask(f"Try profile {match} instead? [y/N]: ").strip().lower()
+        if response not in {"y", "yes"}:
+            print("Aborted.")
+            return None, None, "", profile
+
+    new_session = boto3.Session(profile_name=match)
+    new_s3 = new_session.client("s3")
+    region = get_bucket_region(bucket, s3_client=new_s3)
+    return new_session, new_s3, region, match
+
+
 QUILT_POLICY_SID = "QuiltCrossAccountAccess"
 SNS_PUBLISH_POLICY_SID = "QuiltBucketNotifications"
 SNS_SUBSCRIBE_POLICY_SID = "QuiltCrossAccountSNSAccess"

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -209,9 +209,12 @@ def _cmd_add(args: argparse.Namespace) -> int:
         control_region = _stack_payload_value(stack_payload, "region", "unknown")
         catalog_url = str(config.get("navigator_url") or catalog_name)
 
-        session = boto3.Session(profile_name=args.profile)
-        s3_client = session.client("s3")
-        bucket_region = get_bucket_region(args.bucket_name, s3_client=s3_client)
+        session, s3_client, bucket_region, resolved_profile = _resolve_bucket_session(
+            args.bucket_name, args.profile, assume_yes=args.yes
+        )
+        if session is None:
+            return 1
+        args.profile = resolved_profile
         sns_client = session.client("sns", region_name=bucket_region)
 
         from quilt3.admin import buckets as admin_buckets
@@ -383,6 +386,51 @@ def _cmd_profile(args: argparse.Namespace) -> int:
         return 1
     print(match)
     return 0
+
+
+def _resolve_bucket_session(
+    bucket: str, profile: str | None, *, assume_yes: bool
+) -> tuple[boto3.Session | None, Any, str, str | None]:
+    """Open an S3 session for the bucket, probing other profiles if the first fails.
+
+    Returns (session, s3_client, region, profile_name) or (None, ...) if aborted.
+    """
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    session = boto3.Session(profile_name=profile)
+    s3_client = session.client("s3")
+    try:
+        region = get_bucket_region(bucket, s3_client=s3_client)
+        return session, s3_client, region, profile
+    except (ClientError, BotoCoreError) as exc:
+        print(
+            f"Profile {profile or '<default>'} cannot access bucket {bucket}: {exc}",
+            file=sys.stderr,
+        )
+
+    candidates = [
+        name for name in boto3.Session().available_profiles if name != (profile or "")
+    ]
+    match = _find_profile_for_bucket(bucket, candidates)
+    if match is None:
+        print(
+            f"No other configured profile can access bucket {bucket}.",
+            file=sys.stderr,
+        )
+        return None, None, "", profile
+
+    if assume_yes:
+        print(f"Retrying with profile {match}.")
+    else:
+        response = input(f"Try profile {match} instead? [y/N]: ").strip().lower()
+        if response not in {"y", "yes"}:
+            print("Aborted.")
+            return None, None, "", profile
+
+    new_session = boto3.Session(profile_name=match)
+    new_s3 = new_session.client("s3")
+    region = get_bucket_region(bucket, s3_client=new_s3)
+    return new_session, new_s3, region, match
 
 
 def _find_profile_for_bucket(bucket: str, profiles: list[str]) -> str | None:

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -203,10 +203,18 @@ def _cmd_add(args: argparse.Namespace) -> int:
 
         existing_bucket = admin_buckets.get(args.bucket_name)
         if existing_bucket is not None:
-            print(f"Bucket {args.bucket_name} is already registered.")
+            print(
+                f"Bucket {args.bucket_name} is already registered in Quilt; "
+                f"skipping S3 bucket policy, SNS notification, and "
+                f"cross-account principal grants — none of those were "
+                f"reapplied on this run."
+            )
             if args.no_test:
                 return 0
-            return _verify_bucket_registration_and_access(args.bucket_name)
+            return _verify_bucket_registration_and_access(
+                args.bucket_name,
+                control_account_id=control_account_id,
+            )
 
         bucket_policy = bucket_lib.get_bucket_policy(
             args.bucket_name, s3_client=s3_client
@@ -341,7 +349,9 @@ def _cmd_test(args: argparse.Namespace) -> int:
 
 
 @auto_login
-def _verify_bucket_registration_and_access(bucket_name: str) -> int:
+def _verify_bucket_registration_and_access(
+    bucket_name: str, *, control_account_id: str | None = None
+) -> int:
     import quilt3
     from quilt3.admin import buckets as admin_buckets
 
@@ -364,8 +374,16 @@ def _verify_bucket_registration_and_access(bucket_name: str) -> int:
     except Exception as exc:
         if "Authentication failed" in str(exc):
             raise
+        principal = (
+            f"arn:aws:iam::{control_account_id}:root"
+            if control_account_id
+            else "the control account"
+        )
         print(
-            f"Control account cannot read {bucket_uri}: {exc}",
+            f"Bucket {bucket_name} is registered in Quilt, but its S3 "
+            f"bucket policy does not grant {principal} access: {exc}. "
+            f"Until that grant is in place, managed Quilt roles referencing "
+            f"this bucket will be silently dropped by the catalog.",
             file=sys.stderr,
         )
         return 1

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -353,12 +353,12 @@ def _verify_bucket_registration_and_access(bucket_name: str) -> int:
         )
         if registered is None:
             raise ValueError(f"{bucket_name} is not registered in Quilt")
-        print(f"OK: {bucket_name} is registered in Quilt as {registered.title}")
 
         b = quilt3.Bucket(bucket_uri)
         # ls() goes through the control account — if the cross-account
         # bucket policy is wrong, this raises AccessDenied.
         list(b.ls())
+        print(f"OK: {bucket_name} is registered in Quilt as {registered.title}")
         print(f"OK: control account can read {bucket_uri}")
         return 0
     except Exception as exc:

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -77,6 +77,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="List buckets registered in the catalog.",
     )
 
+    profile_parser = subparsers.add_parser(
+        "profile",
+        prog="quiltx bucket profile",
+        help=(
+            "List available AWS profiles, or find which profile can access a bucket."
+        ),
+    )
+    profile_parser.add_argument(
+        "bucket_name",
+        nargs="?",
+        help="If given, find the first AWS profile that can access this bucket.",
+    )
+
     test_parser = subparsers.add_parser(
         "test",
         prog="quiltx bucket test",
@@ -95,6 +108,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_add(args)
     if args.action == "list":
         return _cmd_list()
+    if args.action == "profile":
+        return _cmd_profile(args)
     if args.action == "test":
         return _cmd_test(args)
 
@@ -346,6 +361,41 @@ def _cmd_list() -> int:
             raise
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+
+
+def _cmd_profile(args: argparse.Namespace) -> int:
+    profiles = list(boto3.Session().available_profiles)
+    if not profiles:
+        print("No AWS profiles found.", file=sys.stderr)
+        return 1
+
+    if args.bucket_name is None:
+        for name in profiles:
+            print(name)
+        return 0
+
+    match = _find_profile_for_bucket(args.bucket_name, profiles)
+    if match is None:
+        print(
+            f"No configured profile can access bucket {args.bucket_name!r}.",
+            file=sys.stderr,
+        )
+        return 1
+    print(match)
+    return 0
+
+
+def _find_profile_for_bucket(bucket: str, profiles: list[str]) -> str | None:
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    for name in profiles:
+        try:
+            session = boto3.Session(profile_name=name)
+            session.client("s3").get_bucket_location(Bucket=bucket)
+        except (ClientError, BotoCoreError):
+            continue
+        return name
+    return None
 
 
 def _cmd_test(args: argparse.Namespace) -> int:

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -209,8 +209,10 @@ def _cmd_add(args: argparse.Namespace) -> int:
         control_region = _stack_payload_value(stack_payload, "region", "unknown")
         catalog_url = str(config.get("navigator_url") or catalog_name)
 
-        session, s3_client, bucket_region, resolved_profile = _resolve_bucket_session(
-            args.bucket_name, args.profile, assume_yes=args.yes
+        session, s3_client, bucket_region, resolved_profile = (
+            bucket_lib.resolve_bucket_session(
+                args.bucket_name, args.profile, assume_yes=args.yes
+            )
         )
         if session is None:
             return 1
@@ -377,7 +379,7 @@ def _cmd_profile(args: argparse.Namespace) -> int:
             print(name)
         return 0
 
-    match = _find_profile_for_bucket(args.bucket_name, profiles)
+    match = bucket_lib.find_profile_for_bucket(args.bucket_name, profiles)
     if match is None:
         print(
             f"No configured profile can access bucket {args.bucket_name!r}.",
@@ -386,64 +388,6 @@ def _cmd_profile(args: argparse.Namespace) -> int:
         return 1
     print(match)
     return 0
-
-
-def _resolve_bucket_session(
-    bucket: str, profile: str | None, *, assume_yes: bool
-) -> tuple[boto3.Session | None, Any, str, str | None]:
-    """Open an S3 session for the bucket, probing other profiles if the first fails.
-
-    Returns (session, s3_client, region, profile_name) or (None, ...) if aborted.
-    """
-    from botocore.exceptions import BotoCoreError, ClientError
-
-    session = boto3.Session(profile_name=profile)
-    s3_client = session.client("s3")
-    try:
-        region = get_bucket_region(bucket, s3_client=s3_client)
-        return session, s3_client, region, profile
-    except (ClientError, BotoCoreError) as exc:
-        print(
-            f"Profile {profile or '<default>'} cannot access bucket {bucket}: {exc}",
-            file=sys.stderr,
-        )
-
-    candidates = [
-        name for name in boto3.Session().available_profiles if name != (profile or "")
-    ]
-    match = _find_profile_for_bucket(bucket, candidates)
-    if match is None:
-        print(
-            f"No other configured profile can access bucket {bucket}.",
-            file=sys.stderr,
-        )
-        return None, None, "", profile
-
-    if assume_yes:
-        print(f"Retrying with profile {match}.")
-    else:
-        response = input(f"Try profile {match} instead? [y/N]: ").strip().lower()
-        if response not in {"y", "yes"}:
-            print("Aborted.")
-            return None, None, "", profile
-
-    new_session = boto3.Session(profile_name=match)
-    new_s3 = new_session.client("s3")
-    region = get_bucket_region(bucket, s3_client=new_s3)
-    return new_session, new_s3, region, match
-
-
-def _find_profile_for_bucket(bucket: str, profiles: list[str]) -> str | None:
-    from botocore.exceptions import BotoCoreError, ClientError
-
-    for name in profiles:
-        try:
-            session = boto3.Session(profile_name=name)
-            session.client("s3").get_bucket_location(Bucket=bucket)
-        except (ClientError, BotoCoreError):
-            continue
-        return name
-    return None
 
 
 def _cmd_test(args: argparse.Namespace) -> int:

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -421,17 +421,16 @@ def _verify_bucket_registration_and_access(
     except Exception as exc:
         if "Authentication failed" in str(exc):
             raise
-        owner_line = (
-            f"  - S3 bucket owner account: {control_account_id} "
-            "(same as control account)"
+        control_line = (
+            f"  - Quilt control account: {control_account_id}"
             if control_account_id
-            else "  - S3 bucket owner account: unknown"
+            else "  - Quilt control account: unknown"
         )
         registered_tag = "yes" if registered is not None else "no"
         lines = [
             f"Bucket {bucket_name}: ls() via control account failed.",
             f"  - registered in Quilt: {registered_tag}",
-            owner_line,
+            control_line,
             f"  - ls() error: {exc}",
             "  - likely cause: no managed Quilt policy currently grants "
             "the control-account role s3 access to this bucket",

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -204,11 +204,12 @@ def _cmd_add(args: argparse.Namespace) -> int:
         existing_bucket = admin_buckets.get(args.bucket_name)
         if existing_bucket is not None:
             print(
-                f"Bucket {args.bucket_name} is already registered in Quilt; "
-                f"skipping S3 bucket policy, SNS notification, and "
-                f"cross-account principal grants — none of those were "
-                f"reapplied on this run."
+                f"Bucket {args.bucket_name}: already registered in Quilt; "
+                "nothing reapplied."
             )
+            print("  - skipped: S3 bucket policy")
+            print("  - skipped: SNS notification")
+            print("  - skipped: cross-account principal grants")
             if args.no_test:
                 return 0
             return _verify_bucket_registration_and_access(
@@ -308,7 +309,10 @@ def _cmd_add(args: argparse.Namespace) -> int:
             )
             return 0
         print()
-        return _verify_bucket_registration_and_access(args.bucket_name)
+        return _verify_bucket_registration_and_access(
+            args.bucket_name,
+            control_account_id=control_account_id,
+        )
     except Exception as exc:
         if "Authentication failed" in str(exc):
             raise
@@ -356,6 +360,7 @@ def _verify_bucket_registration_and_access(
     from quilt3.admin import buckets as admin_buckets
 
     bucket_uri = f"s3://{bucket_name}"
+    registered = None
     try:
         registered = next(
             (bucket for bucket in admin_buckets.list() if bucket.name == bucket_name),
@@ -374,18 +379,22 @@ def _verify_bucket_registration_and_access(
     except Exception as exc:
         if "Authentication failed" in str(exc):
             raise
-        principal = (
-            f"arn:aws:iam::{control_account_id}:root"
+        owner_line = (
+            f"  - S3 bucket owner account: {control_account_id} "
+            "(same as control account)"
             if control_account_id
-            else "the control account"
+            else "  - S3 bucket owner account: unknown"
         )
-        print(
-            f"Bucket {bucket_name} is registered in Quilt, but its S3 "
-            f"bucket policy does not grant {principal} access: {exc}. "
-            f"Until that grant is in place, managed Quilt roles referencing "
-            f"this bucket will be silently dropped by the catalog.",
-            file=sys.stderr,
-        )
+        registered_tag = "yes" if registered is not None else "no"
+        lines = [
+            f"Bucket {bucket_name}: ls() via control account failed.",
+            f"  - registered in Quilt: {registered_tag}",
+            owner_line,
+            f"  - ls() error: {exc}",
+            "  - likely cause: no managed Quilt policy currently grants "
+            "the control-account role s3 access to this bucket",
+        ]
+        print("\n".join(lines), file=sys.stderr)
         return 1
 
 

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -84,6 +84,15 @@ def main(argv: list[str] | None = None) -> int:
 
         print("Applying...")
         warnings = acl_lib.apply_acl(diff, current, verbose=args.verbose)
+
+        post_current = acl_lib.fetch_current_state()
+        drift = acl_lib.detect_policy_drift(desired, post_current)
+        if drift:
+            reset_warnings, post_current = _handle_policy_drift(
+                drift, desired, post_current, auto=args.yes, verbose=args.verbose
+            )
+            warnings.extend(reset_warnings)
+
         for warning in warnings:
             print(f"Warning: {warning}", file=sys.stderr)
         if warnings:
@@ -104,6 +113,76 @@ def main(argv: list[str] | None = None) -> int:
 
 def _confirm_apply() -> bool:
     return input("Apply ACL changes? [y/N]: ").strip().lower() in {"y", "yes"}
+
+
+def _handle_policy_drift(
+    drift: list[acl_lib.PolicyDrift],
+    desired: acl_lib.AclConfig,
+    current: acl_lib.CurrentState,
+    *,
+    auto: bool,
+    verbose: bool,
+) -> tuple[list[str], acl_lib.CurrentState]:
+    """Prompt for (or auto-apply) policy resets when server state has drifted.
+
+    Always-on detection: any managed policy whose server state differs from
+    the desired config is a candidate for delete+recreate via the create
+    codepath, which bypasses bugs on the update codepath.
+    """
+    warnings: list[str] = []
+    print(
+        f"Detected {len(drift)} managed polic"
+        f"{'y' if len(drift) == 1 else 'ies'} that did not reach the "
+        f"desired state after apply.",
+        file=sys.stderr,
+    )
+    to_reset: list[str] = []
+    for item in drift:
+        affected_roles = acl_lib.managed_roles_using_policy(item.title, current)
+        print(f"  policy {item.title}:", file=sys.stderr)
+        if item.missing:
+            print(f"    missing on server: {', '.join(item.missing)}", file=sys.stderr)
+        if item.extra:
+            print(f"    extra on server:   {', '.join(item.extra)}", file=sys.stderr)
+        if affected_roles:
+            print(
+                f"    reset would delete+recreate roles: "
+                f"{', '.join(affected_roles)}",
+                file=sys.stderr,
+            )
+        if auto:
+            print("    auto-reset: yes (--yes)", file=sys.stderr)
+            to_reset.append(item.title)
+        else:
+            answer = input(f"  Reset policy {item.title}? [y/N]: ").strip().lower()
+            if answer in {"y", "yes"}:
+                to_reset.append(item.title)
+            else:
+                warnings.append(
+                    f"Policy '{item.title}' left in drifted state (user declined reset)"
+                )
+
+    if not to_reset:
+        return warnings, current
+
+    print("Resetting drifted policies...")
+    for title in to_reset:
+        warnings.extend(acl_lib.reset_policy(title, current, verbose=verbose))
+
+    post_reset = acl_lib.fetch_current_state()
+    new_diff = acl_lib.compute_diff(desired, post_reset)
+    if new_diff.has_changes():
+        print("Reapplying after reset...")
+        warnings.extend(acl_lib.apply_acl(new_diff, post_reset, verbose=verbose))
+        post_reset = acl_lib.fetch_current_state()
+
+    residual = acl_lib.detect_policy_drift(desired, post_reset)
+    for item in residual:
+        warnings.append(
+            f"Policy '{item.title}' still drifted after reset: "
+            f"missing={item.missing or '[]'} extra={item.extra or '[]'}"
+        )
+    return warnings, post_reset
 
 
 def _format_exception_details(exc: Exception) -> list[str]:

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -83,7 +83,9 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
         print("Applying...")
-        warnings = acl_lib.apply_acl(diff, current, verbose=args.verbose)
+        warnings = acl_lib.apply_acl(
+            diff, current, verbose=args.verbose, assume_yes=args.yes
+        )
 
         post_current = acl_lib.fetch_current_state()
         drift = acl_lib.detect_policy_drift(desired, post_current)
@@ -198,7 +200,9 @@ def _handle_policy_drift(
     new_diff = acl_lib.compute_diff(desired, post_reset)
     if new_diff.has_changes():
         print("Reapplying after reset...")
-        warnings.extend(acl_lib.apply_acl(new_diff, post_reset, verbose=verbose))
+        warnings.extend(
+            acl_lib.apply_acl(new_diff, post_reset, verbose=verbose, assume_yes=auto)
+        )
         post_reset = acl_lib.fetch_current_state()
 
     if user_snapshots:

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -191,8 +191,14 @@ def _handle_policy_drift(
 
     print("Resetting drifted policies...")
     user_snapshots: list[acl_lib.UserRoleBinding] = []
+    deleted_roles: set[str] = set()
     for title in to_reset:
-        reset_warnings, snap = acl_lib.reset_policy(title, current, verbose=verbose)
+        reset_warnings, snap = acl_lib.reset_policy(
+            title,
+            current,
+            verbose=verbose,
+            already_deleted_roles=deleted_roles,
+        )
         warnings.extend(reset_warnings)
         user_snapshots.extend(snap)
 

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -137,8 +137,10 @@ def _handle_policy_drift(
         file=sys.stderr,
     )
     to_reset: list[str] = []
+    all_affected_roles: set[str] = set()
     for item in drift:
         affected_roles = acl_lib.managed_roles_using_policy(item.title, current)
+        all_affected_roles.update(affected_roles)
         print(f"  policy {item.title}:", file=sys.stderr)
         if item.missing:
             print(f"    missing on server: {', '.join(item.missing)}", file=sys.stderr)
@@ -165,9 +167,32 @@ def _handle_policy_drift(
     if not to_reset:
         return warnings, current
 
+    affected_users = acl_lib.users_assigned_to_roles(all_affected_roles)
+    if affected_users:
+        print(
+            "WARNING: the following users will be temporarily reassigned "
+            "to the default role while their roles are recreated:",
+            file=sys.stderr,
+        )
+        for binding in affected_users:
+            primary = binding.primary or "(none)"
+            extras = ", ".join(binding.extras) if binding.extras else "(none)"
+            print(
+                f"  - {binding.user_name}: primary={primary} extras={extras}",
+                file=sys.stderr,
+            )
+        print(
+            "  If you are one of these users, your active session may need "
+            "to re-authenticate after the reset completes.",
+            file=sys.stderr,
+        )
+
     print("Resetting drifted policies...")
+    user_snapshots: list[acl_lib.UserRoleBinding] = []
     for title in to_reset:
-        warnings.extend(acl_lib.reset_policy(title, current, verbose=verbose))
+        reset_warnings, snap = acl_lib.reset_policy(title, current, verbose=verbose)
+        warnings.extend(reset_warnings)
+        user_snapshots.extend(snap)
 
     post_reset = acl_lib.fetch_current_state()
     new_diff = acl_lib.compute_diff(desired, post_reset)
@@ -175,6 +200,12 @@ def _handle_policy_drift(
         print("Reapplying after reset...")
         warnings.extend(acl_lib.apply_acl(new_diff, post_reset, verbose=verbose))
         post_reset = acl_lib.fetch_current_state()
+
+    if user_snapshots:
+        print("Restoring user role bindings...")
+        warnings.extend(
+            acl_lib.restore_user_role_bindings(user_snapshots, verbose=verbose)
+        )
 
     residual = acl_lib.detect_policy_drift(desired, post_reset)
     for item in residual:

--- a/quiltx/tools/stack/acl.py
+++ b/quiltx/tools/stack/acl.py
@@ -86,6 +86,9 @@ def main(argv: list[str] | None = None) -> int:
         warnings = acl_lib.apply_acl(diff, current, verbose=args.verbose)
         for warning in warnings:
             print(f"Warning: {warning}", file=sys.stderr)
+        if warnings:
+            print(f"Done with {len(warnings)} warning(s).", file=sys.stderr)
+            return 1
         print("Done.")
         return 0
     except Exception as exc:

--- a/spec/060-stack-acl/simpler-stack-acl.yml
+++ b/spec/060-stack-acl/simpler-stack-acl.yml
@@ -25,7 +25,7 @@ policies:
   internal:
     sso.groups:         [Employees]
     buckets.read_write: [quilt-bake, quilt-dev]
-    buckets.read:       [quilt-leadership]
+    buckets.read:       [quilt-leadership, udp-spec]
 
 ## Roles
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -69,18 +69,6 @@ def test_parse_acl_config_accepts_simpler_stack_acl_example() -> None:
     assert config.roles["exec"].is_admin is True
 
 
-def test_parse_acl_config_rejects_old_format_keys(tmp_path: Path) -> None:
-    config_path = tmp_path / "acl.yml"
-    config_path.write_text("""
-bucket_policies: {}
-roles: {}
-sso: []
-""")
-
-    with pytest.raises(ValueError, match="old stack ACL format"):
-        acl.parse_acl_config(config_path)
-
-
 def test_parse_acl_config_rejects_unknown_top_level_keys(tmp_path: Path) -> None:
     config_path = tmp_path / "acl.yml"
     config_path.write_text("""

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -261,6 +261,7 @@ def test_compute_diff_from_simpler_stack_acl_example_against_empty_state() -> No
         "quilt-dev",
         "quilt-example",
         "quilt-leadership",
+        "udp-spec",
     ]
     assert [policy.title for policy in diff.policies_to_create] == [
         "public",

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -497,6 +497,11 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         return SimpleNamespace(text=text)
 
     monkeypatch.setattr(acl, "admin_buckets", SimpleNamespace(add=bucket_add))
+    # Force the simple (non-cross-account) bucket add path in apply_acl.
+    monkeypatch.setattr(
+        "quiltx.config.get_catalog_config",
+        lambda: (_ for _ in ()).throw(RuntimeError("no config in test")),
+    )
     monkeypatch.setattr(
         acl,
         "admin_policies",
@@ -554,6 +559,36 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         ("role_delete", "legacy_role"),
         ("policy_delete", "legacy_policy"),
     ]
+
+
+def test_apply_acl_uses_cross_account_registration_when_stack_available(
+    monkeypatch,
+) -> None:
+    """When a control account is available, apply_acl goes through the full
+    cross-account bucket registration path (including profile retry)."""
+    calls: list[tuple[Any, ...]] = []
+
+    def fake_register(
+        bucket: str, control_account_id: str, *, assume_yes: bool
+    ) -> None:
+        calls.append(("register", bucket, control_account_id, assume_yes))
+
+    monkeypatch.setattr(acl, "_register_bucket_with_retry", fake_register)
+    monkeypatch.setattr(
+        acl, "admin_buckets", SimpleNamespace(add=lambda *a, **kw: None)
+    )
+    monkeypatch.setattr(
+        "quiltx.config.get_catalog_config", lambda: {"navigator_url": "https://x"}
+    )
+    monkeypatch.setattr("quiltx.stack.extract_catalog_name", lambda _config: "catalog")
+    monkeypatch.setattr(
+        "quiltx.stack.load_stack_payload", lambda _name: {"account_id": "111"}
+    )
+
+    diff = acl.AclDiff(buckets_to_add=["bucket-a"])
+    acl.apply_acl(diff, _empty_current_state(), assume_yes=True)
+
+    assert calls == [("register", "bucket-a", "111", True)]
 
 
 def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1369,6 +1369,75 @@ def test_cmd_profile_finds_profile_for_bucket(monkeypatch, capsys) -> None:
     assert calls == ["sales", "open", "prod"]
 
 
+def test_resolve_bucket_session_switches_on_access_denied(monkeypatch, capsys) -> None:
+    from botocore.exceptions import ClientError
+
+    class FakeS3:
+        def __init__(self, profile: str) -> None:
+            self.profile = profile
+
+        def get_bucket_location(self, Bucket: str) -> dict:
+            if self.profile == "prod":
+                return {"LocationConstraint": None}
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetBucketLocation",
+            )
+
+    class FakeSession:
+        available_profiles = ["sales", "prod"]
+
+        def __init__(self, profile_name: str | None = None) -> None:
+            self.profile_name = profile_name or ""
+
+        def client(self, service: str, region_name: str | None = None):
+            return FakeS3(self.profile_name)
+
+    monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
+
+    session, s3_client, region, profile = bucket_tool._resolve_bucket_session(
+        "quilt-example", "sales", assume_yes=True
+    )
+    assert profile == "prod"
+    assert region == "us-east-1"
+    assert isinstance(session, FakeSession)
+    assert session.profile_name == "prod"
+
+
+def test_resolve_bucket_session_aborts_when_user_declines(monkeypatch, capsys) -> None:
+    from botocore.exceptions import ClientError
+
+    class FakeS3:
+        def __init__(self, profile: str) -> None:
+            self.profile = profile
+
+        def get_bucket_location(self, Bucket: str) -> dict:
+            if self.profile == "prod":
+                return {"LocationConstraint": None}
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetBucketLocation",
+            )
+
+    class FakeSession:
+        available_profiles = ["sales", "prod"]
+
+        def __init__(self, profile_name: str | None = None) -> None:
+            self.profile_name = profile_name or ""
+
+        def client(self, service: str, region_name: str | None = None):
+            return FakeS3(self.profile_name)
+
+    monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    session, _s3, _region, profile = bucket_tool._resolve_bucket_session(
+        "quilt-example", "sales", assume_yes=False
+    )
+    assert session is None
+    assert profile == "sales"
+
+
 def test_cmd_profile_no_matching_profile(monkeypatch, capsys) -> None:
     from botocore.exceptions import ClientError
 

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1395,7 +1395,7 @@ def test_resolve_bucket_session_switches_on_access_denied(monkeypatch, capsys) -
 
     monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
 
-    session, s3_client, region, profile = bucket_tool._resolve_bucket_session(
+    session, s3_client, region, profile = bucket_lib.resolve_bucket_session(
         "quilt-example", "sales", assume_yes=True
     )
     assert profile == "prod"
@@ -1431,7 +1431,7 @@ def test_resolve_bucket_session_aborts_when_user_declines(monkeypatch, capsys) -
     monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
     monkeypatch.setattr("builtins.input", lambda _prompt: "n")
 
-    session, _s3, _region, profile = bucket_tool._resolve_bucket_session(
+    session, _s3, _region, profile = bucket_lib.resolve_bucket_session(
         "quilt-example", "sales", assume_yes=False
     )
     assert session is None

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1313,3 +1313,81 @@ def test_cmd_add_principal_rejects_non_arn(monkeypatch, capsys) -> None:
     assert bucket_tool.main(["add", "bucket", "--principal", "not-an-arn"]) == 1
     captured = capsys.readouterr()
     assert "must be an IAM role ARN" in captured.err
+
+
+def test_cmd_profile_lists_profiles(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        bucket_tool.boto3,
+        "Session",
+        lambda *a, **kw: SimpleNamespace(available_profiles=["sales", "open", "prod"]),
+    )
+    assert bucket_tool.main(["profile"]) == 0
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["sales", "open", "prod"]
+
+
+def test_cmd_profile_no_profiles(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        bucket_tool.boto3,
+        "Session",
+        lambda *a, **kw: SimpleNamespace(available_profiles=[]),
+    )
+    assert bucket_tool.main(["profile"]) == 1
+    assert "No AWS profiles" in capsys.readouterr().err
+
+
+def test_cmd_profile_finds_profile_for_bucket(monkeypatch, capsys) -> None:
+    from botocore.exceptions import ClientError
+
+    calls: list[str] = []
+
+    class FakeS3:
+        def __init__(self, profile: str) -> None:
+            self.profile = profile
+
+        def get_bucket_location(self, Bucket: str) -> dict:
+            calls.append(self.profile)
+            if self.profile == "prod":
+                return {"LocationConstraint": None}
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetBucketLocation",
+            )
+
+    class FakeSession:
+        def __init__(self, profile_name: str | None = None) -> None:
+            self.profile_name = profile_name
+
+        available_profiles = ["sales", "open", "prod"]
+
+        def client(self, service: str):
+            return FakeS3(self.profile_name or "")
+
+    monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
+    assert bucket_tool.main(["profile", "quilt-example"]) == 0
+    assert capsys.readouterr().out.strip() == "prod"
+    assert calls == ["sales", "open", "prod"]
+
+
+def test_cmd_profile_no_matching_profile(monkeypatch, capsys) -> None:
+    from botocore.exceptions import ClientError
+
+    class FakeS3:
+        def get_bucket_location(self, Bucket: str) -> dict:
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetBucketLocation",
+            )
+
+    class FakeSession:
+        def __init__(self, profile_name: str | None = None) -> None:
+            pass
+
+        available_profiles = ["sales", "open"]
+
+        def client(self, service: str):
+            return FakeS3()
+
+    monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
+    assert bucket_tool.main(["profile", "nope"]) == 1
+    assert "No configured profile" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- Post-apply drift detection for every managed policy in the ACL YAML; auto-reset (delete + recreate via the create codepath) with `--yes`, otherwise prompt per policy. Motivating backend bug: [enterprise#1044](https://github.com/quiltdata/enterprise/issues/1044).
- Always-on permission round-trip check on `policyUpdateManaged`: if the mutation claims success but the returned permissions are a subset of what was sent, warn and exit 1 instead of printing "Done." and exit 0.
- Clearer `quiltx bucket add` output: bullet-form state when the bucket is already registered (enumerates which subsystems were skipped) and a bullet-form `ls()` failure report (registration state, S3 bucket owner account, raw ls error, likely cause).
- Bumped to 0.10.0 (minor: user-visible CLI behavior change — new warnings, new exit codes, new interactive prompt flow).

## Test plan
- [x] `uv run pytest` (133 passed, 1 skipped)
- [x] Exercised `quiltx stack acl simpler-stack-acl.yml --yes` against `tf-dev-unstable` (`unstable.dev.quilttest.com`): drift on the `internal` policy was detected, auto-reset was attempted, the catalog's 500 on every downstream call was surfaced as explicit residual-drift warnings, exit 1.
- [x] `quiltx bucket add udp-spec --yes` on a re-registered bucket: bullet diagnostics render with `control_account_id` when available; bucket creation path verified end-to-end (catalog registration + SNS wiring).
- [ ] Follow-up: once [enterprise#1044](https://github.com/quiltdata/enterprise/issues/1044) is fixed, re-run against the same stack to confirm the auto-reset path recreates `internal` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces post-apply drift detection for managed ACL policies (delete + recreate via the create codepath), a dropped-permission round-trip check on every policy create/update, richer `bucket add` diagnostics, and bumps the version to 0.10.0.

- **P1**: In `_handle_policy_drift`, the `to_reset` loop calls `reset_policy(title, current, …)` with a single pre-loop snapshot of `current`. Because roles in this codebase are cumulative (role `public+internal` references both `public` and `internal`), `managed_roles_using_policy` returns the same shared role for multiple drifted policies. The second deletion attempt catches a \"not found\" error and appends a spurious `\"Role '…' could not be deleted\"` warning, making a successful reset look partially broken.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the caveat that simultaneous multi-policy drift will emit spurious role-deletion warnings.

One P1 defect: duplicate role deletion in the reset loop produces misleading warnings when two or more policies that share cumulative roles are both drifted. No data loss results, but the operator sees false failure signals. All other findings are P2 or cosmetic.

quiltx/tools/stack/acl.py (_handle_policy_drift to_reset loop) and quiltx/acl.py (reset_policy)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds dropped-permission detection after create/update, plus new PolicyDrift, detect_policy_drift, managed_roles_using_policy, reset_policy functions; _dropped_permissions helper is correct, but reset_policy can be called redundantly on shared roles when multiple drifted policies are reset in one pass. |
| quiltx/tools/stack/acl.py | Adds post-apply drift detection and _handle_policy_drift with auto/interactive reset; the stale current snapshot used across the to_reset loop causes duplicate role-delete attempts and spurious warnings when multiple policies share cumulative roles. |
| quiltx/tools/bucket.py | Improves bucket add UX with bullet-form already-registered state and richer ls() failure diagnostics; control_account_id label may mislead in cross-account setups but is cosmetic. |
| tests/test_acl.py | Adds udp-spec bucket to the expected buckets_to_add list; minimal but correct update matching the spec change. |
| quiltx/_version.py | Version bump to 0.10.0; consistent with pyproject.toml and uv.lock. |
| spec/060-stack-acl/simpler-stack-acl.yml | Adds udp-spec to internal policy's buckets.read list; aligns with the test update. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[quiltx stack acl config.yml] --> B[fetch_current_state]
    B --> C[compute_diff]
    C -->|has_changes| D{dry_run?}
    D -->|yes| Z[exit 0]
    D -->|no| E{confirmed?}
    E -->|no| F[Aborted exit 1]
    E -->|yes| G[apply_acl\ndropped-permission check per policy]
    G --> H[fetch_current_state post-apply]
    H --> I[detect_policy_drift]
    I -->|no drift| J{warnings?}
    I -->|drift found| K[_handle_policy_drift]
    K -->|auto/interactive| L[reset_policy x N\n⚠ shared roles deleted multiple times if N>1]
    L --> M[fetch_current_state post-reset]
    M --> N[compute_diff + apply_acl reapply]
    N --> O[fetch_current_state]
    O --> P[detect_policy_drift residual]
    P --> J
    J -->|yes| Q[Done with N warning exit 1]
    J -->|no| R[Done exit 0]
```

<sub>Reviews (1): Last reviewed commit: ["Bump version to 0.10.0"](https://github.com/quiltdata/quiltx/commit/606d2aa2e4d9ee52562e0619db8cd59db20fb86d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29326861)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->