### PR TITLE
Auto-release on merge to main (v0.10.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,37 @@ name: Publish
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: check
+        name: Check if version tag exists
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          TAG="v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG does not exist, will release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
   publish:
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -20,9 +45,19 @@ jobs:
           enable-cache: true
       - name: Build
         run: uv build
+      - name: Create and push tag
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $VERSION"
+          git push origin "$TAG"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
           files: dist/*
       - name: Publish to PyPI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,11 @@ Functions for catalog configuration and credentials. Use `from quiltx.config imp
 ## Publishing Releases
 
 1. Update `version` in [pyproject.toml](pyproject.toml) and [CHANGELOG.md](CHANGELOG.md)
-2. Run `./poe tag` to create and push git tag
-3. GitHub workflow auto-creates release and publishes to PyPI after approval
+2. Merge to `main`
 
-See [.github/workflows/publish.yml](.github/workflows/publish.yml) for workflow details.
+On each push to `main`, [.github/workflows/publish.yml](.github/workflows/publish.yml)
+checks whether a `v$VERSION` tag already exists. If not, it builds, tags, creates the
+GitHub release, and publishes to PyPI. If the tag already exists, the run is a no-op —
+so only version bumps trigger a release.
+
+`./poe tag` remains available for manual/local tagging if ever needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-04-23
+
+### Changed
+
+- Auto-release on merge to `main` when `pyproject.toml` version is bumped. The publish workflow now triggers on push to `main`, tags `v$VERSION` if the tag is new, and publishes to PyPI. No more manual `./poe tag` step. If the version tag already exists, the run is a no-op.
+
 ## [0.9.2] - 2026-04-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.10.3"
+version = "0.10.4"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- Publish workflow now triggers on push to `main` instead of tag push
- Checks for existing `v$VERSION` tag; if new, auto-tags, releases, and publishes to PyPI
- Eliminates the manual `./poe tag` step — bump version + merge = release
- Bumps to 0.10.4 to exercise the new flow

## Test plan
- [ ] Merge PR
- [ ] Confirm publish workflow runs on main, tags v0.10.4, creates GH release, publishes to PyPI
- [ ] Verify a subsequent non-bump push to main is a no-op (tag already exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the manual `./poe tag` release step with an automated workflow that triggers on every push to `main`, checks whether a `v$VERSION` tag already exists, and only builds/tags/publishes when the version is new. The version is bumped to 0.10.4 to exercise the new flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only finding is a low-probability race condition that cannot cause duplicate PyPI publishes.

All findings are P2. The race condition between check-version and publish is a theoretical edge case that only produces a noisy workflow failure (not a bad release), and it requires two near-simultaneous merges to main. Version files are consistent across pyproject.toml, _version.py, and uv.lock. Documentation is updated.

.github/workflows/publish.yml — minor race condition in the check-then-tag pattern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Workflow refactored from tag-push trigger to branch-push with idempotent version check; minor TOCTOU race condition possible on concurrent merges. |
| pyproject.toml | Version bumped from 0.10.3 to 0.10.4. |
| quiltx/_version.py | Version string updated to match pyproject.toml. |
| CHANGELOG.md | 0.10.4 entry added describing the auto-release workflow change. |
| AGENTS.md | Publishing instructions updated to reflect new auto-release flow. |
| uv.lock | Lock file version entry updated to 0.10.4. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub (main)
    participant CK as check-version job
    participant PB as publish job
    participant PyPI as PyPI

    Dev->>GH: Merge PR (version bumped)
    GH->>CK: Trigger on push to main
    CK->>GH: git rev-parse vX.Y.Z
    alt Tag does NOT exist
        CK-->>PB: should_release=true
        PB->>GH: uv build
        PB->>GH: git tag -a vX.Y.Z && git push origin vX.Y.Z
        PB->>GH: Create GitHub Release
        PB->>PyPI: Publish
    else Tag already exists
        CK-->>PB: should_release=false (job skipped)
    end
```

<sub>Reviews (1): Last reviewed commit: ["Bump version to 0.10.4"](https://github.com/quiltdata/quiltx/commit/f85500219ae85c440f92c528faabd6cb92b1deb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29495112)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->