### PR TITLE
Prevent publish race on rapid main pushes (v0.10.5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,12 @@ jobs:
           git tag -a "$TAG" -m "Release $VERSION"
           if git push origin "$TAG"; then
             echo "pushed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag push failed — likely pushed by a concurrent run. Skipping release and publish."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on remote — concurrent run won. Skipping release and publish."
             echo "pushed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag push failed for an unexpected reason." >&2
+            exit 1
           fi
       - name: Create GitHub Release
         if: steps.tag.outputs.pushed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -45,7 +49,8 @@ jobs:
           enable-cache: true
       - name: Build
         run: uv build
-      - name: Create and push tag
+      - id: tag
+        name: Create and push tag
         env:
           VERSION: ${{ needs.check-version.outputs.version }}
         run: |
@@ -53,12 +58,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $VERSION"
-          git push origin "$TAG"
+          if git push origin "$TAG"; then
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag push failed — likely pushed by a concurrent run. Skipping release and publish."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create GitHub Release
+        if: steps.tag.outputs.pushed == 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
           files: dist/*
       - name: Publish to PyPI
+        if: steps.tag.outputs.pushed == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: publish
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.5] - 2026-04-23
+
+### Fixed
+
+- Publish workflow now serializes concurrent runs on `main` via a `publish` concurrency group, and tolerates a pre-existing tag gracefully (skips GitHub release + PyPI publish steps rather than failing after `uv build`).
+
 ## [0.10.4] - 2026-04-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.10.4"
+version = "0.10.5"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
Addresses the TOCTOU race review comment on #38:
- Adds `concurrency: publish` group so back-to-back pushes to `main` serialize (second run queues, then its check-version step sees the tag and skips).
- Makes the tag-push step tolerate a pre-existing tag: emits `pushed=false`, and the GitHub release + PyPI publish steps are gated on `pushed=true`, so a losing concurrent run exits cleanly instead of failing after `uv build` or double-uploading.

## Test plan
- [ ] Merge; confirm workflow tags v0.10.5 and publishes
- [ ] (Manual) Simulate a second push while first is running — second should queue, then no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the version to 0.10.5 and hardens the publish workflow against TOCTOU races on rapid back-to-back pushes to `main`. It adds a workflow-level `concurrency: publish` group (with `cancel-in-progress: false`) so queued runs serialize, and adds a graceful fallback for tag-push failures so a losing concurrent run exits cleanly rather than failing mid-publish.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the concurrency group and tag-push guard correctly address the TOCTOU race; the one remaining note is a P2 robustness suggestion.

All findings are P2 or lower. The core logic (concurrency group + pushed output gate) is correct, and the version bump is consistent across all three files. No blocking issues.

.github/workflows/publish.yml — see P2 note on silent failure path for non-race push errors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds workflow-level concurrency group (serialize, no cancel) and a graceful tag-push fallback; minor robustness gap where non-race push failures are silently swallowed. |
| CHANGELOG.md | Adds 0.10.5 changelog entry describing the concurrency fix. |
| pyproject.toml | Version bumped from 0.10.4 to 0.10.5. |
| quiltx/_version.py | Version string bumped to 0.10.5 to match pyproject.toml. |
| uv.lock | Lock file version entry updated to 0.10.5. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([push to main]) --> B{concurrency group\n'publish' — queues if busy}
    B --> C[check-version job\nread version from pyproject.toml\ncheck if tag exists remotely]
    C --> D{should_release?}
    D -- false\ntag already exists --> E([skip — workflow exits cleanly])
    D -- true --> F[publish job\nuv build]
    F --> G[git tag -a and git push origin TAG]
    G --> H{push succeeded?}
    H -- yes\npushed=true --> I[Create GitHub Release]
    H -- no\npushed=false --> J([skip release + PyPI — exits cleanly])
    I --> K[Publish to PyPI]
    K --> L([done])
```

<sub>Reviews (1): Last reviewed commit: ["Bump version to 0.10.5"](https://github.com/quiltdata/quiltx/commit/3ddae86e309a08509834a021c50bcc05a120d4de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29496041)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->