### PR TITLE
Add quiltx bucket reindex <s3-uri> command

### DIFF
--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -132,8 +132,8 @@ def build_parser() -> argparse.ArgumentParser:
         "s3_uri",
         help=(
             "S3 URI to reindex, e.g. 's3://my-bucket/some/prefix/'. "
-            "Use 's3://my-bucket/' to reindex the whole bucket (this still "
-            "preserves indices unless --wipe is also passed)."
+            "Use 's3://my-bucket/' to reindex the whole bucket (this wipes "
+            "and recreates the bucket's ES indices)."
         ),
     )
     reindex_parser.add_argument(
@@ -153,14 +153,6 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=10,
         help="Number of sample keys to print in --dry-run mode (default: 10).",
-    )
-    reindex_parser.add_argument(
-        "--wipe",
-        action="store_true",
-        help=(
-            "Force a wipe + recreate of the bucket's ES indices. By default a "
-            "prefix reindex leaves indices in place."
-        ),
     )
 
     return parser
@@ -282,8 +274,6 @@ def _reindex_post(bucket_name: str, prefix: str, args: argparse.Namespace) -> in
         payload: dict[str, Any] = {}
         if prefix:
             payload["prefix"] = prefix
-        if args.wipe:
-            payload["wipe"] = True
 
         http = quilt3_session.get_session()
         response = http.post(url, json=payload)

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -118,6 +118,51 @@ def build_parser() -> argparse.ArgumentParser:
     )
     test_parser.add_argument("bucket_name", help="S3 bucket name to test.")
 
+    reindex_parser = subparsers.add_parser(
+        "reindex",
+        prog="quiltx bucket reindex",
+        help=(
+            "Re-scan an S3 prefix on a registered bucket so that newly arrived "
+            "objects (added without S3 notifications) get into the search index. "
+            "Calls POST /api/admin/reindex/<bucket> with the prefix; the bucket's "
+            "existing ES indices are NOT wiped."
+        ),
+    )
+    reindex_parser.add_argument(
+        "s3_uri",
+        help=(
+            "S3 URI to reindex, e.g. 's3://my-bucket/some/prefix/'. "
+            "Use 's3://my-bucket/' to reindex the whole bucket (this still "
+            "preserves indices unless --wipe is also passed)."
+        ),
+    )
+    reindex_parser.add_argument(
+        "--profile",
+        help="AWS profile to use for the dry-run S3 listing.",
+    )
+    reindex_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "List a sample of keys under the prefix and print the count; "
+            "do NOT POST to the registry."
+        ),
+    )
+    reindex_parser.add_argument(
+        "--sample",
+        type=int,
+        default=10,
+        help="Number of sample keys to print in --dry-run mode (default: 10).",
+    )
+    reindex_parser.add_argument(
+        "--wipe",
+        action="store_true",
+        help=(
+            "Force a wipe + recreate of the bucket's ES indices. By default a "
+            "prefix reindex leaves indices in place."
+        ),
+    )
+
     return parser
 
 
@@ -135,9 +180,141 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_profile(args)
     if args.action == "test":
         return _cmd_test(args)
+    if args.action == "reindex":
+        return _cmd_reindex(args)
 
     parser.print_help()
     return 1
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse an ``s3://bucket/prefix`` URI into ``(bucket, prefix)``.
+
+    Raises ``ValueError`` for malformed input.
+    """
+    if not uri.startswith("s3://"):
+        raise ValueError(
+            f"Expected an s3:// URI, got {uri!r}. "
+            "Example: s3://my-bucket/some/prefix/"
+        )
+    rest = uri[len("s3://") :]
+    if not rest:
+        raise ValueError("S3 URI is missing a bucket name.")
+    if "/" in rest:
+        bucket, prefix = rest.split("/", 1)
+    else:
+        bucket, prefix = rest, ""
+    if not bucket:
+        raise ValueError(f"S3 URI has an empty bucket name: {uri!r}")
+    return bucket, prefix
+
+
+def _cmd_reindex(args: argparse.Namespace) -> int:
+    try:
+        bucket_name, prefix = parse_s3_uri(args.s3_uri)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        return _reindex_dry_run(bucket_name, prefix, args)
+    return _reindex_post(bucket_name, prefix, args)
+
+
+def _reindex_dry_run(bucket_name: str, prefix: str, args: argparse.Namespace) -> int:
+    """List a sample of keys under *prefix* without POSTing to the registry."""
+    try:
+        session, s3_client, _bucket_region, _resolved_profile = (
+            bucket_lib.resolve_bucket_session(
+                bucket_name,
+                args.profile,
+                assume_yes=True,
+            )
+        )
+        if session is None:
+            return 1
+
+        paginator = s3_client.get_paginator("list_object_versions")
+        sample: list[str] = []
+        seen = 0
+        sample_limit = max(0, args.sample)
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+            for entry in page.get("Versions") or []:
+                seen += 1
+                if len(sample) < sample_limit:
+                    sample.append(str(entry.get("Key", "")))
+            for entry in page.get("DeleteMarkers") or []:
+                seen += 1
+                if len(sample) < sample_limit:
+                    sample.append(str(entry.get("Key", "")) + "  (delete-marker)")
+
+        print(f"Dry-run: would reindex prefix {prefix!r} on bucket {bucket_name!r}.")
+        print(f"  Object versions found: {seen}")
+        if sample:
+            shown = min(sample_limit, len(sample))
+            print(f"  Sample keys ({shown}):")
+            for key in sample[:shown]:
+                print(f"    {key}")
+        else:
+            print("  (no object versions matched this prefix)")
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+@auto_login
+def _reindex_post(bucket_name: str, prefix: str, args: argparse.Namespace) -> int:
+    try:
+        from quilt3 import session as quilt3_session
+
+        registry_url = quilt3_session.get_registry_url()
+        if not registry_url:
+            print(
+                "Error: no Quilt registry is configured. Run `quilt3 config` first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        url = f"{registry_url.rstrip('/')}/api/admin/reindex/{bucket_name}"
+        payload: dict[str, Any] = {}
+        if prefix:
+            payload["prefix"] = prefix
+        if args.wipe:
+            payload["wipe"] = True
+
+        http = quilt3_session.get_session()
+        response = http.post(url, json=payload)
+        if response.status_code == 409:
+            print(
+                f"Error: a reindex is already in progress for "
+                f"s3://{bucket_name}/{prefix} (HTTP 409).",
+                file=sys.stderr,
+            )
+            return 1
+        if response.status_code == 404:
+            print(
+                f"Error: bucket {bucket_name!r} is not registered in this catalog.",
+                file=sys.stderr,
+            )
+            return 1
+        if not response.ok:
+            print(
+                f"Error: registry returned HTTP {response.status_code}: {response.text}",
+                file=sys.stderr,
+            )
+            return 1
+
+        target = f"s3://{bucket_name}/{prefix}" if prefix else f"s3://{bucket_name}"
+        print(f"Enqueued reindex for {target}.")
+        if not prefix:
+            print("(no prefix supplied — full bucket reindex)")
+        return 0
+    except Exception as exc:
+        if "Authentication failed" in str(exc):
+            raise
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
 
 def _ensure_stack_payload(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -255,8 +255,10 @@ def _reindex_dry_run(bucket_name: str, prefix: str, args: argparse.Namespace) ->
             print(f"  Sample keys ({shown}):")
             for key in sample[:shown]:
                 print(f"    {key}")
-        else:
+        elif seen == 0:
             print("  (no object versions matched this prefix)")
+        else:
+            print("  (--sample 0: key display suppressed)")
         return 0
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1512,17 +1512,13 @@ def test_reindex_arg_parser_defaults() -> None:
     assert args.action == "reindex"
     assert args.s3_uri == "s3://b/p/"
     assert args.dry_run is False
-    assert args.wipe is False
     assert args.sample == 10
 
 
 def test_reindex_arg_parser_flags() -> None:
     parser = bucket_tool.build_parser()
-    args = parser.parse_args(
-        ["reindex", "s3://b/p/", "--dry-run", "--sample", "3", "--wipe"]
-    )
+    args = parser.parse_args(["reindex", "s3://b/p/", "--dry-run", "--sample", "3"])
     assert args.dry_run is True
-    assert args.wipe is True
     assert args.sample == 3
 
 
@@ -1615,7 +1611,7 @@ def test_reindex_post_sends_prefix(monkeypatch, capsys) -> None:
     assert "Enqueued reindex for s3://b/some/prefix/" in out
 
 
-def test_reindex_post_with_wipe_flag(monkeypatch) -> None:
+def test_reindex_post_normalizes_registry_url_trailing_slash(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     class FakeResponse:
@@ -1638,11 +1634,10 @@ def test_reindex_post_with_wipe_flag(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
     monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
 
-    rc = bucket_tool.main(["reindex", "s3://b/p/", "--wipe"])
+    rc = bucket_tool.main(["reindex", "s3://b/p/"])
     assert rc == 0
-    # Trailing slash on registry url should be normalized.
     assert captured["url"] == "https://registry.example.com/api/admin/reindex/b"
-    assert captured["json"] == {"prefix": "p/", "wipe": True}
+    assert captured["json"] == {"prefix": "p/"}
 
 
 def test_reindex_post_no_prefix_omits_field(monkeypatch) -> None:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1696,6 +1696,30 @@ def test_reindex_post_409_returns_error(monkeypatch, capsys) -> None:
     assert "already in progress" in err
 
 
+def test_reindex_post_404_returns_error(monkeypatch, capsys) -> None:
+    class FakeResponse:
+        status_code = 404
+        ok = False
+        text = "Bucket not found"
+
+    class FakeHttpSession:
+        def post(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    fake_session_module = ModuleType("quilt3.session")
+    fake_session_module.get_registry_url = lambda: "https://registry.example.com"  # type: ignore[attr-defined]
+    fake_session_module.get_session = lambda: FakeHttpSession()  # type: ignore[attr-defined]
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
+
+    rc = bucket_tool.main(["reindex", "s3://b/p/"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not registered in this catalog" in err
+
+
 def test_reindex_rejects_non_s3_uri(capsys) -> None:
     rc = bucket_tool.main(["reindex", "https://nope.example.com/x"])
     assert rc == 2

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1463,3 +1463,241 @@ def test_cmd_profile_no_matching_profile(monkeypatch, capsys) -> None:
     monkeypatch.setattr(bucket_tool.boto3, "Session", FakeSession)
     assert bucket_tool.main(["profile", "nope"]) == 1
     assert "No configured profile" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# `quiltx bucket reindex` tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_s3_uri_full() -> None:
+    assert bucket_tool.parse_s3_uri("s3://my-bucket/some/prefix/") == (
+        "my-bucket",
+        "some/prefix/",
+    )
+
+
+def test_parse_s3_uri_bucket_only() -> None:
+    # No trailing slash => empty prefix.
+    assert bucket_tool.parse_s3_uri("s3://my-bucket") == ("my-bucket", "")
+
+
+def test_parse_s3_uri_bucket_root_with_slash() -> None:
+    assert bucket_tool.parse_s3_uri("s3://my-bucket/") == ("my-bucket", "")
+
+
+def test_parse_s3_uri_bucket_with_key() -> None:
+    assert bucket_tool.parse_s3_uri("s3://my-bucket/x") == ("my-bucket", "x")
+
+
+def test_parse_s3_uri_rejects_non_s3() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        bucket_tool.parse_s3_uri("https://example.com/foo")
+
+
+def test_parse_s3_uri_rejects_empty_bucket() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        bucket_tool.parse_s3_uri("s3://")
+    with pytest.raises(ValueError):
+        bucket_tool.parse_s3_uri("s3:///foo")
+
+
+def test_reindex_arg_parser_defaults() -> None:
+    parser = bucket_tool.build_parser()
+    args = parser.parse_args(["reindex", "s3://b/p/"])
+    assert args.action == "reindex"
+    assert args.s3_uri == "s3://b/p/"
+    assert args.dry_run is False
+    assert args.wipe is False
+    assert args.sample == 10
+
+
+def test_reindex_arg_parser_flags() -> None:
+    parser = bucket_tool.build_parser()
+    args = parser.parse_args(
+        ["reindex", "s3://b/p/", "--dry-run", "--sample", "3", "--wipe"]
+    )
+    assert args.dry_run is True
+    assert args.wipe is True
+    assert args.sample == 3
+
+
+def test_reindex_dry_run_lists_keys(monkeypatch, capsys) -> None:
+    """Dry-run lists keys via list_object_versions and does NOT POST."""
+
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_location",
+        {"LocationConstraint": "us-west-2"},
+        {"Bucket": "b"},
+    )
+    s3_stubber.add_response(
+        "list_object_versions",
+        {
+            "Versions": [
+                {"Key": "p/one", "VersionId": "v1"},
+                {"Key": "p/two", "VersionId": "v2"},
+            ],
+            "DeleteMarkers": [
+                {"Key": "p/three", "VersionId": "v3"},
+            ],
+            "IsTruncated": False,
+        },
+        {"Bucket": "b", "Prefix": "p/"},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sts_client = _client("sts", region_name="us-west-2")
+    session = FakeSession(s3_client, sns_client, sts_client)
+    monkeypatch.setattr(bucket_tool.boto3, "Session", lambda profile_name=None: session)
+
+    # Make sure we never reach the registry POST.
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("dry-run must not import quilt3.session")
+
+    fake_quilt3_session = ModuleType("quilt3.session")
+    fake_quilt3_session.get_registry_url = _boom  # type: ignore[attr-defined]
+    fake_quilt3_session.get_session = _boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_quilt3_session)
+
+    rc = bucket_tool.main(["reindex", "s3://b/p/", "--dry-run"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "Dry-run" in out
+    assert "Object versions found: 3" in out
+    assert "p/one" in out
+    assert "p/three" in out
+    assert "delete-marker" in out
+
+
+def test_reindex_post_sends_prefix(monkeypatch, capsys) -> None:
+    """Non-dry-run posts {"prefix": ...} to /api/admin/reindex/<bucket>."""
+
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        ok = True
+        text = "{}"
+
+        def json(self):
+            return {}
+
+    class FakeHttpSession:
+        def post(self, url, json=None, **_kwargs):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    fake_session_module = ModuleType("quilt3.session")
+    fake_session_module.get_registry_url = lambda: "https://registry.example.com"  # type: ignore[attr-defined]
+    fake_session_module.get_session = lambda: FakeHttpSession()  # type: ignore[attr-defined]
+
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
+
+    rc = bucket_tool.main(["reindex", "s3://b/some/prefix/"])
+    assert rc == 0
+
+    assert captured["url"] == "https://registry.example.com/api/admin/reindex/b"
+    assert captured["json"] == {"prefix": "some/prefix/"}
+
+    out = capsys.readouterr().out
+    assert "Enqueued reindex for s3://b/some/prefix/" in out
+
+
+def test_reindex_post_with_wipe_flag(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        ok = True
+        text = "{}"
+
+    class FakeHttpSession:
+        def post(self, url, json=None, **_kwargs):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    fake_session_module = ModuleType("quilt3.session")
+    fake_session_module.get_registry_url = lambda: "https://registry.example.com/"  # type: ignore[attr-defined]
+    fake_session_module.get_session = lambda: FakeHttpSession()  # type: ignore[attr-defined]
+
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
+
+    rc = bucket_tool.main(["reindex", "s3://b/p/", "--wipe"])
+    assert rc == 0
+    # Trailing slash on registry url should be normalized.
+    assert captured["url"] == "https://registry.example.com/api/admin/reindex/b"
+    assert captured["json"] == {"prefix": "p/", "wipe": True}
+
+
+def test_reindex_post_no_prefix_omits_field(monkeypatch) -> None:
+    """``s3://bucket/`` should POST an empty body (whole-bucket reindex)."""
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        ok = True
+        text = "{}"
+
+    class FakeHttpSession:
+        def post(self, url, json=None, **_kwargs):
+            captured["json"] = json
+            return FakeResponse()
+
+    fake_session_module = ModuleType("quilt3.session")
+    fake_session_module.get_registry_url = lambda: "https://registry.example.com"  # type: ignore[attr-defined]
+    fake_session_module.get_session = lambda: FakeHttpSession()  # type: ignore[attr-defined]
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
+
+    rc = bucket_tool.main(["reindex", "s3://b/"])
+    assert rc == 0
+    assert captured["json"] == {}
+
+
+def test_reindex_post_409_returns_error(monkeypatch, capsys) -> None:
+    class FakeResponse:
+        status_code = 409
+        ok = False
+        text = "Indexing already in progress."
+
+    class FakeHttpSession:
+        def post(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    fake_session_module = ModuleType("quilt3.session")
+    fake_session_module.get_registry_url = lambda: "https://registry.example.com"  # type: ignore[attr-defined]
+    fake_session_module.get_session = lambda: FakeHttpSession()  # type: ignore[attr-defined]
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session_module)
+
+    rc = bucket_tool.main(["reindex", "s3://b/p/"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already in progress" in err
+
+
+def test_reindex_rejects_non_s3_uri(capsys) -> None:
+    rc = bucket_tool.main(["reindex", "https://nope.example.com/x"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "s3://" in err


### PR DESCRIPTION
## Summary

Adds `quiltx bucket reindex <s3-uri>` to re-scan an S3 prefix on a registered bucket via the registry's `POST /api/admin/reindex/<bucket>` endpoint without wiping the bucket's Elasticsearch indices. Pairs with [enterprise#1049](https://github.com/quiltdata/enterprise/pull/1049).

Background: [02-reindex-research.md](https://nightly.quilttest.com/b/quilt-dev/packages/proj/260424-reindex-prefix/tree/latest/02-reindex-research.md).

## Behavior

- `quiltx bucket reindex s3://bucket/prefix/` POSTs `{"prefix": "prefix/"}` to `/api/admin/reindex/<bucket>`. The bucket's ES indices are preserved.
- `s3://bucket/` (no prefix) POSTs an empty body — full-bucket reindex with the historical wipe-and-recreate behavior.
- `--dry-run` lists a sample of object versions under the prefix via `list_object_versions` and prints the count, without POSTing.
- `--sample N` controls how many sample keys to print in dry-run.
- Friendly error reporting for HTTP 404 / 409 / other registry errors.

## How to test

Test stack: https://unstable2.dev.quilttest.com (registry: `https://unstable2-registry.dev.quilttest.com`). Wait for [enterprise#1049](https://github.com/quiltdata/enterprise/pull/1049) and [deployment#2396](https://github.com/quiltdata/deployment/pull/2396) to reach it, then:

```bash
# Point quilt3 at the unstable2 stack
uv run quilt3 config https://unstable2.dev.quilttest.com
uv run quilt3 login

# 1. Sanity check
uv run quiltx bucket list

# 2. Dry run on a small known prefix (no POST)
uv run quiltx bucket reindex s3://<bucket>/<known-prefix>/ --dry-run --sample 5

# 3. Real prefix reindex (preserves ES indices)
uv run quiltx bucket reindex s3://<bucket>/<known-prefix>/

# 4. Confirm enqueue
uv run python -c "
from quilt3 import session
http = session.get_session()
url = session.get_registry_url().rstrip('/') + '/api/bulk_scanner_jobs'
print(http.get(url).text)
"
```

Reference run on the prior unstable stack: [04-validation.md](https://nightly.quilttest.com/b/quilt-dev/packages/proj/260424-reindex-prefix/tree/latest/04-validation.md).

## Tests

- argument parser: defaults, `--dry-run`, `--sample`.
- `parse_s3_uri`: bucket-only, with-trailing-slash, with-prefix, rejects non-`s3://` and empty-bucket inputs.
- dry-run path: stubs `list_object_versions`, asserts sample/count output and that no registry POST is made.
- POST path: asserts URL, payload (with/without prefix, registry URL trailing-slash normalization), and 409 / 404 / non-OK response handling.

Local: `uv run pytest tests` (154 passed, 1 skipped — `integration` marker is gated behind `QUILTX_STACK_INTEGRATION=1`). `uv run black --check` and `uv run mypy quiltx tests` both clean.

## Links

- Companion enterprise PR: https://github.com/quiltdata/enterprise/pull/1049
- Companion deployment PR: https://github.com/quiltdata/deployment/pull/2396
- Test stack: https://unstable2.dev.quilttest.com