### PR TITLE
acl: fix opaque 500 from duplicate (bucket, level) permissions + diagnostics + SSO prune fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.3] - 2026-05-07
 
+### Fixed
+
+- `quiltx catalog acl`: when a policy fails to create, every role that
+  references it is also skipped — including, in single-role configs, the
+  role pointed at by `config.default_role`. The existing prune dropped
+  `default_role` from the SSO payload to avoid `RolesNotFound`, but the
+  registry's `SsoConfig` schema requires `default_role` (pydantic, no
+  default), so the SSO update then failed with
+  `config.default_role: field required`. The prune now returns `None`
+  in that case and the caller skips the SSO update entirely with a
+  clear warning; the mappings land on the next apply once the missing
+  role exists.
+
 ### Changed
 
 - `quiltx catalog acl`: when `policyCreateManaged`, `policyUpdateManaged`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `quiltx catalog acl`: dedupe `(bucket, level)` permissions when a bucket
+  appears in both `buckets.read` and `buckets.read_write`. RW implies R;
+  emitting both tripped the registry's composite PK on
+  `(role_policy_id, bucket_name)` and surfaced as an opaque 500 from
+  `policyCreateManaged`.
 - `quiltx catalog acl`: skip the SSO update when pruning would drop
   `default_role` (registry requires it). Mappings land on the next
   apply, with a warning explaining why.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-05-07
+
+### Changed
+
+- `quiltx catalog acl`: when `policyCreateManaged`, `policyUpdateManaged`,
+  or the policy delete inside `_handle_policy_drift` returns a generic
+  `Internal Server Error`, the warning now includes the desired
+  permission set we tried to send and a refetch of the policy's
+  current server-side state (id, arn, permissions, or "not present").
+  Lets a follow-up retry distinguish "create silently committed" from
+  "create truly failed" without needing registry CloudWatch access.
+
 ## [0.13.0] - 2026-05-04
 
 This release reshapes `quiltx`'s identity and auth surface around a per-catalog model and switches the stored secret from username/password+refresh-token to a single `qk_...` API key per DNS. quiltx no longer mutates the user's global `quilt3.config()` to do its work, no longer consumes `quilt3`'s `credentials.json`/`auth.json`, and no longer relies on Quilt-minted AWS session credentials — AWS calls flow through the standard boto3 chain. Scripts that referenced the old `quiltx stack ...` surface, `--catalog-name`, or `--username`/`--password` will fail at argparse time — there are no aliases (pre-1.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   current server-side state (id, arn, permissions, or "not present").
   Lets a follow-up retry distinguish "create silently committed" from
   "create truly failed" without needing registry CloudWatch access.
+  Gated on `Internal Server Error` substring — validation/auth/not-found
+  errors carry their own actionable text and do not pay the extra
+  `policies.list()` round trip.
 
 ## [0.13.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,29 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `quiltx catalog acl`: when a policy fails to create, every role that
-  references it is also skipped — including, in single-role configs, the
-  role pointed at by `config.default_role`. The existing prune dropped
-  `default_role` from the SSO payload to avoid `RolesNotFound`, but the
-  registry's `SsoConfig` schema requires `default_role` (pydantic, no
-  default), so the SSO update then failed with
-  `config.default_role: field required`. The prune now returns `None`
-  in that case and the caller skips the SSO update entirely with a
-  clear warning; the mappings land on the next apply once the missing
-  role exists.
+- `quiltx catalog acl`: skip the SSO update when pruning would drop
+  `default_role` (registry requires it). Mappings land on the next
+  apply, with a warning explaining why.
 
 ### Changed
 
-- `quiltx catalog acl`: when `policyCreateManaged`, `policyUpdateManaged`,
-  or the policy delete inside `_handle_policy_drift` returns a generic
-  `Internal Server Error`, the warning now includes the desired
-  permission set we tried to send and a refetch of the policy's
-  current server-side state (id, arn, permissions, or "not present").
-  Lets a follow-up retry distinguish "create silently committed" from
-  "create truly failed" without needing registry CloudWatch access.
-  Gated on `Internal Server Error` substring — validation/auth/not-found
-  errors carry their own actionable text and do not pay the extra
-  `policies.list()` round trip.
+- `quiltx catalog acl`: on opaque `Internal Server Error` from
+  `policyCreateManaged` / `policyUpdateManaged` / policy delete, append
+  the desired permission set and a refetch of server-side state
+  (id, arn, permissions, or "not present"). Other errors unchanged.
 
 ## [0.13.0] - 2026-05-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.13.2"
+version = "0.13.3"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -639,10 +639,17 @@ def apply_acl(
                 else ""
             )
             detail = format_exception(exc)
+            desired = _format_permissions(policy.permissions)
+            server_state = _describe_policy_state(stack, policy.title)
             warnings.append(
-                f"Policy '{policy.title}' could not be created{hint}: {detail}"
+                f"Policy '{policy.title}' could not be created{hint}: {detail} "
+                f"[desired: [{desired}]; {server_state}]"
             )
-            print(f"  ! policy {policy.title}: {detail}", file=sys.stderr)
+            print(
+                f"  ! policy {policy.title}: {detail} "
+                f"[desired: [{desired}]; {server_state}]",
+                file=sys.stderr,
+            )
             continue
         known_policies[policy.title] = created
         print(f"  + policy {policy.title}")
@@ -680,10 +687,17 @@ def apply_acl(
                 else ""
             )
             detail = format_exception(exc)
+            desired = _format_permissions(policy.permissions)
+            server_state = _describe_policy_state(stack, policy.title)
             warnings.append(
-                f"Policy '{policy.title}' could not be updated{hint}: {detail}"
+                f"Policy '{policy.title}' could not be updated{hint}: {detail} "
+                f"[desired: [{desired}]; {server_state}]"
             )
-            print(f"  ! policy {policy.title}: {detail}", file=sys.stderr)
+            print(
+                f"  ! policy {policy.title}: {detail} "
+                f"[desired: [{desired}]; {server_state}]",
+                file=sys.stderr,
+            )
             continue
         known_policies[policy.title] = updated
         print(f"  ~ policy {policy.title}")
@@ -1100,8 +1114,14 @@ def reset_policy(
         print(f"  - policy {title}")
     except Exception as exc:
         detail = format_exception(exc)
-        warnings.append(f"Policy '{title}' could not be deleted: {detail}")
-        print(f"  ! policy {title}: {detail}", file=sys.stderr)
+        server_state = _describe_policy_state(stack, title)
+        warnings.append(
+            f"Policy '{title}' could not be deleted: {detail} [{server_state}]"
+        )
+        print(
+            f"  ! policy {title}: {detail} [{server_state}]",
+            file=sys.stderr,
+        )
     return warnings, user_snapshot
 
 
@@ -1380,6 +1400,38 @@ def _dropped_permissions(
         for bucket, level in _canonical_permissions(sent)
         if (bucket, level) not in returned_set
     ]
+
+
+def _format_permissions(permissions: list[Permission]) -> str:
+    return (
+        ",".join(
+            f"{level.split('.')[-1]}:{bucket}"
+            for bucket, level in _canonical_permissions(permissions)
+        )
+        or "(none)"
+    )
+
+
+def _describe_policy_state(stack: stack_lib.Catalog, title: str) -> str:
+    """Re-fetch policy by title after a failed mutation; return a short
+    diagnostic string describing what (if anything) is on the server now.
+
+    Useful when a mutation returns a generic 500 without context: the
+    refetch tells us whether the policy actually exists, what permissions
+    it has, and what its id/arn are — turning an opaque "Internal Server
+    Error" into something we can act on the next attempt.
+    """
+    try:
+        for p in stack.admin.policies.list():
+            if getattr(p, "title", None) == title:
+                arn = getattr(p, "arn", None)
+                pid = getattr(p, "id", None)
+                perms = _format_permissions(getattr(p, "permissions", []) or [])
+                arn_part = f", arn={arn}" if arn else ""
+                return f"server now: id={pid}{arn_part}, permissions=[{perms}]"
+        return "server now: policy not present"
+    except Exception as inner:
+        return f"refetch failed: {format_exception(inner)}"
 
 
 def _same_yaml(left: str | None, right: str | None) -> bool:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -1394,10 +1394,17 @@ def _coerce_string_list(value: Any, field_name: str) -> list[str]:
 def _permissions_for_buckets(
     read: list[str], read_write: list[str]
 ) -> list[Permission]:
-    permissions = [Permission.read(bucket) for bucket in sorted(set(read))]
-    permissions.extend(
-        Permission.read_write(bucket) for bucket in sorted(set(read_write))
-    )
+    """Build the wire-level Permission list for a (read, read_write) pair.
+
+    Drops any READ entry whose bucket also appears in read_write — RW implies R,
+    and the registry's `RolePolicyBucketPermission` uses a composite primary
+    key on `(role_policy_id, bucket_name)`, so emitting two rows for the same
+    bucket trips a primary-key violation and surfaces as an opaque 500 from
+    `policyCreateManaged` / `policyUpdateManaged`.
+    """
+    rw = set(read_write)
+    permissions = [Permission.read(bucket) for bucket in sorted(set(read) - rw)]
+    permissions.extend(Permission.read_write(bucket) for bucket in sorted(rw))
     return permissions
 
 

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -653,15 +653,17 @@ def apply_acl(
                 else ""
             )
             detail = format_exception(exc)
-            desired = _format_permissions(policy.permissions)
-            server_state = _describe_policy_state(stack, policy.title)
+            if _is_internal_server_error(detail):
+                desired = _format_permissions(policy.permissions)
+                server_state = _describe_policy_state(stack, policy.title)
+                suffix = f" [desired: [{desired}]; {server_state}]"
+            else:
+                suffix = ""
             warnings.append(
-                f"Policy '{policy.title}' could not be created{hint}: {detail} "
-                f"[desired: [{desired}]; {server_state}]"
+                f"Policy '{policy.title}' could not be created{hint}: {detail}{suffix}"
             )
             print(
-                f"  ! policy {policy.title}: {detail} "
-                f"[desired: [{desired}]; {server_state}]",
+                f"  ! policy {policy.title}: {detail}{suffix}",
                 file=sys.stderr,
             )
             continue
@@ -701,15 +703,17 @@ def apply_acl(
                 else ""
             )
             detail = format_exception(exc)
-            desired = _format_permissions(policy.permissions)
-            server_state = _describe_policy_state(stack, policy.title)
+            if _is_internal_server_error(detail):
+                desired = _format_permissions(policy.permissions)
+                server_state = _describe_policy_state(stack, policy.title)
+                suffix = f" [desired: [{desired}]; {server_state}]"
+            else:
+                suffix = ""
             warnings.append(
-                f"Policy '{policy.title}' could not be updated{hint}: {detail} "
-                f"[desired: [{desired}]; {server_state}]"
+                f"Policy '{policy.title}' could not be updated{hint}: {detail}{suffix}"
             )
             print(
-                f"  ! policy {policy.title}: {detail} "
-                f"[desired: [{desired}]; {server_state}]",
+                f"  ! policy {policy.title}: {detail}{suffix}",
                 file=sys.stderr,
             )
             continue
@@ -1133,14 +1137,12 @@ def reset_policy(
         print(f"  - policy {title}")
     except Exception as exc:
         detail = format_exception(exc)
-        server_state = _describe_policy_state(stack, title)
-        warnings.append(
-            f"Policy '{title}' could not be deleted: {detail} [{server_state}]"
-        )
-        print(
-            f"  ! policy {title}: {detail} [{server_state}]",
-            file=sys.stderr,
-        )
+        if _is_internal_server_error(detail):
+            suffix = f" [{_describe_policy_state(stack, title)}]"
+        else:
+            suffix = ""
+        warnings.append(f"Policy '{title}' could not be deleted: {detail}{suffix}")
+        print(f"  ! policy {title}: {detail}{suffix}", file=sys.stderr)
     return warnings, user_snapshot
 
 
@@ -1429,6 +1431,16 @@ def _format_permissions(permissions: list[Permission]) -> str:
         )
         or "(none)"
     )
+
+
+def _is_internal_server_error(detail: str) -> bool:
+    """True iff the formatted error text looks like a server-side 500.
+
+    Used to gate the refetch-and-describe diagnostic so we do not pay an
+    extra `policies.list()` round trip on expected validation, auth, or
+    not-found errors — those carry their own actionable text already.
+    """
+    return "Internal Server Error" in detail
 
 
 def _describe_policy_state(stack: stack_lib.Catalog, title: str) -> str:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -590,8 +590,10 @@ def _prune_sso_config_for_missing_roles(
         default_role_dropped = True
 
     if default_role_dropped:
-        # Registry requires default_role; sending the payload now would 500
-        # the SSO update. Skip entirely; mappings land on a later apply.
+        # Registry's SsoConfig schema requires default_role; sending the
+        # payload without it fails pydantic validation
+        # (`config.default_role: field required`) before any DB write. Skip
+        # entirely; mappings land on a later apply once the role exists.
         return None, dropped
 
     if not pruned_mappings and "default_role" not in payload:
@@ -782,28 +784,33 @@ def apply_acl(
         pruned_text, dropped_roles = _prune_sso_config_for_missing_roles(
             diff.sso_config_text, available_roles
         )
-        if dropped_roles:
-            warnings.append(
-                f"SSO config pruned to skip missing roles: "
-                f"{', '.join(sorted(dropped_roles))}. Mappings/default_role "
-                f"referencing them were dropped so the rest of SSO still applies."
-            )
-            print(
-                f"  ~ sso config: pruned roles {', '.join(sorted(dropped_roles))}",
-                file=sys.stderr,
-            )
         if pruned_text is None:
+            roles_part = (
+                f" (missing roles: {', '.join(sorted(dropped_roles))})"
+                if dropped_roles
+                else ""
+            )
             warnings.append(
                 "SSO config not updated: pruning would leave the payload "
                 "without a default_role (or with no surviving mappings); "
                 "the registry requires default_role to be present. "
-                "Re-run after the missing role(s) are created."
+                f"Re-run after the missing role(s) are created.{roles_part}"
             )
             print(
                 "  ! sso config: skipped (default_role or all mappings dropped)",
                 file=sys.stderr,
             )
         else:
+            if dropped_roles:
+                warnings.append(
+                    f"SSO config pruned to skip missing roles: "
+                    f"{', '.join(sorted(dropped_roles))}. Mappings referencing "
+                    f"them were dropped so the rest of SSO still applies."
+                )
+                print(
+                    f"  ~ sso config: pruned roles {', '.join(sorted(dropped_roles))}",
+                    file=sys.stderr,
+                )
             try:
                 stack.admin.sso_config.set(pruned_text)
             except Exception as exc:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -549,6 +549,13 @@ def _prune_sso_config_for_missing_roles(
     referenced role is missing. Pruning lets us still apply the mappings whose
     roles do exist server-side. Returns ``(pruned_yaml, dropped_role_names)``;
     pruned_yaml is None when nothing meaningful is left to apply.
+
+    The registry's SsoConfig schema makes ``default_role`` a required field
+    (pydantic, no default). If pruning would leave the payload without a
+    ``default_role`` we cannot send it — the registry would reject with
+    ``InvalidInput: config.default_role: field required``. In that case we
+    return None so the caller skips the SSO update; the mappings will land
+    on the next apply once the missing role exists.
     """
     payload = yaml.safe_load(config_text)
     if not isinstance(payload, dict):
@@ -576,9 +583,16 @@ def _prune_sso_config_for_missing_roles(
     payload["mappings"] = pruned_mappings
 
     default_role = payload.get("default_role")
+    default_role_dropped = False
     if default_role and default_role not in available_roles:
         dropped.add(default_role)
         payload.pop("default_role", None)
+        default_role_dropped = True
+
+    if default_role_dropped:
+        # Registry requires default_role; sending the payload now would 500
+        # the SSO update. Skip entirely; mappings land on a later apply.
+        return None, dropped
 
     if not pruned_mappings and "default_role" not in payload:
         return None, dropped
@@ -776,10 +790,15 @@ def apply_acl(
             )
         if pruned_text is None:
             warnings.append(
-                "SSO config not updated: every desired mapping references a "
-                "missing role."
+                "SSO config not updated: pruning would leave the payload "
+                "without a default_role (or with no surviving mappings); "
+                "the registry requires default_role to be present. "
+                "Re-run after the missing role(s) are created."
             )
-            print("  ! sso config: nothing to apply after pruning", file=sys.stderr)
+            print(
+                "  ! sso config: skipped (default_role or all mappings dropped)",
+                file=sys.stderr,
+            )
         else:
             try:
                 stack.admin.sso_config.set(pruned_text)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -804,16 +804,21 @@ def test_apply_acl_prunes_sso_config_when_role_create_fails(monkeypatch) -> None
 
     warnings = acl.apply_acl(stack, diff, _empty_current_state())
 
-    assert len(sso_calls) == 1, "SSO config should still have been applied"
-    applied = sso_calls[0]
-    # `exec` mapping and default_role pruned; `public` mapping survives.
-    assert "default_role" not in applied
-    assert applied["mappings"] == [{"roles": ["public"], "schema": {}}]
-    assert any("pruned to skip missing roles" in w for w in warnings)
+    # Registry's SsoConfig schema requires default_role; since the configured
+    # default_role ("exec") was dropped, we cannot send the payload at all.
+    # The SSO update is deferred to a later run.
+    assert sso_calls == []
+    assert any("default_role" in w for w in warnings)
     assert any("exec" in w for w in warnings)
 
 
-def test_prune_sso_config_drops_mappings_referencing_missing_roles() -> None:
+def test_prune_sso_config_returns_none_when_default_role_dropped() -> None:
+    """If default_role's target role is missing, skip SSO entirely.
+
+    The registry's SsoConfig pydantic schema requires default_role; a payload
+    without it fails with `config.default_role: field required`. Returning
+    None tells the caller to defer the update until the missing role exists.
+    """
     config_text = yaml.safe_dump(
         {
             "version": "1.0",
@@ -832,12 +837,33 @@ def test_prune_sso_config_drops_mappings_referencing_missing_roles() -> None:
         config_text, available_roles={"public"}
     )
 
+    assert pruned is None
     assert dropped == {"internal_public", "exec"}
+
+
+def test_prune_sso_config_keeps_payload_when_default_role_survives() -> None:
+    """If only mapping-only roles are missing, the SSO update still goes."""
+    config_text = yaml.safe_dump(
+        {
+            "version": "1.0",
+            "union_roles": True,
+            "default_role": "public",
+            "mappings": [
+                {"roles": ["public"], "schema": {}},
+                {"roles": ["exec"], "schema": {}, "admin": True},
+            ],
+        },
+        sort_keys=False,
+    )
+
+    pruned, dropped = acl._prune_sso_config_for_missing_roles(
+        config_text, available_roles={"public"}
+    )
+
     assert pruned is not None
+    assert dropped == {"exec"}
     payload = yaml.safe_load(pruned)
-    # Only the surviving mapping remains; default_role and the two missing
-    # role mappings are gone, but `public` still gets its SSO grant.
-    assert "default_role" not in payload
+    assert payload["default_role"] == "public"
     assert payload["mappings"] == [{"roles": ["public"], "schema": {}}]
 
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -10,6 +10,8 @@ from typing import Any
 import pytest
 import yaml
 
+from quilt3.admin.types import BucketPermissionLevel, Permission
+
 from quiltx import acl
 from quiltx.tools.catalog import acl as acl_tool
 
@@ -944,3 +946,85 @@ def test_acl_parser_accepts_catalog_and_api_key_flags() -> None:
     assert args.api_key == "qk_test"
     assert args.no_prompt is True
     assert args.config_file == "config.yaml"
+
+
+# Diagnostic helpers (added in 0.13.3 for opaque-500 surfacing).
+
+
+def test_is_internal_server_error_matches_500_text() -> None:
+    assert acl._is_internal_server_error(
+        "Internal Server Error: Internal Server Error (path: ['policyCreateManaged'])"
+    )
+    assert acl._is_internal_server_error("Wrapper: Internal Server Error: foo")
+
+
+def test_is_internal_server_error_skips_validation_and_auth() -> None:
+    assert not acl._is_internal_server_error(
+        "errors=[InvalidInputSelectionErrors(path='config.default_role', "
+        "message='field required', name='ValidationError')] typename__='InvalidInput'"
+    )
+    assert not acl._is_internal_server_error("Unauthorized")
+    assert not acl._is_internal_server_error("Not Found")
+    assert not acl._is_internal_server_error("")
+
+
+def test_format_permissions_empty() -> None:
+    assert acl._format_permissions([]) == "(none)"
+
+
+def test_format_permissions_canonicalises_and_renders() -> None:
+    perms = [
+        Permission(bucket="quilt-bake", level=BucketPermissionLevel.READ_WRITE),
+        Permission(bucket="quilt-dev", level=BucketPermissionLevel.READ),
+        Permission(bucket="quilt-dev", level=BucketPermissionLevel.READ_WRITE),
+    ]
+    # Sorted by (bucket, level); enum repr split on '.' to surface just the name.
+    assert (
+        acl._format_permissions(perms)
+        == "READ_WRITE:quilt-bake,READ:quilt-dev,READ_WRITE:quilt-dev"
+    )
+
+
+def test_describe_policy_state_returns_id_arn_and_perms() -> None:
+    policy = SimpleNamespace(
+        title="internal",
+        id="pid-7",
+        arn="arn:aws:iam::123:policy/quilt-internal",
+        permissions=[
+            Permission(bucket="quilt-bake", level=BucketPermissionLevel.READ_WRITE),
+        ],
+    )
+    stack = _fake_stack(
+        policies=SimpleNamespace(list=lambda: [policy]),
+    )
+    out = acl._describe_policy_state(stack, "internal")
+    assert out == (
+        "server now: id=pid-7, arn=arn:aws:iam::123:policy/quilt-internal, "
+        "permissions=[READ_WRITE:quilt-bake]"
+    )
+
+
+def test_describe_policy_state_omits_arn_when_missing() -> None:
+    policy = SimpleNamespace(title="internal", id="pid-7", arn=None, permissions=[])
+    stack = _fake_stack(policies=SimpleNamespace(list=lambda: [policy]))
+    assert acl._describe_policy_state(stack, "internal") == (
+        "server now: id=pid-7, permissions=[(none)]"
+    )
+
+
+def test_describe_policy_state_reports_not_present() -> None:
+    stack = _fake_stack(policies=SimpleNamespace(list=lambda: []))
+    assert (
+        acl._describe_policy_state(stack, "internal")
+        == "server now: policy not present"
+    )
+
+
+def test_describe_policy_state_reports_refetch_failure() -> None:
+    def boom() -> Any:
+        raise RuntimeError("graphql down")
+
+    stack = _fake_stack(policies=SimpleNamespace(list=boom))
+    out = acl._describe_policy_state(stack, "internal")
+    assert out.startswith("refetch failed: ")
+    assert "graphql down" in out

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -951,6 +951,33 @@ def test_acl_parser_accepts_catalog_and_api_key_flags() -> None:
 # Diagnostic helpers (added in 0.13.3 for opaque-500 surfacing).
 
 
+def test_permissions_for_buckets_dedupes_rw_over_read() -> None:
+    """A bucket listed in both read and read_write must yield ONE permission.
+
+    The registry's RolePolicyBucketPermission has a composite PK on
+    (role_policy_id, bucket_name); emitting both READ and READ_WRITE for the
+    same bucket trips a PK violation that surfaces as an opaque 500 from
+    policyCreateManaged. RW implies R, so we drop the redundant READ.
+    """
+    perms = acl._permissions_for_buckets(
+        read=["quilt-dev", "quilt-example"],
+        read_write=["quilt-bake", "quilt-dev"],
+    )
+    rendered = [(p.bucket, p.level.name) for p in perms]
+    # quilt-dev appears once, as READ_WRITE.
+    assert rendered == [
+        ("quilt-example", "READ"),
+        ("quilt-bake", "READ_WRITE"),
+        ("quilt-dev", "READ_WRITE"),
+    ]
+
+
+def test_permissions_for_buckets_handles_disjoint_inputs() -> None:
+    perms = acl._permissions_for_buckets(read=["a"], read_write=["b"])
+    rendered = [(p.bucket, p.level.name) for p in perms]
+    assert rendered == [("a", "READ"), ("b", "READ_WRITE")]
+
+
 def test_is_internal_server_error_matches_500_text() -> None:
     assert acl._is_internal_server_error(
         "Internal Server Error: Internal Server Error (path: ['policyCreateManaged'])"

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary

Three fixes to \`quiltx catalog acl\`, motivated by [stack/databricks run 25479142576](https://github.com/quiltdata/deployment/actions/runs/25479142576).

**Fix 1 — root cause of the 500.** When a bucket appears in both \`buckets.read\` and \`buckets.read_write\` (as \`quilt-dev\` does in [default-acl.yaml](repos/deployment/tf/auto-stack-dev/default-acl.yaml)), \`_permissions_for_buckets\` emitted two \`Permission\` entries for it. The registry's [\`RolePolicyBucketPermission\`](repos/enterprise/registry/quilt_server/models.py) has a composite primary key on \`(role_policy_id, bucket_name)\` — \`value\` is *not* part of the PK — so \`bulk_insert_mappings\` of both rows tripped a PK violation that bubbled out as an unhandled \`Internal Server Error\` from \`policyCreateManaged\`. RW implies R, so dropping the redundant READ produces a semantically identical policy that the registry accepts.

**Fix 2 — SSO config skipped when default_role would be dropped.** When a policy fails to create, every role referencing it is also skipped, including the role \`config.default_role\` points at. The existing prune dropped \`default_role\` from the payload, then sent it anyway; the registry's \`SsoConfig\` pydantic schema requires \`default_role\`, so the SSO update failed with \`config.default_role: field required\`. Now the prune returns \`None\` in that case and the caller skips \`setSsoConfig\` with a clear warning.

**Fix 3 — diagnostic on opaque 500s.** When \`policyCreateManaged\` / \`policyUpdateManaged\` / policy delete return a generic \`Internal Server Error\`, the warning now includes the desired permission set and a refetch of server-side state (id, arn, permissions, or "not present"). Gated on the \`Internal Server Error\` substring so validation/auth/not-found errors stay concise.

End-to-end validated against \`databricks.dev.quilttest.com\` — first clean apply ever:

\`\`\`
+ policy internal
+ role internal_public
+ role exec
+ sso config
Applying...
-> create policy internal
  + policy internal
-> create role internal_public
  + role internal_public
-> create role exec
  + role exec
-> update sso config
  + sso config
Done.
\`\`\`

Stacked on \`260506-coc-quiltx\` (PR #45). Bumps version to **0.13.3**.

## Test plan

- [x] \`pytest tests/\` — 281 passed, 1 skipped (45 acl tests, +10 new)
- [x] Live apply against \`databricks.dev.quilttest.com\` succeeds (exit 0; policy/roles/sso all landed)
- [ ] Pin \`260506-coc-deployment\` to this version; rerun stack/databricks deploy and confirm the workflow's "Apply ACL" step exits 0 on first attempt without the soft-fail wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)