### PR TITLE
[codex] Fix catalog ACL SSO claims and delete cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-05-07
+
+### Added
+
+- `quiltx catalog acl` accepts arbitrary `sso.<claim>` selectors, not only `sso.groups`, and emits SSO JSON Schema mappings for scalar or array-valued custom claims.
+
+### Fixed
+
+- `quiltx catalog acl` uses role and policy IDs from fetched state when updating or deleting existing resources, avoiding quilt3 name-as-ID lookup failures that surfaced as opaque `Internal Server Error` GraphQL errors.
+- `quiltx catalog acl` now detaches users, SSO mappings, policy associations, and policy role associations before deleting roles or policies, allowing stale managed roles and inline policies to be removed cleanly.
+- GraphQL error formatting no longer repeats identical wrapper and nested messages such as `Internal Server Error: Internal Server Error`.
+
 ## [0.14.1] - 2026-05-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ policies:
     sso.groups: [Employees]
     buckets.read_write: [quilt-bake, quilt-dev]
     buckets.read: [quilt-leadership]
+    config.is_admin: true
 
 roles:
   exec:
@@ -88,6 +89,10 @@ Policy order matters. In this example `public` synthesizes the `public` role,
 and `internal` synthesizes `internal_public`, which cumulatively includes both
 `public` and `internal`. Reordering the policies changes those synthesized role
 names and who receives which cumulative grants.
+
+Policy `config.is_admin` also composes cumulatively for synthesized roles.
+Unset is neutral, `true` grants admin, and an explicit `false` vetoes any prior
+`true` in that generated role and is reported as a warning.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.14.1"
+version = "0.14.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -15,14 +15,12 @@ from quiltx import stack as stack_lib
 INLINE_POLICY_SUFFIX = "__inline"
 ACL_TOP_LEVEL_KEYS = {"policies", "roles", "store_last_login_context"}
 ACL_POLICY_KEYS = {
-    "sso.groups",
     "buckets.read",
     "buckets.read_write",
     "config.is_admin",
     "config.default_role",
 }
 ACL_ROLE_KEYS = {
-    "sso.groups",
     "config.policies",
     "buckets.read",
     "buckets.read_write",
@@ -34,7 +32,7 @@ EVERYONE_GROUP = "Everyone"
 @dataclass(frozen=True)
 class AclPolicy:
     name: str
-    groups: list[str] = field(default_factory=list)
+    sso: dict[str, list[str]] = field(default_factory=dict)
     read: list[str] = field(default_factory=list)
     read_write: list[str] = field(default_factory=list)
     default_role: bool = False
@@ -44,7 +42,7 @@ class AclPolicy:
 @dataclass(frozen=True)
 class AclStaticRole:
     name: str
-    groups: list[str] = field(default_factory=list)
+    sso: dict[str, list[str]] = field(default_factory=dict)
     policies: list[str] = field(default_factory=list)
     read: list[str] = field(default_factory=list)
     read_write: list[str] = field(default_factory=list)
@@ -115,7 +113,7 @@ class AclDiff:
 @dataclass(frozen=True)
 class _SynthesizedRole:
     name: str
-    groups: list[str]
+    sso: dict[str, list[str]]
     policy_titles: list[str]
     source_policies: list[str]
     is_admin: bool | None
@@ -124,7 +122,7 @@ class _SynthesizedRole:
 @dataclass(frozen=True)
 class _ResolvedStaticRole:
     name: str
-    groups: list[str]
+    sso: dict[str, list[str]]
     policy_titles: list[str]
     is_admin: bool
     inline_policy_title: str | None
@@ -132,7 +130,8 @@ class _ResolvedStaticRole:
 
 @dataclass(frozen=True)
 class _SsoMapping:
-    group: str
+    claim: str
+    value: str
     role_name: str
     admin: bool | None = None
 
@@ -154,16 +153,19 @@ def format_exception(exc: Exception) -> str:
     errors = getattr(exc, "errors", None)
     if not isinstance(errors, list) or not errors:
         return base
-    details: list[str] = []
+    details: list[tuple[str, str]] = []
     for error in errors:
         message = getattr(error, "message", None)
         if not message:
             continue
         path = getattr(error, "path", None)
-        details.append(f"{message} (path: {path})" if path else str(message))
+        rendered = f"{message} (path: {path})" if path else str(message)
+        details.append((str(message), rendered))
     if not details:
         return base
-    return f"{base}: {'; '.join(details)}"
+    if all(message == base for message, _rendered in details):
+        return "; ".join(rendered for _message, rendered in details)
+    return f"{base}: {'; '.join(rendered for _message, rendered in details)}"
 
 
 def parse_acl_config(path: str | Path) -> AclConfig:
@@ -207,9 +209,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 f"'{INLINE_POLICY_SUFFIX}'; that suffix is reserved for generated "
                 "inline-role policies"
             )
-        groups = _coerce_non_empty_string_list(
-            value.get("sso.groups"), f"policies.{name}.sso.groups"
-        )
+        sso = _coerce_sso_selectors(value, f"policies.{name}")
         read = _coerce_string_list(
             value.get("buckets.read", []), f"policies.{name}.buckets.read"
         )
@@ -225,7 +225,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError(f"policies.{name}.config.default_role must be a boolean")
         policy = AclPolicy(
             name=name,
-            groups=_dedupe_preserve_order(groups),
+            sso=sso,
             read=_dedupe_preserve_order(read),
             read_write=_dedupe_preserve_order(read_write),
             is_admin=is_admin,
@@ -254,7 +254,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             allowed_keys=ACL_ROLE_KEYS,
             section="roles",
             name=name,
-            hint="User-specific SSO selectors such as 'sso.users' are not supported.",
+            hint="SSO selectors must be named 'sso.<claim>' and contain a non-empty list of strings.",
         )
         reserved_inline_policy = f"{name}{INLINE_POLICY_SUFFIX}"
         if reserved_inline_policy in raw_policies:
@@ -262,9 +262,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 f"Role '{name}' conflicts with reserved generated inline policy "
                 f"'{reserved_inline_policy}'"
             )
-        groups = _coerce_non_empty_string_list(
-            value.get("sso.groups"), f"roles.{name}.sso.groups"
-        )
+        sso = _coerce_sso_selectors(value, f"roles.{name}")
         policy_refs = _coerce_string_list(
             value.get("config.policies", []), f"roles.{name}.config.policies"
         )
@@ -289,7 +287,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError(f"roles.{name}.config.is_admin must be a boolean")
         roles[name] = AclStaticRole(
             name=name,
-            groups=_dedupe_preserve_order(groups),
+            sso=sso,
             policies=_dedupe_preserve_order(policy_refs),
             read=_dedupe_preserve_order(read),
             read_write=_dedupe_preserve_order(read_write),
@@ -439,12 +437,9 @@ def build_sso_config(config: AclConfig) -> str | None:
             "schema": {
                 "type": "object",
                 "properties": {
-                    "groups": {
-                        "type": "array",
-                        "contains": {"const": mapping.group},
-                    }
+                    mapping.claim: _sso_claim_schema(mapping.claim, mapping.value)
                 },
-                "required": ["groups"],
+                "required": [mapping.claim],
             },
             "roles": [mapping.role_name],
         }
@@ -790,8 +785,10 @@ def apply_acl(
         _print_apply_step(f"update role {role.name}", verbose=verbose)
         try:
             policy_ids = _resolve_policy_ids(role.policy_titles, known_policies)
+            existing = current.managed_roles.get(role.name)
+            role_ref = existing.id if existing is not None else role.name
             stack.admin.roles.update_managed(
-                role.name, name=role.name, policies=policy_ids
+                role_ref, name=role.name, policies=policy_ids
             )
         except KeyError as exc:
             warnings.append(
@@ -856,20 +853,89 @@ def apply_acl(
                 prefix = "+" if diff.sso_is_create else "~"
                 print(f"  {prefix} sso config")
 
+    sso_cleared_for_role_delete = False
+    roles_to_delete = set(diff.roles_to_delete)
+    if roles_to_delete:
+        try:
+            users_to_detach = users_assigned_to_roles(stack, roles_to_delete)
+        except Exception as exc:  # pragma: no cover - external API surface
+            detail = format_exception(exc)
+            warnings.append(f"Users could not be checked before role delete: {detail}")
+            users_to_detach = []
+        if users_to_detach:
+            warnings.extend(clear_sso_config(stack, verbose=verbose))
+            sso_cleared_for_role_delete = True
+        else:
+            try:
+                sso_detach_warnings = detach_sso_mappings_for_roles(
+                    stack, roles_to_delete, verbose=verbose
+                )
+            except Exception as exc:  # pragma: no cover - external API surface
+                warnings.append(
+                    "SSO mappings could not be checked before role delete: "
+                    f"{format_exception(exc)}"
+                )
+            else:
+                warnings.extend(sso_detach_warnings)
+
     for role_name in diff.roles_to_delete:
         try:
+            detach_warnings, _snapshot = detach_users_from_role(
+                stack, role_name, verbose=verbose
+            )
+        except Exception as exc:  # pragma: no cover - external API surface
+            warnings.append(
+                f"Users could not be detached before deleting role "
+                f"'{role_name}': {format_exception(exc)}"
+            )
+        else:
+            warnings.extend(detach_warnings)
+        warnings.extend(
+            detach_all_policies_from_roles(
+                stack,
+                {role_name},
+                current,
+                known_policies,
+                verbose=verbose,
+            )
+        )
+        try:
+            role_ref = _role_ref(role_name, current)
             _print_apply_step(f"delete role {role_name}", verbose=verbose)
-            stack.admin.roles.delete(role_name)
+            stack.admin.roles.delete(role_ref)
             print(f"  - role {role_name}")
         except Exception as exc:  # pragma: no cover - external API surface
             warnings.append(
                 f"Role '{role_name}' could not be deleted: {format_exception(exc)}"
             )
 
+    if sso_cleared_for_role_delete and diff.sso_config_text is not None:
+        _print_apply_step("restore sso config", verbose=verbose)
+        try:
+            stack.admin.sso_config.set(diff.sso_config_text)
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(f"SSO config could not be restored: {detail}")
+            print(f"  ! sso config: {detail}", file=sys.stderr)
+        else:
+            print("  ~ sso config (restored)")
+
+    warnings.extend(
+        detach_policies_from_roles(
+            stack,
+            set(diff.policies_to_delete),
+            current,
+            known_policies,
+            roles_to_delete=roles_to_delete,
+            verbose=verbose,
+        )
+    )
+
     for policy_title in diff.policies_to_delete:
         try:
+            policy_ref = _policy_ref(policy_title, current)
             _print_apply_step(f"delete policy {policy_title}", verbose=verbose)
-            stack.admin.policies.delete(policy_title)
+            stack.admin.policies.delete(policy_ref)
             print(f"  - policy {policy_title}")
         except Exception as exc:  # pragma: no cover - external API surface
             warnings.append(
@@ -944,6 +1010,161 @@ def managed_roles_using_policy(policy_title: str, current: CurrentState) -> list
         for name, role in current.managed_roles.items()
         if any(p.title == policy_title for p in getattr(role, "policies", []) or [])
     )
+
+
+def _role_ref(role_name: str, current: CurrentState) -> str:
+    role = current.all_roles.get(role_name)
+    return str(role.id) if role is not None else role_name
+
+
+def _policy_ref(policy_title: str, current: CurrentState) -> str:
+    policy = current.all_policies.get(policy_title)
+    return str(policy.id) if policy is not None else policy_title
+
+
+def detach_all_policies_from_roles(
+    stack: stack_lib.Catalog,
+    role_names: set[str],
+    current: CurrentState,
+    known_policies: dict[str, Any],
+    *,
+    verbose: bool = False,
+) -> list[str]:
+    """Remove all policy associations from roles before deleting those roles."""
+    warnings: list[str] = []
+    for role_name in sorted(role_names):
+        role = current.managed_roles.get(role_name)
+        if role is None:
+            continue
+        current_policies = list(getattr(role, "policies", []) or [])
+        if not current_policies:
+            continue
+        try:
+            _print_apply_step(f"detach policies from role {role_name}", verbose=verbose)
+            stack.admin.roles.update_managed(role.id, name=role_name, policies=[])
+            print(f"  ~ role {role_name} (detached policies)")
+        except Exception as exc:
+            detail = format_exception(exc)
+            fallback_warnings = detach_role_from_policies_via_policy_updates(
+                stack,
+                role_name,
+                current_policies,
+                current,
+                known_policies,
+                verbose=verbose,
+            )
+            if fallback_warnings:
+                warnings.append(
+                    f"Role '{role_name}' could not be detached from policies "
+                    f"before delete: {detail}"
+                )
+                warnings.extend(fallback_warnings)
+            print(f"  ! role {role_name}: {detail}", file=sys.stderr)
+    return warnings
+
+
+def detach_role_from_policies_via_policy_updates(
+    stack: stack_lib.Catalog,
+    role_name: str,
+    current_policies: list[Any],
+    current: CurrentState,
+    known_policies: dict[str, Any],
+    *,
+    verbose: bool = False,
+) -> list[str]:
+    """Remove a role association by rewriting each attached policy's role list."""
+    warnings: list[str] = []
+    role = current.managed_roles.get(role_name)
+    if role is None:
+        return warnings
+
+    for policy_summary in current_policies:
+        policy = known_policies.get(policy_summary.title)
+        if policy is None:
+            policy = current.managed_policies.get(policy_summary.title)
+        if policy is None:
+            warnings.append(
+                f"Policy '{policy_summary.title}' could not be used to detach "
+                f"role '{role_name}': policy not found in current state"
+            )
+            continue
+
+        remaining_role_ids = [
+            r.id
+            for r in getattr(policy, "roles", []) or []
+            if getattr(r, "name", None) != role_name
+            and getattr(r, "id", None) != role.id
+        ]
+        try:
+            _print_apply_step(
+                f"detach role {role_name} from policy {policy.title}",
+                verbose=verbose,
+            )
+            stack.admin.policies.update_managed(
+                policy.id,
+                title=policy.title,
+                permissions=list(getattr(policy, "permissions", []) or []),
+                roles=remaining_role_ids,
+            )
+            print(f"  ~ policy {policy.title} (detached role {role_name})")
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(
+                f"Policy '{policy.title}' could not detach role "
+                f"'{role_name}': {detail}"
+            )
+            print(f"  ! policy {policy.title}: {detail}", file=sys.stderr)
+
+    return warnings
+
+
+def detach_policies_from_roles(
+    stack: stack_lib.Catalog,
+    policy_titles: set[str],
+    current: CurrentState,
+    known_policies: dict[str, Any],
+    *,
+    roles_to_delete: set[str],
+    verbose: bool = False,
+) -> list[str]:
+    """Remove retiring policies from surviving managed roles before policy delete."""
+    warnings: list[str] = []
+    if not policy_titles:
+        return warnings
+
+    for role_name, role in sorted(current.managed_roles.items()):
+        if role_name in roles_to_delete:
+            continue
+        current_policies = list(getattr(role, "policies", []) or [])
+        if not any(policy.title in policy_titles for policy in current_policies):
+            continue
+
+        surviving_policy_ids: list[str] = []
+        for policy in current_policies:
+            if policy.title in policy_titles:
+                continue
+            known = known_policies.get(policy.title)
+            surviving_policy_ids.append(
+                str(known.id if known is not None else policy.id)
+            )
+
+        try:
+            _print_apply_step(f"detach policies from role {role_name}", verbose=verbose)
+            stack.admin.roles.update_managed(
+                role.id,
+                name=role_name,
+                policies=surviving_policy_ids,
+            )
+            print(f"  ~ role {role_name} (detached deleted policies)")
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(
+                f"Role '{role_name}' could not be detached from deleted "
+                f"policies {', '.join(sorted(policy_titles))}: {detail}"
+            )
+            print(f"  ! role {role_name}: {detail}", file=sys.stderr)
+
+    return warnings
 
 
 def detach_sso_mappings_for_roles(
@@ -1027,8 +1248,8 @@ def detach_users_from_role(
     """
     warnings: list[str] = []
     snapshot: list[UserRoleBinding] = []
-    default_role = stack.admin.roles.get_default()
-    fallback_name = default_role.name if default_role is not None else None
+    fallback_name: str | None = None
+    fallback_loaded = False
     for user in stack.admin.users.list():
         primary = user.role.name if user.role else None
         extras = [
@@ -1036,6 +1257,10 @@ def detach_users_from_role(
         ]
         if primary != role_name and role_name not in extras:
             continue
+        if not fallback_loaded:
+            default_role = stack.admin.roles.get_default()
+            fallback_name = default_role.name if default_role is not None else None
+            fallback_loaded = True
         snapshot.append(
             UserRoleBinding(user_name=user.name, primary=primary, extras=extras)
         )
@@ -1214,7 +1439,7 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         )
         synthesized_role = _SynthesizedRole(
             name=synthesized_role_name,
-            groups=policy.groups,
+            sso=policy.sso,
             policy_titles=list(cumulative_policy_titles),
             source_policies=list(cumulative_policy_titles),
             is_admin=synthesized_admin,
@@ -1224,14 +1449,16 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
             name=synthesized_role.name,
             policy_titles=list(cumulative_policy_titles),
         )
-        for group in policy.groups:
-            sso_mappings.append(
-                _SsoMapping(
-                    group=group,
-                    role_name=synthesized_role.name,
-                    admin=synthesized_role.is_admin,
+        for claim, values in policy.sso.items():
+            for value in values:
+                sso_mappings.append(
+                    _SsoMapping(
+                        claim=claim,
+                        value=value,
+                        role_name=synthesized_role.name,
+                        admin=synthesized_role.is_admin,
+                    )
                 )
-            )
         if policy.default_role:
             default_role_name = synthesized_role.name
 
@@ -1248,7 +1475,7 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
             policy_titles.append(inline_policy_title)
         resolved_role = _ResolvedStaticRole(
             name=role.name,
-            groups=role.groups,
+            sso=role.sso,
             policy_titles=policy_titles,
             is_admin=role.is_admin,
             inline_policy_title=inline_policy_title,
@@ -1257,14 +1484,16 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         role_updates[role.name] = RoleUpdate(
             name=role.name, policy_titles=policy_titles
         )
-        for group in role.groups:
-            sso_mappings.append(
-                _SsoMapping(
-                    group=group,
-                    role_name=role.name,
-                    admin=True if role.is_admin else None,
+        for claim, values in role.sso.items():
+            for value in values:
+                sso_mappings.append(
+                    _SsoMapping(
+                        claim=claim,
+                        value=value,
+                        role_name=role.name,
+                        admin=True if role.is_admin else None,
+                    )
                 )
-            )
 
     return _DesiredAclState(
         policy_updates=policy_updates,
@@ -1315,39 +1544,46 @@ def _validate_acl_section_keys(
     name: str,
     hint: str,
 ) -> None:
-    unknown_keys = sorted(set(value) - allowed_keys)
+    unknown_keys = sorted(
+        key for key in value if key not in allowed_keys and not key.startswith("sso.")
+    )
     if not unknown_keys:
         return
     raise ValueError(
         f"Unknown ACL fields in {section}.{name}: "
         + ", ".join(unknown_keys)
         + ". Supported fields: "
-        + ", ".join(sorted(allowed_keys))
+        + ", ".join([*sorted(allowed_keys), "sso.<claim>"])
         + f". {hint}"
     )
 
 
 def _validate_policy_ladder(policies: list[AclPolicy]) -> None:
     for previous, current in zip(policies, policies[1:]):
-        if _groups_are_nested(current.groups, previous.groups):
+        if _policy_audience_is_compatible(current.sso, previous.sso):
             continue
-        violating_groups = sorted(set(current.groups) - set(previous.groups))
-        if not violating_groups:
-            violating_groups = current.groups
         raise ValueError(
             "Policy ladder is not nested: "
-            f"policy '{current.name}' has groups {current.groups}, which are not a "
-            f"subset of policy '{previous.name}' groups {previous.groups}. "
+            f"policy '{current.name}' has SSO selectors {_format_sso_selectors(current.sso)}, "
+            f"which are not a subset of policy '{previous.name}' selectors "
+            f"{_format_sso_selectors(previous.sso)}. "
             "Without a declared hierarchy, only explicitly repeated groups or a prior "
-            f"'{EVERYONE_GROUP}' audience are accepted. Offending groups: "
-            + ", ".join(violating_groups)
+            f"'{EVERYONE_GROUP}' audience are accepted."
         )
 
 
-def _groups_are_nested(current_groups: list[str], previous_groups: list[str]) -> bool:
-    current_set = set(current_groups)
-    previous_set = set(previous_groups)
-    return current_set <= previous_set or EVERYONE_GROUP in previous_set
+def _policy_audience_is_compatible(
+    current_sso: dict[str, list[str]], previous_sso: dict[str, list[str]]
+) -> bool:
+    if EVERYONE_GROUP in previous_sso.get("groups", []):
+        return True
+    for claim, current_values in current_sso.items():
+        previous_values = previous_sso.get(claim)
+        if previous_values is not None and not set(current_values) <= set(
+            previous_values
+        ):
+            return False
+    return True
 
 
 def _validate_synthetic_role_names(
@@ -1395,7 +1631,7 @@ def _print_verbose_state(
     for policy in desired.policies:
         prefix = _diff_prefix(policy.name, created_policies, updated_policies)
         print(f"{prefix} policy {policy.name}")
-        print(f"    groups: {', '.join(policy.groups)}")
+        print(f"    sso: {_format_sso_selectors(policy.sso)}")
         _print_permissions(_permissions_for_buckets(policy.read, policy.read_write))
         if policy.default_role:
             print("    default_role: true")
@@ -1418,7 +1654,7 @@ def _print_verbose_state(
         prefix = _diff_prefix(synth_role.name, created_roles, updated_roles)
         sources = ", ".join(synth_role.source_policies)
         print(f"{prefix} role {synth_role.name} (synthesized from policies {sources})")
-        print(f"    groups: {', '.join(synth_role.groups)}")
+        print(f"    sso: {_format_sso_selectors(synth_role.sso)}")
         print(f"    policies: {', '.join(synth_role.policy_titles)}")
         if desired_state.default_role_name == synth_role.name:
             print("    default_role: true")
@@ -1426,7 +1662,7 @@ def _print_verbose_state(
     for role in desired_state.static_roles:
         prefix = _diff_prefix(role.name, created_roles, updated_roles)
         print(f"{prefix} role {role.name}")
-        print(f"    groups: {', '.join(role.groups)}")
+        print(f"    sso: {_format_sso_selectors(role.sso)}")
         print(f"    policies: {', '.join(role.policy_titles) or '(none)'}")
         if role.inline_policy_title is not None:
             print(f"    inline policy: {role.inline_policy_title}")
@@ -1473,6 +1709,42 @@ def _print_sso_summary(sso_text: str) -> None:
         roles = mapping.get("roles", [])
         admin = " (admin)" if mapping.get("admin") else ""
         print(f"    {match_str} -> [{', '.join(roles)}]{admin}")
+
+
+def _coerce_sso_selectors(
+    value: dict[str, Any], section_name: str
+) -> dict[str, list[str]]:
+    sso: dict[str, list[str]] = {}
+    for key, raw_values in value.items():
+        if not key.startswith("sso."):
+            continue
+        claim = key.removeprefix("sso.")
+        if not claim:
+            raise ValueError(f"'{section_name}.{key}' must include a claim name")
+        values = _coerce_non_empty_string_list(raw_values, f"{section_name}.{key}")
+        sso[claim] = _dedupe_preserve_order(values)
+    if not sso:
+        raise ValueError(
+            f"'{section_name}' must include at least one sso.<claim> selector"
+        )
+    return sso
+
+
+def _format_sso_selectors(sso: dict[str, list[str]]) -> str:
+    if not sso:
+        return "(none)"
+    return ", ".join(f"sso.{claim}={values}" for claim, values in sso.items())
+
+
+def _sso_claim_schema(claim: str, value: str) -> dict[str, Any]:
+    if claim == "groups":
+        return {"type": "array", "contains": {"const": value}}
+    return {
+        "anyOf": [
+            {"const": value},
+            {"type": "array", "contains": {"const": value}},
+        ]
+    }
 
 
 def _coerce_non_empty_string_list(value: Any, field_name: str) -> list[str]:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -13,7 +13,7 @@ from quilt3.admin.types import Permission
 from quiltx import stack as stack_lib
 
 INLINE_POLICY_SUFFIX = "__inline"
-ACL_TOP_LEVEL_KEYS = {"policies", "roles", "store_last_login_context"}
+ACL_TOP_LEVEL_KEYS = {"policies", "roles"}
 ACL_ENTRY_KEYS = {
     "buckets.read",
     "buckets.read_write",
@@ -49,7 +49,6 @@ class AclStaticRole:
 class AclConfig:
     policies: list[AclPolicy]
     roles: dict[str, AclStaticRole]
-    store_last_login_context: bool = False
 
 
 @dataclass(frozen=True)
@@ -182,10 +181,6 @@ def parse_acl_config(path: str | Path) -> AclConfig:
 
     _validate_top_level_keys(raw)
 
-    store_last_login_context = raw.get("store_last_login_context", False)
-    if not isinstance(store_last_login_context, bool):
-        raise ValueError("'store_last_login_context' must be a boolean")
-
     raw_policies = raw.get("policies") or {}
     raw_roles = raw.get("roles") or {}
 
@@ -275,7 +270,6 @@ def parse_acl_config(path: str | Path) -> AclConfig:
     return AclConfig(
         policies=policies,
         roles=roles,
-        store_last_login_context=store_last_login_context,
     )
 
 
@@ -402,7 +396,6 @@ def build_sso_config(config: AclConfig) -> str | None:
         return None
 
     payload: dict[str, Any] = {"version": "1.0", "union_roles": True, "mappings": []}
-    payload["store_last_login_context"] = config.store_last_login_context
     if desired_state.default_role_name is not None:
         payload["default_role"] = desired_state.default_role_name
 

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -14,6 +14,20 @@ from quiltx import stack as stack_lib
 
 INLINE_POLICY_SUFFIX = "__inline"
 ACL_TOP_LEVEL_KEYS = {"policies", "roles", "store_last_login_context"}
+ACL_POLICY_KEYS = {
+    "sso.groups",
+    "buckets.read",
+    "buckets.read_write",
+    "config.is_admin",
+    "config.default_role",
+}
+ACL_ROLE_KEYS = {
+    "sso.groups",
+    "config.policies",
+    "buckets.read",
+    "buckets.read_write",
+    "config.is_admin",
+}
 EVERYONE_GROUP = "Everyone"
 
 
@@ -24,6 +38,7 @@ class AclPolicy:
     read: list[str] = field(default_factory=list)
     read_write: list[str] = field(default_factory=list)
     default_role: bool = False
+    is_admin: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -103,6 +118,7 @@ class _SynthesizedRole:
     groups: list[str]
     policy_titles: list[str]
     source_policies: list[str]
+    is_admin: bool | None
 
 
 @dataclass(frozen=True)
@@ -118,7 +134,7 @@ class _ResolvedStaticRole:
 class _SsoMapping:
     group: str
     role_name: str
-    admin: bool = False
+    admin: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -129,6 +145,7 @@ class _DesiredAclState:
     role_updates: dict[str, RoleUpdate]
     sso_mappings: list[_SsoMapping]
     default_role_name: str | None
+    warnings: list[str] = field(default_factory=list)
 
 
 def format_exception(exc: Exception) -> str:
@@ -177,6 +194,13 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError("Policy names must be strings")
         if not isinstance(value, dict):
             raise ValueError(f"Policy '{name}' must be a mapping")
+        _validate_acl_section_keys(
+            value,
+            allowed_keys=ACL_POLICY_KEYS,
+            section="policies",
+            name=name,
+            hint="Role-only fields such as 'config.policies' belong under top-level 'roles:'.",
+        )
         if name.endswith(INLINE_POLICY_SUFFIX):
             raise ValueError(
                 "Policy names may not end with "
@@ -193,6 +217,9 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             value.get("buckets.read_write", []),
             f"policies.{name}.buckets.read_write",
         )
+        is_admin = value.get("config.is_admin")
+        if is_admin is not None and not isinstance(is_admin, bool):
+            raise ValueError(f"policies.{name}.config.is_admin must be a boolean")
         default_role = value.get("config.default_role", False)
         if not isinstance(default_role, bool):
             raise ValueError(f"policies.{name}.config.default_role must be a boolean")
@@ -201,6 +228,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             groups=_dedupe_preserve_order(groups),
             read=_dedupe_preserve_order(read),
             read_write=_dedupe_preserve_order(read_write),
+            is_admin=is_admin,
             default_role=default_role,
         )
         policies.append(policy)
@@ -221,6 +249,13 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError("Role names must be strings")
         if not isinstance(value, dict):
             raise ValueError(f"Role '{name}' must be a mapping")
+        _validate_acl_section_keys(
+            value,
+            allowed_keys=ACL_ROLE_KEYS,
+            section="roles",
+            name=name,
+            hint="User-specific SSO selectors such as 'sso.users' are not supported.",
+        )
         reserved_inline_policy = f"{name}{INLINE_POLICY_SUFFIX}"
         if reserved_inline_policy in raw_policies:
             raise ValueError(
@@ -324,6 +359,7 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
     """Compute the actions required to reconcile ACL state."""
     desired_state = _build_desired_acl_state(desired)
     diff = AclDiff()
+    diff.warnings.extend(desired_state.warnings)
     diff.buckets_to_add = sorted(all_buckets(desired) - current.buckets.keys())
 
     desired_policy_titles = set(desired_state.policy_updates)
@@ -413,10 +449,9 @@ def build_sso_config(config: AclConfig) -> str | None:
             "roles": [mapping.role_name],
         }
         # Server tri-state: True grants admin, False vetoes, missing = non-vote.
-        # Under union_roles, emitting admin:false for ordinary roles would veto
-        # the admin grant from a co-matching admin role. Only emit when True.
-        if mapping.admin:
-            entry["admin"] = True
+        # Only emit False when the config explicitly requests a veto.
+        if mapping.admin is not None:
+            entry["admin"] = mapping.admin
         payload["mappings"].append(entry)
 
     return yaml.safe_dump(payload, sort_keys=False)
@@ -1159,20 +1194,30 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
     role_updates: dict[str, RoleUpdate] = {}
     sso_mappings: list[_SsoMapping] = []
     default_role_name: str | None = None
+    warnings: list[str] = []
 
     cumulative_policy_titles: list[str] = []
+    cumulative_admin_votes: list[tuple[str, bool]] = []
     for policy in config.policies:
         policy_updates[policy.name] = PolicyUpdate(
             title=policy.name,
             permissions=_permissions_for_buckets(policy.read, policy.read_write),
         )
         cumulative_policy_titles.append(policy.name)
+        if policy.is_admin is not None:
+            cumulative_admin_votes.append((policy.name, policy.is_admin))
         synthesized_role_name = _synthesized_role_name(cumulative_policy_titles)
+        synthesized_admin = _resolve_policy_admin_vote(
+            cumulative_admin_votes,
+            synthesized_role_name,
+            warnings,
+        )
         synthesized_role = _SynthesizedRole(
             name=synthesized_role_name,
             groups=policy.groups,
             policy_titles=list(cumulative_policy_titles),
             source_policies=list(cumulative_policy_titles),
+            is_admin=synthesized_admin,
         )
         synthesized_roles.append(synthesized_role)
         role_updates[synthesized_role.name] = RoleUpdate(
@@ -1181,7 +1226,11 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         )
         for group in policy.groups:
             sso_mappings.append(
-                _SsoMapping(group=group, role_name=synthesized_role.name)
+                _SsoMapping(
+                    group=group,
+                    role_name=synthesized_role.name,
+                    admin=synthesized_role.is_admin,
+                )
             )
         if policy.default_role:
             default_role_name = synthesized_role.name
@@ -1210,7 +1259,11 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         )
         for group in role.groups:
             sso_mappings.append(
-                _SsoMapping(group=group, role_name=role.name, admin=role.is_admin)
+                _SsoMapping(
+                    group=group,
+                    role_name=role.name,
+                    admin=True if role.is_admin else None,
+                )
             )
 
     return _DesiredAclState(
@@ -1220,7 +1273,26 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         role_updates=role_updates,
         sso_mappings=sso_mappings,
         default_role_name=default_role_name,
+        warnings=warnings,
     )
+
+
+def _resolve_policy_admin_vote(
+    votes: list[tuple[str, bool]], role_name: str, warnings: list[str]
+) -> bool | None:
+    false_votes = [name for name, is_admin in votes if not is_admin]
+    true_votes = [name for name, is_admin in votes if is_admin]
+    if false_votes:
+        if true_votes:
+            warnings.append(
+                "Policy config.is_admin: false vetoes true for generated role "
+                f"'{role_name}' (true: {', '.join(true_votes)}; "
+                f"false: {', '.join(false_votes)})"
+            )
+        return False
+    if true_votes:
+        return True
+    return None
 
 
 def _validate_top_level_keys(raw: dict[str, Any]) -> None:
@@ -1233,6 +1305,26 @@ def _validate_top_level_keys(raw: dict[str, Any]) -> None:
             + ", ".join(sorted(ACL_TOP_LEVEL_KEYS))
             + "."
         )
+
+
+def _validate_acl_section_keys(
+    value: dict[str, Any],
+    *,
+    allowed_keys: set[str],
+    section: str,
+    name: str,
+    hint: str,
+) -> None:
+    unknown_keys = sorted(set(value) - allowed_keys)
+    if not unknown_keys:
+        return
+    raise ValueError(
+        f"Unknown ACL fields in {section}.{name}: "
+        + ", ".join(unknown_keys)
+        + ". Supported fields: "
+        + ", ".join(sorted(allowed_keys))
+        + f". {hint}"
+    )
 
 
 def _validate_policy_ladder(policies: list[AclPolicy]) -> None:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -14,18 +14,13 @@ from quiltx import stack as stack_lib
 
 INLINE_POLICY_SUFFIX = "__inline"
 ACL_TOP_LEVEL_KEYS = {"policies", "roles", "store_last_login_context"}
-ACL_POLICY_KEYS = {
+ACL_ENTRY_KEYS = {
     "buckets.read",
     "buckets.read_write",
-    "config.is_admin",
     "config.default_role",
-}
-ACL_ROLE_KEYS = {
-    "config.policies",
-    "buckets.read",
-    "buckets.read_write",
     "config.is_admin",
 }
+CONFIG_POLICIES_KEY = "config.policies"
 EVERYONE_GROUP = "Everyone"
 
 
@@ -46,6 +41,7 @@ class AclStaticRole:
     policies: list[str] = field(default_factory=list)
     read: list[str] = field(default_factory=list)
     read_write: list[str] = field(default_factory=list)
+    default_role: bool = False
     is_admin: bool = False
 
 
@@ -125,6 +121,7 @@ class _ResolvedStaticRole:
     sso: dict[str, list[str]]
     policy_titles: list[str]
     is_admin: bool
+    default_role: bool
     inline_policy_title: str | None
 
 
@@ -134,6 +131,15 @@ class _SsoMapping:
     value: str
     role_name: str
     admin: bool | None = None
+
+
+@dataclass(frozen=True)
+class _ParsedAclEntry:
+    sso: dict[str, list[str]]
+    read: list[str]
+    read_write: list[str]
+    default_role: bool
+    is_admin: bool | None
 
 
 @dataclass(frozen=True)
@@ -190,57 +196,32 @@ def parse_acl_config(path: str | Path) -> AclConfig:
 
     policies: list[AclPolicy] = []
     policy_names: set[str] = set()
-    default_policy_names: list[str] = []
+    default_role_sources: list[str] = []
     for name, value in raw_policies.items():
         if not isinstance(name, str):
             raise ValueError("Policy names must be strings")
         if not isinstance(value, dict):
             raise ValueError(f"Policy '{name}' must be a mapping")
-        _validate_acl_section_keys(
-            value,
-            allowed_keys=ACL_POLICY_KEYS,
-            section="policies",
-            name=name,
-            hint="Role-only fields such as 'config.policies' belong under top-level 'roles:'.",
-        )
+        _validate_acl_entry_keys(value, section="policies", name=name)
         if name.endswith(INLINE_POLICY_SUFFIX):
             raise ValueError(
                 "Policy names may not end with "
                 f"'{INLINE_POLICY_SUFFIX}'; that suffix is reserved for generated "
                 "inline-role policies"
             )
-        sso = _coerce_sso_selectors(value, f"policies.{name}")
-        read = _coerce_string_list(
-            value.get("buckets.read", []), f"policies.{name}.buckets.read"
-        )
-        read_write = _coerce_string_list(
-            value.get("buckets.read_write", []),
-            f"policies.{name}.buckets.read_write",
-        )
-        is_admin = value.get("config.is_admin")
-        if is_admin is not None and not isinstance(is_admin, bool):
-            raise ValueError(f"policies.{name}.config.is_admin must be a boolean")
-        default_role = value.get("config.default_role", False)
-        if not isinstance(default_role, bool):
-            raise ValueError(f"policies.{name}.config.default_role must be a boolean")
+        entry = _parse_acl_entry(value, f"policies.{name}")
         policy = AclPolicy(
             name=name,
-            sso=sso,
-            read=_dedupe_preserve_order(read),
-            read_write=_dedupe_preserve_order(read_write),
-            is_admin=is_admin,
-            default_role=default_role,
+            sso=entry.sso,
+            read=entry.read,
+            read_write=entry.read_write,
+            is_admin=entry.is_admin,
+            default_role=entry.default_role,
         )
         policies.append(policy)
         policy_names.add(name)
-        if default_role:
-            default_policy_names.append(name)
-
-    if len(default_policy_names) > 1:
-        raise ValueError(
-            "Only one policy may set config.default_role: true; found "
-            + ", ".join(default_policy_names)
-        )
+        if entry.default_role:
+            default_role_sources.append(f"policies.{name}")
 
     roles: dict[str, AclStaticRole] = {}
     role_names: set[str] = set()
@@ -249,22 +230,16 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError("Role names must be strings")
         if not isinstance(value, dict):
             raise ValueError(f"Role '{name}' must be a mapping")
-        _validate_acl_section_keys(
-            value,
-            allowed_keys=ACL_ROLE_KEYS,
-            section="roles",
-            name=name,
-            hint="SSO selectors must be named 'sso.<claim>' and contain a non-empty list of strings.",
-        )
+        _validate_acl_entry_keys(value, section="roles", name=name)
         reserved_inline_policy = f"{name}{INLINE_POLICY_SUFFIX}"
         if reserved_inline_policy in raw_policies:
             raise ValueError(
                 f"Role '{name}' conflicts with reserved generated inline policy "
                 f"'{reserved_inline_policy}'"
             )
-        sso = _coerce_sso_selectors(value, f"roles.{name}")
+        entry = _parse_acl_entry(value, f"roles.{name}")
         policy_refs = _coerce_string_list(
-            value.get("config.policies", []), f"roles.{name}.config.policies"
+            value.get(CONFIG_POLICIES_KEY, []), f"roles.{name}.{CONFIG_POLICIES_KEY}"
         )
         missing = [
             policy_name
@@ -275,25 +250,24 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             raise ValueError(
                 f"Role '{name}' references unknown policies: {', '.join(missing)}"
             )
-        read = _coerce_string_list(
-            value.get("buckets.read", []), f"roles.{name}.buckets.read"
-        )
-        read_write = _coerce_string_list(
-            value.get("buckets.read_write", []),
-            f"roles.{name}.buckets.read_write",
-        )
-        is_admin = value.get("config.is_admin", False)
-        if not isinstance(is_admin, bool):
-            raise ValueError(f"roles.{name}.config.is_admin must be a boolean")
         roles[name] = AclStaticRole(
             name=name,
-            sso=sso,
+            sso=entry.sso,
             policies=_dedupe_preserve_order(policy_refs),
-            read=_dedupe_preserve_order(read),
-            read_write=_dedupe_preserve_order(read_write),
-            is_admin=is_admin,
+            read=entry.read,
+            read_write=entry.read_write,
+            default_role=entry.default_role,
+            is_admin=bool(entry.is_admin),
         )
         role_names.add(name)
+        if entry.default_role:
+            default_role_sources.append(f"roles.{name}")
+
+    if len(default_role_sources) > 1:
+        raise ValueError(
+            "Only one ACL entry may set config.default_role: true; found "
+            + ", ".join(default_role_sources)
+        )
 
     _validate_policy_ladder(policies)
     _validate_synthetic_role_names(policies, role_names)
@@ -1478,6 +1452,7 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
             sso=role.sso,
             policy_titles=policy_titles,
             is_admin=role.is_admin,
+            default_role=role.default_role,
             inline_policy_title=inline_policy_title,
         )
         static_roles.append(resolved_role)
@@ -1494,6 +1469,8 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
                         admin=True if role.is_admin else None,
                     )
                 )
+        if role.default_role:
+            default_role_name = role.name
 
     return _DesiredAclState(
         policy_updates=policy_updates,
@@ -1536,25 +1513,56 @@ def _validate_top_level_keys(raw: dict[str, Any]) -> None:
         )
 
 
-def _validate_acl_section_keys(
-    value: dict[str, Any],
-    *,
-    allowed_keys: set[str],
-    section: str,
-    name: str,
-    hint: str,
-) -> None:
+def _validate_acl_entry_keys(value: dict[str, Any], *, section: str, name: str) -> None:
+    allowed_keys = set(ACL_ENTRY_KEYS)
+    if section == "roles":
+        allowed_keys.add(CONFIG_POLICIES_KEY)
     unknown_keys = sorted(
         key for key in value if key not in allowed_keys and not key.startswith("sso.")
     )
     if not unknown_keys:
         return
+    hint = (
+        f" Supported ACL entry fields are {', '.join(sorted(ACL_ENTRY_KEYS))} "
+        "and any `sso.<claim>` selector."
+    )
+    if section == "roles":
+        hint += f" Explicit roles also support the magic {CONFIG_POLICIES_KEY} key."
+    if section == "policies" and CONFIG_POLICIES_KEY in unknown_keys:
+        hint += (
+            f" {CONFIG_POLICIES_KEY} is only valid under top-level 'roles:' "
+            "because it composes existing named policies."
+        )
     raise ValueError(
         f"Unknown ACL fields in {section}.{name}: "
         + ", ".join(unknown_keys)
         + ". Supported fields: "
         + ", ".join([*sorted(allowed_keys), "sso.<claim>"])
-        + f". {hint}"
+        + "."
+        + hint
+    )
+
+
+def _parse_acl_entry(value: dict[str, Any], field_name: str) -> _ParsedAclEntry:
+    sso = _coerce_sso_selectors(value, field_name)
+    read = _coerce_string_list(
+        value.get("buckets.read", []), f"{field_name}.buckets.read"
+    )
+    read_write = _coerce_string_list(
+        value.get("buckets.read_write", []), f"{field_name}.buckets.read_write"
+    )
+    default_role = value.get("config.default_role", False)
+    if not isinstance(default_role, bool):
+        raise ValueError(f"{field_name}.config.default_role must be a boolean")
+    is_admin = value.get("config.is_admin")
+    if is_admin is not None and not isinstance(is_admin, bool):
+        raise ValueError(f"{field_name}.config.is_admin must be a boolean")
+    return _ParsedAclEntry(
+        sso=sso,
+        read=_dedupe_preserve_order(read),
+        read_write=_dedupe_preserve_order(read_write),
+        default_role=default_role,
+        is_admin=is_admin,
     )
 
 
@@ -1664,6 +1672,8 @@ def _print_verbose_state(
         print(f"{prefix} role {role.name}")
         print(f"    sso: {_format_sso_selectors(role.sso)}")
         print(f"    policies: {', '.join(role.policy_titles) or '(none)'}")
+        if desired_state.default_role_name == role.name:
+            print("    default_role: true")
         if role.inline_policy_title is not None:
             print(f"    inline policy: {role.inline_policy_title}")
         if role.is_admin:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -779,6 +779,7 @@ def apply_acl(
             continue
         print(f"  ~ role {role.name}")
 
+    sso_text_to_restore = current.sso_config_text
     if diff.sso_needs_update and diff.sso_config_text is not None:
         _print_apply_step("update sso config", verbose=verbose)
         # Failed roles would make the registry reject the entire SSO config
@@ -824,6 +825,7 @@ def apply_acl(
                 warnings.append(f"SSO config could not be updated: {detail}")
                 print(f"  ! sso config: {detail}", file=sys.stderr)
             else:
+                sso_text_to_restore = pruned_text
                 prefix = "+" if diff.sso_is_create else "~"
                 print(f"  {prefix} sso config")
 
@@ -883,16 +885,22 @@ def apply_acl(
                 f"Role '{role_name}' could not be deleted: {format_exception(exc)}"
             )
 
-    if sso_cleared_for_role_delete and diff.sso_config_text is not None:
+    if sso_cleared_for_role_delete and sso_text_to_restore is not None:
         _print_apply_step("restore sso config", verbose=verbose)
         try:
-            stack.admin.sso_config.set(diff.sso_config_text)
+            stack.admin.sso_config.set(sso_text_to_restore)
         except Exception as exc:
             detail = format_exception(exc)
             warnings.append(f"SSO config could not be restored: {detail}")
             print(f"  ! sso config: {detail}", file=sys.stderr)
         else:
             print("  ~ sso config (restored)")
+    elif sso_cleared_for_role_delete:
+        warnings.append(
+            "SSO config was cleared for role deletion and no SSO config text "
+            "was available to restore."
+        )
+        print("  ! sso config: no restore payload available", file=sys.stderr)
 
     warnings.extend(
         detach_policies_from_roles(
@@ -1033,7 +1041,7 @@ def detach_all_policies_from_roles(
                     f"before delete: {detail}"
                 )
                 warnings.extend(fallback_warnings)
-            print(f"  ! role {role_name}: {detail}", file=sys.stderr)
+                print(f"  ! role {role_name}: {detail}", file=sys.stderr)
     return warnings
 
 
@@ -1587,9 +1595,9 @@ def _policy_audience_is_compatible(
         return True
     for claim, current_values in current_sso.items():
         previous_values = previous_sso.get(claim)
-        if previous_values is not None and not set(current_values) <= set(
-            previous_values
-        ):
+        if previous_values is None:
+            return False
+        if not set(current_values) <= set(previous_values):
             return False
     return True
 

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import replace
 
 from quiltx import acl as acl_lib
 from quiltx import stack as stack_lib
@@ -40,12 +39,6 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show planned changes without applying them.",
     )
-    parser.add_argument(
-        "--store-last-login-context",
-        action="store_true",
-        default=False,
-        help="Enable store_last_login_context in SSO config for debugging.",
-    )
     return parser
 
 
@@ -78,8 +71,6 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             return 0
 
         desired = acl_lib.parse_acl_config(args.config_file)
-        if args.store_last_login_context:
-            desired = replace(desired, store_last_login_context=True)
         current = acl_lib.fetch_current_state(stack)
         diff = acl_lib.compute_diff(desired, current)
         acl_lib.print_diff(diff, verbose=args.verbose, desired=desired, current=current)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -133,7 +133,11 @@ roles: {}
     policy_message = str(policy_error.value)
     assert "Unknown ACL fields in policies.exec" in policy_message
     assert "config.policies" in policy_message
-    assert "belong under top-level 'roles:'" in policy_message
+    assert "only valid under top-level 'roles:'" in policy_message
+    assert (
+        "Supported ACL entry fields are buckets.read, buckets.read_write, "
+        "config.default_role, config.is_admin" in policy_message
+    )
 
     role_path = tmp_path / "role.yml"
     role_path.write_text("""
@@ -154,6 +158,7 @@ roles:
     assert "unknown" in role_message
     assert "sso.users" not in role_message
     assert "sso.<claim>" in role_message
+    assert "Explicit roles also support the magic config.policies key" in role_message
 
 
 def test_parse_acl_config_accepts_arbitrary_sso_claims(tmp_path: Path) -> None:
@@ -233,6 +238,19 @@ roles: {}
     with pytest.raises(ValueError, match="policies.public.config.default_role"):
         acl.parse_acl_config(default_path)
 
+    role_default_path = tmp_path / "role_default.yml"
+    role_default_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+roles:
+  exec:
+    sso.groups: [Executives]
+    config.default_role: "yes"
+""")
+    with pytest.raises(ValueError, match="roles.exec.config.default_role"):
+        acl.parse_acl_config(role_default_path)
+
 
 def test_parse_acl_config_rejects_unknown_static_role_policy(tmp_path: Path) -> None:
     config_path = tmp_path / "acl.yml"
@@ -250,7 +268,7 @@ roles:
         acl.parse_acl_config(config_path)
 
 
-def test_parse_acl_config_rejects_multiple_default_policies(tmp_path: Path) -> None:
+def test_parse_acl_config_rejects_multiple_default_entries(tmp_path: Path) -> None:
     config_path = tmp_path / "acl.yml"
     config_path.write_text("""
 policies:
@@ -259,11 +277,15 @@ policies:
     config.default_role: true
   internal:
     sso.groups: [Everyone]
+roles:
+  exec:
+    sso.groups: [Executives]
     config.default_role: true
-roles: {}
 """)
 
-    with pytest.raises(ValueError, match="Only one policy may set config.default_role"):
+    with pytest.raises(
+        ValueError, match="Only one ACL entry may set config.default_role"
+    ):
         acl.parse_acl_config(config_path)
 
 
@@ -401,6 +423,28 @@ roles:
         }
     }
     assert payload["mappings"][2]["schema"]["required"] == ["email"]
+
+
+def test_static_role_can_be_default_role(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+roles:
+  exec:
+    sso.groups: [Executives]
+    config.policies: [public]
+    config.default_role: true
+""")
+
+    config = acl.parse_acl_config(config_path)
+    sso_config = acl.build_sso_config(config)
+    assert sso_config is not None
+    payload = yaml.safe_load(sso_config)
+
+    assert config.roles["exec"].default_role is True
+    assert payload["default_role"] == "exec"
 
 
 def test_policy_config_is_admin_marks_synthesized_role_admin(tmp_path: Path) -> None:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -92,7 +92,7 @@ roles: {}
     config = acl.parse_acl_config(config_path)
 
     assert [policy.name for policy in config.policies] == ["public"]
-    assert config.policies[0].groups == ["Everyone"]
+    assert config.policies[0].sso == {"groups": ["Everyone"]}
     assert config.roles == {}
 
 
@@ -123,7 +123,7 @@ def test_parse_acl_config_rejects_unknown_policy_and_role_fields(
     policy_path.write_text("""
 policies:
   exec:
-    sso.users: [ernest@example.com]
+    sso.groups: [Everyone]
     config.policies: [public]
 roles: {}
 """)
@@ -133,7 +133,6 @@ roles: {}
     policy_message = str(policy_error.value)
     assert "Unknown ACL fields in policies.exec" in policy_message
     assert "config.policies" in policy_message
-    assert "sso.users" in policy_message
     assert "belong under top-level 'roles:'" in policy_message
 
     role_path = tmp_path / "role.yml"
@@ -145,14 +144,56 @@ roles:
   exec:
     sso.users: [ernest@example.com]
     config.policies: [public]
+    unknown: true
 """)
     with pytest.raises(ValueError) as role_error:
         acl.parse_acl_config(role_path)
 
     role_message = str(role_error.value)
     assert "Unknown ACL fields in roles.exec" in role_message
-    assert "sso.users" in role_message
-    assert "User-specific SSO selectors" in role_message
+    assert "unknown" in role_message
+    assert "sso.users" not in role_message
+    assert "sso.<claim>" in role_message
+
+
+def test_parse_acl_config_accepts_arbitrary_sso_claims(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+  sales:
+    sso.department: [Sales]
+roles:
+  owner:
+    sso.email: [owner@example.com]
+    config.policies: [public]
+""")
+
+    config = acl.parse_acl_config(config_path)
+
+    assert config.policies[1].sso == {"department": ["Sales"]}
+    assert config.roles["owner"].sso == {"email": ["owner@example.com"]}
+
+
+def test_parse_acl_config_accepts_user_policy_after_group_policy(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+  internal:
+    sso.groups: [Employees]
+  exec:
+    sso.users: [ernest@quilt.bio]
+roles: {}
+""")
+
+    config = acl.parse_acl_config(config_path)
+
+    assert config.policies[2].sso == {"users": ["ernest@quilt.bio"]}
 
 
 def test_parse_acl_config_rejects_non_list_groups_and_non_bool_flags(
@@ -284,11 +325,15 @@ roles:
 
 def test_all_buckets_includes_inline_role_buckets() -> None:
     config = acl.AclConfig(
-        policies=[acl.AclPolicy(name="public", groups=["Everyone"], read=["bucket-a"])],
+        policies=[
+            acl.AclPolicy(
+                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+            )
+        ],
         roles={
             "exec": acl.AclStaticRole(
                 name="exec",
-                groups=["Executives"],
+                sso={"groups": ["Executives"]},
                 read=["bucket-b"],
                 read_write=["bucket-c"],
             )
@@ -317,6 +362,45 @@ def test_build_sso_config_emits_policy_and_static_role_mappings() -> None:
     # any co-matching admin role.
     assert "admin" not in payload["mappings"][0]
     assert "admin" not in payload["mappings"][1]
+
+
+def test_build_sso_config_emits_arbitrary_sso_claim_schema(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+  sales:
+    sso.department: [Sales]
+roles:
+  owner:
+    sso.email: [owner@example.com]
+    config.policies: [public]
+""")
+
+    config = acl.parse_acl_config(config_path)
+    sso_config = acl.build_sso_config(config)
+    assert sso_config is not None
+    payload = yaml.safe_load(sso_config)
+
+    assert payload["mappings"][1]["schema"]["properties"] == {
+        "department": {
+            "anyOf": [
+                {"const": "Sales"},
+                {"type": "array", "contains": {"const": "Sales"}},
+            ]
+        }
+    }
+    assert payload["mappings"][1]["schema"]["required"] == ["department"]
+    assert payload["mappings"][2]["schema"]["properties"] == {
+        "email": {
+            "anyOf": [
+                {"const": "owner@example.com"},
+                {"type": "array", "contains": {"const": "owner@example.com"}},
+            ]
+        }
+    }
+    assert payload["mappings"][2]["schema"]["required"] == ["email"]
 
 
 def test_policy_config_is_admin_marks_synthesized_role_admin(tmp_path: Path) -> None:
@@ -415,7 +499,10 @@ def test_compute_diff_single_policy_config_produces_one_synthesized_role() -> No
     desired = acl.AclConfig(
         policies=[
             acl.AclPolicy(
-                name="public", groups=["Everyone"], read=["bucket-a"], default_role=True
+                name="public",
+                sso={"groups": ["Everyone"]},
+                read=["bucket-a"],
+                default_role=True,
             )
         ],
         roles={},
@@ -430,15 +517,23 @@ def test_compute_diff_single_policy_config_produces_one_synthesized_role() -> No
 def test_reordering_policies_changes_synthesized_role_names() -> None:
     first = acl.AclConfig(
         policies=[
-            acl.AclPolicy(name="public", groups=["Everyone"], read=["bucket-a"]),
-            acl.AclPolicy(name="internal", groups=["Everyone"], read=["bucket-b"]),
+            acl.AclPolicy(
+                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+            ),
+            acl.AclPolicy(
+                name="internal", sso={"groups": ["Everyone"]}, read=["bucket-b"]
+            ),
         ],
         roles={},
     )
     second = acl.AclConfig(
         policies=[
-            acl.AclPolicy(name="internal", groups=["Everyone"], read=["bucket-b"]),
-            acl.AclPolicy(name="public", groups=["Everyone"], read=["bucket-a"]),
+            acl.AclPolicy(
+                name="internal", sso={"groups": ["Everyone"]}, read=["bucket-b"]
+            ),
+            acl.AclPolicy(
+                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+            ),
         ],
         roles={},
     )
@@ -510,12 +605,18 @@ def test_compute_diff_warns_and_skips_unmanaged_name_collisions() -> None:
 
 def test_changing_policy_groups_updates_sso_config() -> None:
     original = acl.AclConfig(
-        policies=[acl.AclPolicy(name="public", groups=["Everyone"], read=["bucket-a"])],
+        policies=[
+            acl.AclPolicy(
+                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+            )
+        ],
         roles={},
     )
     updated = acl.AclConfig(
         policies=[
-            acl.AclPolicy(name="public", groups=["Employees"], read=["bucket-a"])
+            acl.AclPolicy(
+                name="public", sso={"groups": ["Employees"]}, read=["bucket-a"]
+            )
         ],
         roles={},
     )
@@ -535,13 +636,13 @@ def test_policy_rename_cleans_up_old_synthesized_role_in_single_pass() -> None:
         policies=[
             acl.AclPolicy(
                 name="public",
-                groups=["Everyone"],
+                sso={"groups": ["Everyone"]},
                 read=["quilt-example"],
                 default_role=True,
             ),
             acl.AclPolicy(
                 name="employees",
-                groups=["Employees"],
+                sso={"groups": ["Employees"]},
                 read=["quilt-leadership"],
                 read_write=["quilt-bake", "quilt-dev"],
             ),
@@ -549,7 +650,7 @@ def test_policy_rename_cleans_up_old_synthesized_role_in_single_pass() -> None:
         roles={
             "exec": acl.AclStaticRole(
                 name="exec",
-                groups=["Executives"],
+                sso={"groups": ["Executives"]},
                 policies=["public", "employees"],
                 read_write=["quilt-leadership"],
                 is_admin=True,
@@ -647,7 +748,7 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
                 policies=[
                     acl.AclPolicy(
                         name="public",
-                        groups=["Everyone"],
+                        sso={"groups": ["Everyone"]},
                         read=["bucket-a"],
                         default_role=True,
                     )
@@ -668,6 +769,204 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         ("sso_set", "public"),
         ("role_delete", "legacy_role"),
         ("policy_delete", "legacy_policy"),
+    ]
+
+
+def test_apply_acl_detaches_users_before_deleting_roles() -> None:
+    calls: list[tuple[Any, ...]] = []
+
+    def sso_set(text: str | None) -> None:
+        calls.append(("sso_set", text))
+
+    stack = _fake_stack(
+        policies=SimpleNamespace(delete=lambda title: None),
+        roles=SimpleNamespace(
+            delete=lambda name: calls.append(("role_delete", name)),
+            get_default=lambda: SimpleNamespace(name="default"),
+        ),
+        sso_config=SimpleNamespace(set=sso_set),
+        users=SimpleNamespace(
+            list=lambda: [
+                SimpleNamespace(
+                    name="alice",
+                    role=SimpleNamespace(name="legacy_role"),
+                    extra_roles=[],
+                )
+            ],
+            remove_roles=lambda name, roles, *, fallback: calls.append(
+                ("remove_roles", name, list(roles), fallback)
+            ),
+        ),
+    )
+
+    diff = acl.AclDiff(
+        roles_to_delete=["legacy_role"],
+        sso_config_text="version: '1.0'\nmappings: []\n",
+    )
+
+    warnings = acl.apply_acl(stack, diff, _empty_current_state())
+
+    assert warnings == []
+    assert calls == [
+        ("sso_set", None),
+        ("remove_roles", "alice", ["legacy_role"], "default"),
+        ("role_delete", "legacy_role"),
+        ("sso_set", "version: '1.0'\nmappings: []\n"),
+    ]
+
+
+def test_apply_acl_detaches_policies_before_deleting_roles() -> None:
+    calls: list[tuple[Any, ...]] = []
+    inline_policy = FakePolicy(
+        id="id-inline",
+        title="exec__inline",
+        managed=True,
+        permissions=[],
+        roles=[],
+    )
+    current = _empty_current_state()
+    current.managed_policies["exec__inline"] = inline_policy
+    current.all_policies.update(current.managed_policies)
+    current.managed_roles["exec"] = FakeRole(
+        id="id-exec",
+        name="exec",
+        policies=[FakePolicySummary(id="id-inline", title="exec__inline")],
+        permissions=[],
+    )
+    current.all_roles.update(current.managed_roles)
+
+    def role_update(role_ref: str, *, name: str, policies: list[str]) -> None:
+        calls.append(("role_update", role_ref, name, list(policies)))
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(
+            update_managed=role_update,
+            delete=lambda name: calls.append(("role_delete", name)),
+        ),
+        users=SimpleNamespace(list=lambda: []),
+        sso_config=SimpleNamespace(get=lambda: None),
+        policies=SimpleNamespace(delete=lambda title: None),
+    )
+
+    warnings = acl.apply_acl(stack, acl.AclDiff(roles_to_delete=["exec"]), current)
+
+    assert warnings == []
+    assert calls == [
+        ("role_update", "id-exec", "exec", []),
+        ("role_delete", "id-exec"),
+    ]
+
+
+def test_apply_acl_falls_back_to_policy_update_when_role_detach_fails() -> None:
+    calls: list[tuple[Any, ...]] = []
+    exec_role = FakeRole(
+        id="id-exec",
+        name="exec",
+        policies=[FakePolicySummary(id="id-inline", title="exec__inline")],
+        permissions=[],
+    )
+    inline_policy = FakePolicy(
+        id="id-inline",
+        title="exec__inline",
+        managed=True,
+        permissions=[],
+        roles=[exec_role],
+    )
+    current = _empty_current_state()
+    current.managed_roles["exec"] = exec_role
+    current.all_roles.update(current.managed_roles)
+    current.managed_policies["exec__inline"] = inline_policy
+    current.all_policies.update(current.managed_policies)
+
+    def role_update(role_ref: str, *, name: str, policies: list[str]) -> None:
+        calls.append(("role_update", role_ref, name, list(policies)))
+        raise RuntimeError("role update failed")
+
+    def policy_update(
+        policy_ref: str,
+        *,
+        title: str,
+        permissions: list[Any],
+        roles: list[str],
+    ) -> FakePolicy:
+        calls.append(("policy_update", policy_ref, title, list(roles)))
+        return inline_policy
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(
+            update_managed=role_update,
+            delete=lambda name: calls.append(("role_delete", name)),
+        ),
+        policies=SimpleNamespace(
+            update_managed=policy_update,
+            delete=lambda title: None,
+        ),
+        users=SimpleNamespace(list=lambda: []),
+        sso_config=SimpleNamespace(get=lambda: None),
+    )
+
+    warnings = acl.apply_acl(stack, acl.AclDiff(roles_to_delete=["exec"]), current)
+
+    assert warnings == []
+    assert calls == [
+        ("role_update", "id-exec", "exec", []),
+        ("policy_update", "id-inline", "exec__inline", []),
+        ("role_delete", "id-exec"),
+    ]
+
+
+def test_apply_acl_detaches_deleted_policies_from_surviving_roles() -> None:
+    calls: list[tuple[Any, ...]] = []
+    legacy_policy = FakePolicy(
+        id="id-legacy",
+        title="legacy_policy",
+        managed=True,
+        permissions=[],
+        roles=[],
+    )
+    keep_policy = FakePolicy(
+        id="id-keep",
+        title="keep_policy",
+        managed=True,
+        permissions=[],
+        roles=[],
+    )
+    current = _empty_current_state()
+    current.managed_policies.update(
+        {"legacy_policy": legacy_policy, "keep_policy": keep_policy}
+    )
+    current.all_policies.update(current.managed_policies)
+    current.managed_roles["survivor"] = FakeRole(
+        id="id-survivor",
+        name="survivor",
+        policies=[
+            FakePolicySummary(id="id-legacy", title="legacy_policy"),
+            FakePolicySummary(id="id-keep", title="keep_policy"),
+        ],
+        permissions=[],
+    )
+    current.all_roles.update(current.managed_roles)
+
+    def role_update(role_ref: str, *, name: str, policies: list[str]) -> None:
+        calls.append(("role_update", role_ref, name, list(policies)))
+
+    stack = _fake_stack(
+        policies=SimpleNamespace(
+            delete=lambda title: calls.append(("policy_delete", title))
+        ),
+        roles=SimpleNamespace(update_managed=role_update),
+    )
+
+    warnings = acl.apply_acl(
+        stack,
+        acl.AclDiff(policies_to_delete=["legacy_policy"]),
+        current,
+    )
+
+    assert warnings == []
+    assert calls == [
+        ("role_update", "id-survivor", "survivor", ["id-keep"]),
+        ("policy_delete", "id-legacy"),
     ]
 
 
@@ -819,6 +1118,11 @@ def _current_state_for_config(config: acl.AclConfig) -> acl.CurrentState:
         )
         for name, update in desired_state.role_updates.items()
     }
+    for role in managed_roles.values():
+        for policy_summary in role.policies or []:
+            policy = managed_policies.get(policy_summary.title)
+            if policy is not None:
+                policy.roles.append(role)
     buckets = {
         bucket: FakeBucket(name=bucket, title=bucket)
         for bucket in acl.all_buckets(config)
@@ -1084,6 +1388,13 @@ def test_is_internal_server_error_skips_validation_and_auth() -> None:
     assert not acl._is_internal_server_error("Unauthorized")
     assert not acl._is_internal_server_error("Not Found")
     assert not acl._is_internal_server_error("")
+
+
+def test_format_exception_avoids_duplicate_graphql_message() -> None:
+    exc = RuntimeError("Internal Server Error")
+    exc.errors = [SimpleNamespace(message="Internal Server Error", path=["role"])]  # type: ignore[attr-defined]
+
+    assert acl.format_exception(exc) == "Internal Server Error (path: ['role'])"
 
 
 def test_format_permissions_empty() -> None:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -189,8 +189,6 @@ def test_parse_acl_config_accepts_user_policy_after_group_policy(
 policies:
   public:
     sso.groups: [Everyone]
-  internal:
-    sso.groups: [Employees]
   exec:
     sso.users: [ernest@quilt.bio]
 roles: {}
@@ -198,7 +196,7 @@ roles: {}
 
     config = acl.parse_acl_config(config_path)
 
-    assert config.policies[2].sso == {"users": ["ernest@quilt.bio"]}
+    assert config.policies[1].sso == {"users": ["ernest@quilt.bio"]}
 
 
 def test_parse_acl_config_rejects_non_list_groups_and_non_bool_flags(
@@ -297,6 +295,23 @@ policies:
     sso.groups: [Contractors]
   finance:
     sso.groups: [Executives]
+roles: {}
+""")
+
+    with pytest.raises(ValueError, match="Policy ladder is not nested"):
+        acl.parse_acl_config(config_path)
+
+
+def test_parse_acl_config_rejects_policy_ladder_with_new_sso_claim(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  internal:
+    sso.groups: [Employees]
+  exec:
+    sso.users: [ernest@quilt.bio]
 roles: {}
 """)
 
@@ -845,10 +860,12 @@ def test_apply_acl_detaches_users_before_deleting_roles() -> None:
 
     diff = acl.AclDiff(
         roles_to_delete=["legacy_role"],
-        sso_config_text="version: '1.0'\nmappings: []\n",
+    )
+    current = replace(
+        _empty_current_state(), sso_config_text="version: '1.0'\nmappings: []\n"
     )
 
-    warnings = acl.apply_acl(stack, diff, _empty_current_state())
+    warnings = acl.apply_acl(stack, diff, current)
 
     assert warnings == []
     assert calls == [
@@ -856,6 +873,77 @@ def test_apply_acl_detaches_users_before_deleting_roles() -> None:
         ("remove_roles", "alice", ["legacy_role"], "default"),
         ("role_delete", "legacy_role"),
         ("sso_set", "version: '1.0'\nmappings: []\n"),
+    ]
+
+
+def test_apply_acl_restores_pruned_sso_after_role_delete_clear() -> None:
+    sso_calls: list[dict[str, Any] | None] = []
+
+    def role_create(name: str, policies: list[str]) -> FakeRole:
+        if name == "exec":
+            raise RuntimeError("role create failed")
+        return FakeRole(id=f"id-{name}", name=name, policies=[], permissions=[])
+
+    def sso_set(text: str | None) -> None:
+        sso_calls.append(None if text is None else yaml.safe_load(text))
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(
+            create_managed=role_create,
+            delete=lambda name: None,
+            get_default=lambda: SimpleNamespace(name="public"),
+        ),
+        sso_config=SimpleNamespace(set=sso_set),
+        users=SimpleNamespace(
+            list=lambda: [
+                SimpleNamespace(
+                    name="alice",
+                    role=SimpleNamespace(name="legacy_role"),
+                    extra_roles=[],
+                )
+            ],
+            remove_roles=lambda *args, **kwargs: None,
+        ),
+    )
+
+    diff = acl.AclDiff(
+        roles_to_create=[
+            acl.RoleUpdate(name="public", policy_titles=[]),
+            acl.RoleUpdate(name="exec", policy_titles=[]),
+        ],
+        roles_to_delete=["legacy_role"],
+        sso_config_text=yaml.safe_dump(
+            {
+                "version": "1.0",
+                "default_role": "public",
+                "mappings": [
+                    {
+                        "schema": {"properties": {}, "required": []},
+                        "roles": ["public"],
+                    },
+                    {
+                        "schema": {"properties": {}, "required": []},
+                        "roles": ["exec"],
+                    },
+                ],
+            }
+        ),
+        sso_needs_update=True,
+    )
+
+    warnings = acl.apply_acl(stack, diff, _empty_current_state())
+
+    assert any("Role 'exec' could not be created" in warning for warning in warnings)
+    assert [call["default_role"] if call else None for call in sso_calls] == [
+        "public",
+        None,
+        "public",
+    ]
+    restored_payload = sso_calls[0]
+    assert restored_payload is not None
+    assert restored_payload == sso_calls[2]
+    assert restored_payload["mappings"] == [
+        {"schema": {"properties": {}, "required": []}, "roles": ["public"]}
     ]
 
 
@@ -901,7 +989,9 @@ def test_apply_acl_detaches_policies_before_deleting_roles() -> None:
     ]
 
 
-def test_apply_acl_falls_back_to_policy_update_when_role_detach_fails() -> None:
+def test_apply_acl_falls_back_to_policy_update_when_role_detach_fails(
+    capsys,
+) -> None:
     calls: list[tuple[Any, ...]] = []
     exec_role = FakeRole(
         id="id-exec",
@@ -952,6 +1042,7 @@ def test_apply_acl_falls_back_to_policy_update_when_role_detach_fails() -> None:
     warnings = acl.apply_acl(stack, acl.AclDiff(roles_to_delete=["exec"]), current)
 
     assert warnings == []
+    assert "role exec: role update failed" not in capsys.readouterr().err
     assert calls == [
         ("role_update", "id-exec", "exec", []),
         ("policy_update", "id-inline", "exec__inline", []),

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -116,6 +116,45 @@ groups: {}
         acl.parse_acl_config(config_path)
 
 
+def test_parse_acl_config_rejects_unknown_policy_and_role_fields(
+    tmp_path: Path,
+) -> None:
+    policy_path = tmp_path / "policy.yml"
+    policy_path.write_text("""
+policies:
+  exec:
+    sso.users: [ernest@example.com]
+    config.policies: [public]
+roles: {}
+""")
+    with pytest.raises(ValueError) as policy_error:
+        acl.parse_acl_config(policy_path)
+
+    policy_message = str(policy_error.value)
+    assert "Unknown ACL fields in policies.exec" in policy_message
+    assert "config.policies" in policy_message
+    assert "sso.users" in policy_message
+    assert "belong under top-level 'roles:'" in policy_message
+
+    role_path = tmp_path / "role.yml"
+    role_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+roles:
+  exec:
+    sso.users: [ernest@example.com]
+    config.policies: [public]
+""")
+    with pytest.raises(ValueError) as role_error:
+        acl.parse_acl_config(role_path)
+
+    role_message = str(role_error.value)
+    assert "Unknown ACL fields in roles.exec" in role_message
+    assert "sso.users" in role_message
+    assert "User-specific SSO selectors" in role_message
+
+
 def test_parse_acl_config_rejects_non_list_groups_and_non_bool_flags(
     tmp_path: Path,
 ) -> None:
@@ -278,6 +317,58 @@ def test_build_sso_config_emits_policy_and_static_role_mappings() -> None:
     # any co-matching admin role.
     assert "admin" not in payload["mappings"][0]
     assert "admin" not in payload["mappings"][1]
+
+
+def test_policy_config_is_admin_marks_synthesized_role_admin(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+    config.is_admin: true
+roles: {}
+""")
+
+    config = acl.parse_acl_config(config_path)
+    sso_config = acl.build_sso_config(config)
+    assert sso_config is not None
+    payload = yaml.safe_load(sso_config)
+
+    assert config.policies[0].is_admin is True
+    assert payload["mappings"][0]["roles"] == ["public"]
+    assert payload["mappings"][0]["admin"] is True
+
+
+def test_policy_config_is_admin_false_vetoes_generated_role_admin_and_warns(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+    config.is_admin: true
+  internal:
+    sso.groups: [Employees]
+    config.is_admin: false
+roles: {}
+""")
+
+    desired = acl.parse_acl_config(config_path)
+    diff = acl.compute_diff(desired, _empty_current_state())
+    assert diff.sso_config_text is not None
+    payload = yaml.safe_load(diff.sso_config_text)
+
+    assert payload["mappings"][0]["roles"] == ["public"]
+    assert payload["mappings"][0]["admin"] is True
+    assert payload["mappings"][1]["roles"] == ["internal_public"]
+    assert payload["mappings"][1]["admin"] is False
+    assert any(
+        "config.is_admin: false" in warning
+        and "vetoes" in warning
+        and "internal_public" in warning
+        for warning in diff.warnings
+    )
 
 
 def test_compute_diff_from_simpler_stack_acl_example_against_empty_state() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary

- Generalize `quiltx catalog acl` SSO support: accept arbitrary `sso.<claim>` selectors (scalar or array) instead of only `sso.groups`.
- Resolve role/policy IDs from fetched state before update/delete to avoid quilt3 name-as-ID lookups that surface as opaque `Internal Server Error`.
- Detach users, SSO mappings, and policy associations before deleting managed roles or policies so stale resources can be removed cleanly.
- De-duplicate GraphQL error formatting (no more `Internal Server Error: Internal Server Error`).
- Bump to 0.14.2; CHANGELOG and README updated.

## Validation

- `./poe lint`
- `uv run pytest tests`
- Live apply against `databricks.dev.quilttest.com`, then dry-run shows `Stack ACL is up to date`.