### PR TITLE
Catalog API keys (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-08
+
+### Added
+
+- `quiltx catalog api-key` prints the stored `qk_...` API key for a catalog, with `--new` to mint, store, and print a replacement. Supports browser-based login or `--username`/`--password` U/P bootstrap, plus `--insecure` for localhost testing.
+- `quiltx catalog login` mints and stores a catalog API key during the auth flow so downstream tools can reuse it without re-authenticating.
+
 ## [0.15.0] - 2026-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.15.0"
+version = "0.16.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/quiltx/auth.py
+++ b/quiltx/auth.py
@@ -6,7 +6,7 @@ CLI ladder ([05 §4]):
   1. --api-key flag
   2. QUILTX_API_KEY env var
   3. Keyring entry for catalog.catalog_name
-  4. Interactive prompt (only if TTY + not --no-prompt + not QUILTX_NO_PROMPT)
+  4. Interactive browser/SSO auth flow
   5. Error
 
 API ladder (no CLI args, no TTY):
@@ -15,7 +15,7 @@ API ladder (no CLI args, no TTY):
   3. Keyring entry for catalog.catalog_name
   4. Error
 
-``source`` is one of: "flag", "env", "keyring", "prompt".
+``source`` is one of: "flag", "env", "keyring", "auth-flow".
 
 When ``skip_keyring=True`` is passed, step 3 is skipped — used by the retry
 envelope in @catalog_command after an auth failure to force re-prompt
@@ -24,7 +24,6 @@ envelope in @catalog_command after an auth failure to force re-prompt
 
 from __future__ import annotations
 
-import getpass
 import os
 import sys
 from typing import TYPE_CHECKING, Literal, NamedTuple
@@ -34,7 +33,7 @@ from quiltx import credentials
 if TYPE_CHECKING:
     from quiltx.stack import Catalog
 
-CredentialSource = Literal["flag", "env", "keyring", "prompt"]
+CredentialSource = Literal["flag", "env", "keyring", "auth-flow"]
 
 
 class ResolvedCredentials(NamedTuple):
@@ -53,10 +52,6 @@ def _no_prompt_active(args: object | None) -> bool:
     if args is not None and getattr(args, "no_prompt", False):
         return True
     return False
-
-
-def _generate_url_for(catalog: "Catalog") -> str:
-    return f"{catalog.catalog_url.rstrip('/')}/profile/api-keys"
 
 
 def resolve_cli(
@@ -88,12 +83,12 @@ def resolve_cli(
         if stored is not None:
             return ResolvedCredentials(stored["api_key"], "keyring")
 
-    # 4. Interactive prompt
+    # 4. Interactive auth flow
     if _no_prompt_active(args) or not sys.stdin.isatty():
         raise CredentialError(
             f"No API key available for {dns}. "
             "Provide --api-key, set QUILTX_API_KEY, "
-            "or run interactively to be prompted."
+            f"or run `quiltx catalog api-key --catalog {dns}` interactively."
         )
 
     if skip_keyring:
@@ -103,27 +98,20 @@ def resolve_cli(
         )
     else:
         print(f"No stored API key for {dns}.", file=sys.stderr)
-    print(
-        f"Generate one at {_generate_url_for(catalog)}",
-        file=sys.stderr,
-    )
+
+    from quiltx.tools.catalog import login as login_tool
+
     try:
-        api_key = getpass.getpass("API key: ")
-    except (KeyboardInterrupt, EOFError):
-        print("\nAborted.", file=sys.stderr)
-        raise CredentialError(f"Authentication aborted for {dns}.")
-
-    api_key = api_key.strip()
-    if not api_key:
-        raise CredentialError(f"Empty API key entered for {dns}.")
-    if not api_key.startswith("qk_"):
-        raise CredentialError(
-            f"Invalid API key for {dns}: Quilt API keys begin with 'qk_'."
+        minted = login_tool.mint_api_key(
+            catalog.catalog_url,
+            dns,
+            no_prompt=False,
         )
+    except login_tool.LoginError as exc:
+        raise CredentialError(str(exc)) from exc
 
-    # Store for future runs (paste-only bootstrap leaves name/expires_at null)
-    credentials.set(dns, api_key)
-    return ResolvedCredentials(api_key, "prompt")
+    login_tool.print_stored_message(minted, dns)
+    return ResolvedCredentials(minted.secret, "auth-flow")
 
 
 def resolve_api(

--- a/quiltx/tools/catalog/__init__.py
+++ b/quiltx/tools/catalog/__init__.py
@@ -8,6 +8,7 @@ from importlib import import_module
 
 SUBCOMMANDS = {
     "acl": "quiltx.tools.catalog.acl",
+    "api-key": "quiltx.tools.catalog.api_key",
     "default": "quiltx.tools.catalog.default",
     "forget": "quiltx.tools.catalog.forget",
     "list": "quiltx.tools.catalog.list_",
@@ -31,6 +32,11 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "acl",
         help="Reconcile Quilt bucket, role, policy, and SSO ACLs from YAML.",
+        add_help=False,
+    )
+    subparsers.add_parser(
+        "api-key",
+        help="Mint, store, and print a new qk_... API key.",
         add_help=False,
     )
     subparsers.add_parser(

--- a/quiltx/tools/catalog/api_key.py
+++ b/quiltx/tools/catalog/api_key.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+from quiltx import credentials
 from quiltx.cli_common import add_catalog_args
 from quiltx.identity import build_catalog_url, normalize_dns
 from quiltx.tools.catalog import login as login_cmd
@@ -14,7 +15,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="quiltx catalog api-key",
         description=(
-            "Mint a new qk_... API key, store it locally, and print the secret."
+            "Print the stored qk_... API key for a catalog. Use --new to "
+            "mint, store, and print a replacement key."
         ),
     )
     add_catalog_args(parser, auth_required=False)
@@ -60,6 +62,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=365,
         help="API key expiration window in days (1-365). Default: 365.",
     )
+    parser.add_argument(
+        "--new",
+        action="store_true",
+        help="Mint and store a new API key instead of printing the stored key.",
+    )
     return parser
 
 
@@ -79,6 +86,15 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
+
+    if not args.new:
+        stored = credentials.get(dns)
+        if stored is not None:
+            print(stored["api_key"])
+            return 0
+        if args.no_prompt:
+            print(f"Error: no stored API key for {dns}.", file=sys.stderr)
+            return 1
 
     catalog_url = build_catalog_url(dns, insecure=args.insecure)
 

--- a/quiltx/tools/catalog/api_key.py
+++ b/quiltx/tools/catalog/api_key.py
@@ -1,0 +1,106 @@
+"""Mint and display a Quilt catalog API key."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from quiltx.cli_common import add_catalog_args
+from quiltx.identity import build_catalog_url, normalize_dns
+from quiltx.tools.catalog import login as login_cmd
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="quiltx catalog api-key",
+        description=(
+            "Mint a new qk_... API key, store it locally, and print the secret."
+        ),
+    )
+    add_catalog_args(parser, auth_required=False)
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow http:// transport to localhost for testing local catalog "
+            "builds. Refused for any non-localhost target. Never persisted."
+        ),
+    )
+    parser.add_argument(
+        "--username",
+        help="Catalog admin username for U/P -> API-key bootstrap.",
+    )
+    parser.add_argument(
+        "--password",
+        help=(
+            "Catalog admin password. If --username is given without --password "
+            "in interactive mode, you will be prompted."
+        ),
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help=(
+            "Disable the default browser-based login flow; fall back to "
+            "interactive username/password prompts."
+        ),
+    )
+    parser.add_argument(
+        "--key-name",
+        default=None,
+        help=(
+            "Name for the new API key (visible in `quiltx catalog list`). "
+            "Defaults to quiltx-<host>-<YYYYMMDD>."
+        ),
+    )
+    parser.add_argument(
+        "--expires-in-days",
+        type=int,
+        default=365,
+        help="API key expiration window in days (1-365). Default: 365.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.catalog:
+        print(
+            "Error: --catalog <dns> is required for `quiltx catalog api-key`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        dns = normalize_dns(args.catalog, insecure=args.insecure)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    catalog_url = build_catalog_url(dns, insecure=args.insecure)
+
+    try:
+        minted = login_cmd.mint_api_key(
+            catalog_url,
+            dns,
+            username=args.username,
+            password=args.password,
+            no_browser=args.no_browser,
+            no_prompt=args.no_prompt,
+            key_name=args.key_name,
+            expires_in_days=args.expires_in_days,
+        )
+    except login_cmd.LoginError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2 if login_cmd.is_usage_error(exc) else 1
+
+    login_cmd.print_stored_message(minted, dns)
+    print(minted.secret)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quiltx/tools/catalog/api_key.py
+++ b/quiltx/tools/catalog/api_key.py
@@ -36,8 +36,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--password",
         help=(
-            "Catalog admin password. If --username is given without --password "
-            "in interactive mode, you will be prompted."
+            "Catalog admin password. INSECURE: visible in `ps`/process listings; "
+            "prefer omitting it so you are prompted via getpass on TTY."
         ),
     )
     parser.add_argument(
@@ -111,7 +111,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     except login_cmd.LoginError as exc:
         print(f"Error: {exc}", file=sys.stderr)
-        return 2 if login_cmd.is_usage_error(exc) else 1
+        return 2 if isinstance(exc, login_cmd.LoginUsageError) else 1
 
     login_cmd.print_stored_message(minted, dns)
     print(minted.secret)

--- a/quiltx/tools/catalog/login.py
+++ b/quiltx/tools/catalog/login.py
@@ -60,9 +60,8 @@ class LoginError(RuntimeError):
     """Raised when an interactive catalog login flow cannot complete."""
 
 
-def is_usage_error(exc: LoginError) -> bool:
-    message = str(exc)
-    return "--password is required" in message or "interactive TTY" in message
+class LoginUsageError(LoginError):
+    """Raised when the caller invoked the login flow with bad arguments."""
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -84,8 +83,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--password",
         help=(
-            "Catalog admin password. If --username is given without --password "
-            "in interactive mode, you will be prompted."
+            "Catalog admin password. INSECURE: visible in `ps`/process listings; "
+            "prefer omitting it so you are prompted via getpass on TTY."
         ),
     )
     parser.add_argument(
@@ -190,7 +189,7 @@ def mint_api_key(
         resolved_password = password
         if resolved_password is None:
             if not interactive:
-                raise LoginError(
+                raise LoginUsageError(
                     "--password is required when --username is set headlessly."
                 )
             try:
@@ -214,7 +213,7 @@ def mint_api_key(
         )
     else:
         if not interactive:
-            raise LoginError(
+            raise LoginUsageError(
                 "--username/--password or interactive TTY is required "
                 "(browser flow needs a TTY for paste-back)."
             )
@@ -251,7 +250,7 @@ def print_stored_message(minted: MintedApiKey, dns: str) -> None:
     if minted.expires_at:
         expiry_dt = _dt.datetime.fromtimestamp(minted.expires_at, _dt.timezone.utc)
         pretty_expiry = f" (expires {expiry_dt.strftime('%Y-%m-%d')})"
-    print(f"Stored API key '{minted.name}' for {dns}{pretty_expiry}.")
+    print(f"Stored API key '{minted.name}' for {dns}{pretty_expiry}.", file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -304,7 +303,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     except LoginError as exc:
         print(f"Error: {exc}", file=sys.stderr)
-        return 2 if is_usage_error(exc) else 1
+        return 2 if isinstance(exc, LoginUsageError) else 1
 
     print_stored_message(minted, dns)
     return 0

--- a/quiltx/tools/catalog/login.py
+++ b/quiltx/tools/catalog/login.py
@@ -22,6 +22,8 @@ import getpass
 import socket
 import sys
 
+from dataclasses import dataclass
+
 from quiltx import credentials, quilt_auth
 from quiltx.cli_common import add_catalog_args
 from quiltx.identity import build_catalog_url, normalize_dns
@@ -45,6 +47,22 @@ def _parse_expires_at(value: object) -> int | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=_dt.timezone.utc)
     return int(dt.timestamp())
+
+
+@dataclass(frozen=True)
+class MintedApiKey:
+    secret: str
+    name: str
+    expires_at: int | None
+
+
+class LoginError(RuntimeError):
+    """Raised when an interactive catalog login flow cannot complete."""
+
+
+def is_usage_error(exc: LoginError) -> bool:
+    message = str(exc)
+    return "--password is required" in message or "interactive TTY" in message
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -112,10 +130,9 @@ def _bootstrap_from_browser(
         refresh_token = input("Paste the code from the page here: ").strip()
     except (KeyboardInterrupt, EOFError):
         print("\nAborted.", file=sys.stderr)
-        raise SystemExit(1)
+        raise LoginError(f"Authentication aborted for {dns}.")
     if not refresh_token:
-        print("Error: no code provided.", file=sys.stderr)
-        raise SystemExit(1)
+        raise LoginError("No code provided.")
     try:
         return quilt_auth.bootstrap_api_key_from_refresh_token(
             catalog_url,
@@ -124,8 +141,7 @@ def _bootstrap_from_browser(
             expires_in_days=expires_in_days,
         )
     except quilt_auth.CatalogAuthError as exc:
-        print(f"Error: catalog rejected the code from {dns}: {exc}", file=sys.stderr)
-        raise SystemExit(1)
+        raise LoginError(f"Catalog rejected the code from {dns}: {exc}") from exc
 
 
 def _bootstrap_from_credentials(
@@ -147,14 +163,95 @@ def _bootstrap_from_credentials(
     except quilt_auth.CatalogAuthError as exc:
         # SSO-only catalogs reject /api/login; the catalog's body is in str(exc).
         message = str(exc)
-        print(f"Error: {message}", file=sys.stderr)
         if "sso" in message.lower() or "401" in message:
-            print(
-                "If this catalog uses SSO, mint a key from the catalog UI and "
-                "pass it via --api-key.",
-                file=sys.stderr,
+            message = (
+                f"{message}\nIf this catalog uses SSO, rerun without "
+                "--no-browser to use the browser auth flow."
             )
-        raise SystemExit(1)
+        raise LoginError(message) from exc
+
+
+def mint_api_key(
+    catalog_url: str,
+    dns: str,
+    *,
+    username: str | None = None,
+    password: str | None = None,
+    no_browser: bool = False,
+    no_prompt: bool = False,
+    key_name: str | None = None,
+    expires_in_days: int = 365,
+) -> MintedApiKey:
+    """Mint and store a catalog API key using browser SSO or U/P fallback."""
+    interactive = not no_prompt and sys.stdin.isatty()
+    name = key_name or _default_key_name()
+
+    if username is not None:
+        resolved_password = password
+        if resolved_password is None:
+            if not interactive:
+                raise LoginError(
+                    "--password is required when --username is set headlessly."
+                )
+            try:
+                resolved_password = getpass.getpass(f"Password for {username}@{dns}: ")
+            except (KeyboardInterrupt, EOFError) as exc:
+                print("\nAborted.", file=sys.stderr)
+                raise LoginError(f"Authentication aborted for {dns}.") from exc
+        result = _bootstrap_from_credentials(
+            catalog_url,
+            username=username,
+            password=resolved_password,
+            name=name,
+            expires_in_days=expires_in_days,
+        )
+    elif interactive and not no_browser:
+        result = _bootstrap_from_browser(
+            catalog_url,
+            dns,
+            name=name,
+            expires_in_days=expires_in_days,
+        )
+    else:
+        if not interactive:
+            raise LoginError(
+                "--username/--password or interactive TTY is required "
+                "(browser flow needs a TTY for paste-back)."
+            )
+        try:
+            prompted_username = input(f"Username for {dns}: ").strip()
+        except (KeyboardInterrupt, EOFError) as exc:
+            print("\nAborted.", file=sys.stderr)
+            raise LoginError(f"Authentication aborted for {dns}.") from exc
+        if not prompted_username:
+            raise LoginError("Username is required.")
+        try:
+            prompted_password = getpass.getpass(
+                f"Password for {prompted_username}@{dns}: "
+            )
+        except (KeyboardInterrupt, EOFError) as exc:
+            print("\nAborted.", file=sys.stderr)
+            raise LoginError(f"Authentication aborted for {dns}.") from exc
+        result = _bootstrap_from_credentials(
+            catalog_url,
+            username=prompted_username,
+            password=prompted_password,
+            name=name,
+            expires_in_days=expires_in_days,
+        )
+
+    secret = str(result["secret"])
+    expires_at = _parse_expires_at(result.get("expires_at"))
+    credentials.store(dns, secret, name=name, expires_at=expires_at)
+    return MintedApiKey(secret=secret, name=name, expires_at=expires_at)
+
+
+def print_stored_message(minted: MintedApiKey, dns: str) -> None:
+    pretty_expiry = ""
+    if minted.expires_at:
+        expiry_dt = _dt.datetime.fromtimestamp(minted.expires_at, _dt.timezone.utc)
+        pretty_expiry = f" (expires {expiry_dt.strftime('%Y-%m-%d')})"
+    print(f"Stored API key '{minted.name}' for {dns}{pretty_expiry}.")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -194,82 +291,22 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Stored API key for {dns}.")
         return 0
 
-    interactive = not args.no_prompt and sys.stdin.isatty()
-    name = args.key_name or _default_key_name()
-
-    # Path 2: explicit username (and/or password) — U/P bootstrap, with
-    # interactive password prompt when omitted on a TTY.
-    if args.username is not None:
-        username = args.username
-        password = args.password
-        if password is None:
-            if not interactive:
-                print(
-                    "Error: --password is required when --username is set headlessly.",
-                    file=sys.stderr,
-                )
-                return 2
-            try:
-                password = getpass.getpass(f"Password for {username}@{dns}: ")
-            except (KeyboardInterrupt, EOFError):
-                print("\nAborted.", file=sys.stderr)
-                return 1
-        result = _bootstrap_from_credentials(
-            catalog_url,
-            username=username,
-            password=password,
-            name=name,
-            expires_in_days=args.expires_in_days,
-        )
-
-    # Path 3 (default on a TTY without --username): browser flow.
-    elif interactive and not args.no_browser:
-        result = _bootstrap_from_browser(
+    try:
+        minted = mint_api_key(
             catalog_url,
             dns,
-            name=name,
+            username=args.username,
+            password=args.password,
+            no_browser=args.no_browser,
+            no_prompt=args.no_prompt,
+            key_name=args.key_name,
             expires_in_days=args.expires_in_days,
         )
+    except LoginError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2 if is_usage_error(exc) else 1
 
-    # Path 4: --no-browser (or no TTY): fall back to interactive U/P prompt.
-    else:
-        if not interactive:
-            print(
-                "Error: --username, --api-key, or interactive TTY is "
-                "required (browser flow needs a TTY for paste-back).",
-                file=sys.stderr,
-            )
-            return 2
-        try:
-            username = input(f"Username for {dns}: ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print("\nAborted.", file=sys.stderr)
-            return 1
-        if not username:
-            print("Error: username is required.", file=sys.stderr)
-            return 1
-        try:
-            password = getpass.getpass(f"Password for {username}@{dns}: ")
-        except (KeyboardInterrupt, EOFError):
-            print("\nAborted.", file=sys.stderr)
-            return 1
-        result = _bootstrap_from_credentials(
-            catalog_url,
-            username=username,
-            password=password,
-            name=name,
-            expires_in_days=args.expires_in_days,
-        )
-
-    secret = str(result["secret"])
-    expires_at = _parse_expires_at(result.get("expires_at"))
-    credentials.store(dns, secret, name=name, expires_at=expires_at)
-
-    pretty_expiry = ""
-    if expires_at:
-        expiry_dt = _dt.datetime.fromtimestamp(expires_at, _dt.timezone.utc)
-        pretty_expiry = f" (expires {expiry_dt.strftime('%Y-%m-%d')})"
-    print(f"Stored API key '{name}' for {dns}{pretty_expiry}.")
+    print_stored_message(minted, dns)
     return 0
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -91,39 +91,52 @@ def test_cli_skip_keyring(monkeypatch, tmp_path):
         auth.resolve_cli(FAKE_CATALOG, args, skip_keyring=True)
 
 
-def test_cli_prompt_stores_key(monkeypatch, tmp_path):
-    """Interactive prompt stores the pasted API key."""
+def test_cli_auth_flow_mints_and_stores_key(monkeypatch, tmp_path):
+    """Interactive auth flow mints and stores an API key."""
     _clear_env(monkeypatch)
     _no_keyring(monkeypatch)
     _tmp_fallback(monkeypatch, tmp_path)
     args = SimpleNamespace(api_key=None, no_prompt=False)
 
-    with (
-        patch("sys.stdin.isatty", return_value=True),
-        patch("getpass.getpass", return_value="qk_prompted"),
-    ):
+    from quiltx.tools.catalog import login as login_tool
+
+    def fake_mint(catalog_url, dns, **_kw):
+        assert catalog_url == "https://nightly.quilttest.com"
+        assert dns == "nightly.quilttest.com"
+        credentials.store(dns, "qk_minted", name="minted", expires_at=None)
+        return login_tool.MintedApiKey(
+            secret="qk_minted", name="minted", expires_at=None
+        )
+
+    monkeypatch.setattr(login_tool, "mint_api_key", fake_mint)
+
+    with (patch("sys.stdin.isatty", return_value=True),):
         result = auth.resolve_cli(FAKE_CATALOG, args)
 
-    assert result.api_key == "qk_prompted"
-    assert result.source == "prompt"
+    assert result.api_key == "qk_minted"
+    assert result.source == "auth-flow"
     stored = credentials.get("nightly.quilttest.com")
     assert stored is not None
-    assert stored["api_key"] == "qk_prompted"
-    # Paste-only bootstrap leaves metadata null per [05 §3].
-    assert stored.get("name") is None
+    assert stored["api_key"] == "qk_minted"
+    assert stored.get("name") == "minted"
     assert stored.get("expires_at") is None
 
 
-def test_cli_prompt_empty_rejected(monkeypatch, tmp_path):
+def test_cli_auth_flow_error_propagates(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     _no_keyring(monkeypatch)
     _tmp_fallback(monkeypatch, tmp_path)
     args = SimpleNamespace(api_key=None, no_prompt=False)
-    with (
-        patch("sys.stdin.isatty", return_value=True),
-        patch("getpass.getpass", return_value="   "),
-    ):
-        with pytest.raises(auth.CredentialError, match="Empty API key"):
+
+    from quiltx.tools.catalog import login as login_tool
+
+    def fake_mint(*_a, **_kw):
+        raise login_tool.LoginError("No code provided.")
+
+    monkeypatch.setattr(login_tool, "mint_api_key", fake_mint)
+
+    with (patch("sys.stdin.isatty", return_value=True),):
+        with pytest.raises(auth.CredentialError, match="No code provided"):
             auth.resolve_cli(FAKE_CATALOG, args)
 
 

--- a/tests/test_catalog_login.py
+++ b/tests/test_catalog_login.py
@@ -221,7 +221,34 @@ def test_login_browser_flow_default_on_tty(tmp_path, monkeypatch, capsys):
     assert stored["api_key"] == "qk_browser"
 
 
-def test_api_key_command_mints_stores_and_prints_secret(tmp_path, monkeypatch, capsys):
+def test_api_key_command_prints_stored_secret_without_auth_flow(
+    tmp_path, monkeypatch, capsys
+):
+    _setup_no_keyring(monkeypatch, tmp_path)
+    credentials.store(
+        "nightly.quilttest.com",
+        "qk_stored",
+        name="stored",
+        expires_at=None,
+    )
+
+    opened: list[str] = []
+    monkeypatch.setattr(
+        api_key_cmd.login_cmd.quilt_auth,
+        "open_browser",
+        lambda url: opened.append(url) or True,
+    )
+
+    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com"])
+
+    assert rc == 0
+    assert capsys.readouterr().out == "qk_stored\n"
+    assert opened == []
+
+
+def test_api_key_command_mints_stores_and_prints_new_secret(
+    tmp_path, monkeypatch, capsys
+):
     _setup_no_keyring(monkeypatch, tmp_path)
 
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -250,7 +277,7 @@ def test_api_key_command_mints_stores_and_prints_secret(tmp_path, monkeypatch, c
         quilt_auth, "bootstrap_api_key_from_refresh_token", fake_bootstrap
     )
 
-    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com"])
+    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com", "--new"])
 
     assert rc == 0
     out = capsys.readouterr().out
@@ -258,6 +285,55 @@ def test_api_key_command_mints_stores_and_prints_secret(tmp_path, monkeypatch, c
     stored = credentials.get("nightly.quilttest.com")
     assert stored is not None
     assert stored["api_key"] == "qk_printed"
+
+
+def test_api_key_command_mints_when_no_stored_secret(tmp_path, monkeypatch, capsys):
+    _setup_no_keyring(monkeypatch, tmp_path)
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        api_key_cmd.login_cmd.quilt_auth,
+        "open_browser",
+        lambda _url: True,
+    )
+    monkeypatch.setattr(
+        api_key_cmd.login_cmd.quilt_auth,
+        "browser_login_url",
+        lambda _catalog_url: "https://nightly.quilttest.com/login",
+    )
+    monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "rt_pasted")
+
+    def fake_bootstrap(catalog_url, *, refresh_token, name, expires_in_days):
+        assert catalog_url == "https://nightly.quilttest.com"
+        assert refresh_token == "rt_pasted"
+        return {
+            "secret": "qk_first",
+            "name": name,
+            "expires_at": "2027-05-04T00:00:00Z",
+        }
+
+    monkeypatch.setattr(
+        quilt_auth, "bootstrap_api_key_from_refresh_token", fake_bootstrap
+    )
+
+    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com"])
+
+    assert rc == 0
+    assert "qk_first" in capsys.readouterr().out
+    stored = credentials.get("nightly.quilttest.com")
+    assert stored is not None
+    assert stored["api_key"] == "qk_first"
+
+
+def test_api_key_command_no_prompt_errors_without_stored_secret(
+    tmp_path, monkeypatch, capsys
+):
+    _setup_no_keyring(monkeypatch, tmp_path)
+
+    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com", "--no-prompt"])
+
+    assert rc == 1
+    assert "no stored API key" in capsys.readouterr().err
 
 
 def test_login_no_browser_falls_back_to_username_prompt(tmp_path, monkeypatch, capsys):

--- a/tests/test_catalog_login.py
+++ b/tests/test_catalog_login.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from quiltx import credentials, quilt_auth
+from quiltx.tools.catalog import api_key as api_key_cmd
 from quiltx.tools.catalog import login as login_cmd
 
 
@@ -113,7 +114,7 @@ def test_login_no_prompt_without_creds_errors(tmp_path, monkeypatch, capsys):
     rc = login_cmd.main(["--catalog", "nightly.quilttest.com", "--no-prompt"])
     assert rc == 2
     err = capsys.readouterr().err
-    assert "--username" in err or "--api-key" in err
+    assert "--username" in err and "interactive TTY" in err
 
 
 def test_login_sso_only_catalog_surfaces_catalog_error(tmp_path, monkeypatch, capsys):
@@ -129,21 +130,20 @@ def test_login_sso_only_catalog_surfaces_catalog_error(tmp_path, monkeypatch, ca
 
     monkeypatch.setattr(quilt_auth, "bootstrap_api_key", fake_bootstrap)
 
-    with pytest.raises(SystemExit) as excinfo:
-        login_cmd.main(
-            [
-                "--catalog",
-                "nightly.quilttest.com",
-                "--username",
-                "admin",
-                "--password",
-                "x",
-            ]
-        )
-    assert excinfo.value.code == 1
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--password",
+            "x",
+        ]
+    )
+    assert rc == 1
     err = capsys.readouterr().err
     assert "SSO is required" in err
-    assert "--api-key" in err  # hint
+    assert "browser auth flow" in err
     assert credentials.get("nightly.quilttest.com") is None  # not stored
 
 
@@ -219,6 +219,45 @@ def test_login_browser_flow_default_on_tty(tmp_path, monkeypatch, capsys):
     stored = credentials.get("nightly.quilttest.com")
     assert stored is not None
     assert stored["api_key"] == "qk_browser"
+
+
+def test_api_key_command_mints_stores_and_prints_secret(tmp_path, monkeypatch, capsys):
+    _setup_no_keyring(monkeypatch, tmp_path)
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        api_key_cmd.login_cmd.quilt_auth,
+        "open_browser",
+        lambda _url: True,
+    )
+    monkeypatch.setattr(
+        api_key_cmd.login_cmd.quilt_auth,
+        "browser_login_url",
+        lambda _catalog_url: "https://nightly.quilttest.com/login",
+    )
+    monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "rt_pasted")
+
+    def fake_bootstrap(catalog_url, *, refresh_token, name, expires_in_days):
+        assert catalog_url == "https://nightly.quilttest.com"
+        assert refresh_token == "rt_pasted"
+        return {
+            "secret": "qk_printed",
+            "name": name,
+            "expires_at": "2027-05-04T00:00:00Z",
+        }
+
+    monkeypatch.setattr(
+        quilt_auth, "bootstrap_api_key_from_refresh_token", fake_bootstrap
+    )
+
+    rc = api_key_cmd.main(["--catalog", "nightly.quilttest.com"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "qk_printed" in out
+    stored = credentials.get("nightly.quilttest.com")
+    assert stored is not None
+    assert stored["api_key"] == "qk_printed"
 
 
 def test_login_no_browser_falls_back_to_username_prompt(tmp_path, monkeypatch, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- Add `quiltx catalog api-key` command to print, mint (`--new`), and store a catalog API key. Supports browser-based login, `--username`/`--password` U/P bootstrap, and `--insecure` for localhost.
- `quiltx catalog login` now mints and stores a catalog API key as part of the auth flow so downstream tools can reuse it.
- Bump to 0.16.0.

## Test plan
- [x] `./poe test`
- [x] `quiltx catalog api-key` prints stored key
- [x] `quiltx catalog api-key --new` mints and stores a fresh key
- [x] `quiltx catalog login` stores an API key on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `quiltx catalog api-key` — a new subcommand that prints, mints, and stores a catalog API key — and wires the same `mint_api_key` helper into `quiltx catalog login` and the interactive credential-resolution ladder in `auth.py`.

- **New `api_key.py` command**: prints the stored key by default; `--new` mints a replacement via browser SSO or `--username`/`--password` bootstrap; supports `--insecure` for localhost.
- **`login.py` refactor**: login logic extracted into `mint_api_key()`/`MintedApiKey` so both `catalog login` and `catalog api-key` share one implementation; `SystemExit` calls replaced with `LoginError`.
- **`auth.py` credential ladder step 4**: the old `getpass` paste-prompt is replaced with the full browser/SSO `mint_api_key` flow.

<h3>Confidence Score: 3/5</h3>

The new api-key command is functional but its stdout output is inconsistent: printing the stored key emits only the key, while minting a new one mixes an informational status line with the key on the same stream, breaking the common shell pattern of capturing command output into a variable.

The stdout-mixing issue in api_key.py affects a core use case — automating key retrieval — and leaves the two code paths in an inconsistent state that tests only partially catch (the mint tests assert 'key in out' rather than strict equality). The rest of the refactor is clean and well-structured.

quiltx/tools/catalog/api_key.py (stdout mixing) and quiltx/tools/catalog/login.py (is_usage_error string matching).

<details open><summary><h3>Security Review</h3></summary>

- **`--password` exposed in process listing** (`quiltx/tools/catalog/api_key.py`, `login.py`): passing the catalog admin password as a command-line argument makes it readable via `ps aux` / `/proc/<pid>/cmdline` for the duration of the process. The interactive `getpass` prompt (used when `--password` is omitted) is the safer path; the help text for `--password` should warn that inline use is insecure.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/tools/catalog/api_key.py | New command: prints stored API key or mints a new one; stdout mixing issue between informational message and machine-readable key value. |
| quiltx/tools/catalog/login.py | Refactored login logic into reusable `mint_api_key` + `MintedApiKey`; introduces `LoginError` and fragile string-based `is_usage_error` classifier. |
| quiltx/auth.py | Step 4 of the credential ladder replaced from `getpass` prompt to browser/SSO auth flow via deferred `login_tool.mint_api_key`; doc comments updated to match. |
| quiltx/tools/catalog/__init__.py | Registers the new `api-key` subcommand; straightforward addition with no issues. |
| tests/test_auth.py | Tests updated to match the new auth-flow credential source; prompt tests replaced with mint-mock equivalents. |
| tests/test_catalog_login.py | Adds four new tests for the `api-key` command and updates existing login tests to reflect refactored error surface. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant api_key_cmd as catalog api-key
    participant login_cmd as login.mint_api_key
    participant auth_py as auth.resolve_cli
    participant Catalog as Catalog API

    User->>api_key_cmd: quiltx catalog api-key [--new]
    alt stored key exists and not --new
        api_key_cmd->>User: print stored key (stdout)
    else mint new key
        api_key_cmd->>login_cmd: mint_api_key(catalog_url, dns, ...)
        alt browser flow (default TTY)
            login_cmd->>User: open browser, prompt for code
            User->>login_cmd: paste refresh_token
            login_cmd->>Catalog: bootstrap_api_key_from_refresh_token
        else U/P flow (--username given)
            login_cmd->>Catalog: bootstrap_api_key(username, password)
        end
        Catalog-->>login_cmd: "{secret, name, expires_at}"
        login_cmd->>login_cmd: credentials.store(dns, secret)
        login_cmd-->>api_key_cmd: MintedApiKey
        api_key_cmd->>User: print stored message + secret (both stdout)
    end

    User->>auth_py: any catalog command (no stored key, TTY)
    auth_py->>login_cmd: "mint_api_key(catalog_url, dns, no_prompt=False)"
    login_cmd-->>auth_py: MintedApiKey
    auth_py-->>User: ResolvedCredentials(secret, auth-flow)
```

<sub>Reviews (1): Last reviewed commit: ["CHANGELOG: 0.16.0"](https://github.com/quiltdata/quiltx/commit/7a367f5d541d96d73f8f2fec938ec65832c5d2ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31339471)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->