### PR TITLE
Add no-preflight bucket registration (v0.16.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@
 
 ## Tools
 
+### Bucket Tool (`quiltx bucket`)
+
+`quiltx bucket add --no-preflight` skips local S3/SNS bucket-owner setup and
+registers through GraphQL only, letting the catalog stack probe with its own
+IAM. The same mode is available for ACL reconciliation with
+`quiltx catalog acl --no-preflight` or `QUILTX_NO_PREFLIGHT=1`.
+
 ### ECS Tool (`quiltx ecs`)
 
 Provides catalog ECS operations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-05-14
+
 ### Added
 
 - `quiltx bucket add --no-preflight` and `quiltx catalog acl --no-preflight` register buckets through GraphQL only, skipping local S3/SNS bucket-owner setup and letting the catalog stack probe with its own IAM. `QUILTX_NO_PREFLIGHT=1` enables the same mode for scripted runs.
+- `quiltx catalog acl --no-preflight --dry-run` now lists the local AWS steps that would be skipped (per `spec/7-no-preflight.md` §140).
+
+### Changed
+
+- `quiltx bucket add --no-preflight` never prompts for confirmation; `--yes` help, `--no-preflight` help, and the README example document `--yes` as unnecessary in that mode (spec §144).
+
+### Fixed
+
+- `quiltx bucket add --no-preflight` now has CLI-boundary test coverage asserting that `BucketAddError` is rendered to stderr with a non-zero exit code.
 
 ## [0.16.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `quiltx bucket add --no-preflight` and `quiltx catalog acl --no-preflight` register buckets through GraphQL only, skipping local S3/SNS bucket-owner setup and letting the catalog stack probe with its own IAM. `QUILTX_NO_PREFLIGHT=1` enables the same mode for scripted runs.
+
 ## [0.16.0] - 2026-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ arguments and normalized to the bare DNS.
 See [README_DEV.md](README_DEV.md) for programmatic usage of ECS, ACL, config,
 and stack APIs.
 
+## Bucket registration
+
+`quiltx bucket add BUCKET` defaults to bucket-owner mode: it uses your local
+AWS profile to probe the bucket, update the bucket policy, configure SNS, and
+wire S3 notifications before registering the bucket with the catalog.
+
+Use `--no-preflight` when the catalog stack can already access the bucket but
+your local AWS identity cannot or should not modify it, such as public AWS Open
+Data buckets or buckets already plumbed by Quilt infrastructure:
+
+```bash
+uvx quiltx bucket add igvf-public --catalog example.quiltdata.com --no-preflight --yes
+uvx quiltx catalog acl acl.yml --catalog example.quiltdata.com --no-preflight --yes
+```
+
+`--no-preflight` submits the GraphQL registration directly, lets the stack probe
+with its IAM, skips local S3/SNS setup, and implies `--no-test`. Set
+`QUILTX_NO_PREFLIGHT=1` to use the same mode for scripted runs.
+
 ### Persistent install (optional)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ your local AWS identity cannot or should not modify it, such as public AWS Open
 Data buckets or buckets already plumbed by Quilt infrastructure:
 
 ```bash
-uvx quiltx bucket add igvf-public --catalog example.quiltdata.com --no-preflight --yes
+uvx quiltx bucket add igvf-public --catalog example.quiltdata.com --no-preflight
 uvx quiltx catalog acl acl.yml --catalog example.quiltdata.com --no-preflight --yes
 ```
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -16,6 +16,18 @@ stack = find_matching_stack(get_catalog_url())
 print(stack["StackName"])
 ```
 
+## Bucket registration paths
+
+Bucket registration has two explicit paths. The default bucket-owner path uses
+local AWS credentials to probe S3, merge the Quilt bucket-policy statement,
+configure SNS, configure bucket notifications, and then call GraphQL
+`bucketAdd` with the SNS topic ARN.
+
+The `--no-preflight` path is GraphQL-only. It skips local S3/SNS calls and
+submits `bucketAdd` without an SNS ARN so the catalog stack probes the bucket
+with its own IAM, matching the admin UI behavior. Use this for public buckets
+or buckets already configured outside the caller's local AWS account.
+
 ## ECS
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.0"
+version = "0.16.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -503,14 +503,9 @@ def _register_bucket_with_retry(
     control_account_id: str,
     *,
     assume_yes: bool,
-    no_preflight: bool = False,
 ) -> None:
     """Run the full cross-account bucket registration, probing profiles on failure."""
     from quiltx import bucket as bucket_lib
-
-    if no_preflight:
-        bucket_lib.add_bucket_without_preflight(stack, bucket, title=bucket)
-        return
 
     session, s3_client, region, _profile = bucket_lib.resolve_bucket_session(
         bucket, None, assume_yes=assume_yes
@@ -636,13 +631,9 @@ def apply_acl(
         try:
             _print_apply_step(f"add bucket {bucket}", verbose=verbose)
             if no_preflight:
-                _register_bucket_with_retry(
-                    stack,
-                    bucket,
-                    control_account_id or "",
-                    assume_yes=assume_yes,
-                    no_preflight=True,
-                )
+                from quiltx import bucket as bucket_lib
+
+                bucket_lib.add_bucket_without_preflight(stack, bucket, title=bucket)
             elif control_account_id is None:
                 stack.admin.buckets.add(bucket, bucket)
             else:
@@ -653,7 +644,7 @@ def apply_acl(
                     assume_yes=assume_yes,
                 )
             print(f"  + bucket {bucket}")
-        except Exception as exc:  # pragma: no cover - external API surface
+        except Exception as exc:
             failed_buckets.add(bucket)
             warnings.append(f"Bucket '{bucket}' could not be added: {exc}")
             print(f"  ! bucket {bucket}: {exc}", file=sys.stderr)

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -498,10 +498,19 @@ def print_current_state(current: CurrentState) -> None:
 
 
 def _register_bucket_with_retry(
-    stack: stack_lib.Catalog, bucket: str, control_account_id: str, *, assume_yes: bool
+    stack: stack_lib.Catalog,
+    bucket: str,
+    control_account_id: str,
+    *,
+    assume_yes: bool,
+    no_preflight: bool = False,
 ) -> None:
     """Run the full cross-account bucket registration, probing profiles on failure."""
     from quiltx import bucket as bucket_lib
+
+    if no_preflight:
+        bucket_lib.add_bucket_without_preflight(stack, bucket, title=bucket)
+        return
 
     session, s3_client, region, _profile = bucket_lib.resolve_bucket_session(
         bucket, None, assume_yes=assume_yes
@@ -606,6 +615,7 @@ def apply_acl(
     *,
     verbose: bool = False,
     assume_yes: bool = False,
+    no_preflight: bool = False,
 ) -> list[str]:
     """Apply ACL changes. Returns any runtime warnings."""
 
@@ -625,11 +635,22 @@ def apply_acl(
     for bucket in diff.buckets_to_add:
         try:
             _print_apply_step(f"add bucket {bucket}", verbose=verbose)
-            if control_account_id is None:
+            if no_preflight:
+                _register_bucket_with_retry(
+                    stack,
+                    bucket,
+                    control_account_id or "",
+                    assume_yes=assume_yes,
+                    no_preflight=True,
+                )
+            elif control_account_id is None:
                 stack.admin.buckets.add(bucket, bucket)
             else:
                 _register_bucket_with_retry(
-                    stack, bucket, control_account_id, assume_yes=assume_yes
+                    stack,
+                    bucket,
+                    control_account_id,
+                    assume_yes=assume_yes,
                 )
             print(f"  + bucket {bucket}")
         except Exception as exc:  # pragma: no cover - external API surface

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -318,6 +318,50 @@ class AddBucketResult:
     already_registered: bool
 
 
+class BucketAddError(RuntimeError):
+    """Human-readable error for a GraphQL bucketAdd failure."""
+
+
+def add_bucket_without_preflight(
+    stack: stack_lib.Catalog,
+    bucket: str,
+    *,
+    title: str | None = None,
+) -> AddBucketResult:
+    """Register a bucket by GraphQL only, without local AWS preflight/setup."""
+    stack.ensure_auth()
+
+    from quilt3 import _graphql_client
+    from quilt3.admin import util
+
+    bucket_title = title or bucket
+    result = util.get_client().bucket_add(
+        input=_graphql_client.BucketAddInput(
+            name=bucket,
+            title=bucket_title,
+            sns_notification_arn=None,
+        )
+    )
+    typename = _bucket_add_typename(result)
+    if typename == "BucketAddSuccess":
+        config = getattr(result, "bucket_config", None)
+        return AddBucketResult(
+            bucket=_field_value(config, "name", bucket),
+            title=_field_value(config, "title", bucket_title),
+            sns_topic_arn=_field_value(config, "sns_notification_arn", ""),
+            already_registered=False,
+        )
+    if typename == "BucketAlreadyAdded":
+        return AddBucketResult(
+            bucket=bucket,
+            title=bucket_title,
+            sns_topic_arn="",
+            already_registered=True,
+        )
+
+    raise BucketAddError(_bucket_add_error_message(result, typename))
+
+
 def add_bucket(
     stack: stack_lib.Catalog,
     bucket: str,
@@ -423,6 +467,49 @@ def add_bucket(
         sns_topic_arn=sns_topic_arn,
         already_registered=False,
     )
+
+
+def _bucket_add_typename(result: Any) -> str:
+    if isinstance(result, Mapping):
+        value = result.get("__typename") or result.get("typename__")
+        return str(value or "")
+    return str(
+        getattr(result, "typename__", None)
+        or getattr(result, "__typename", None)
+        or result.__class__.__name__
+    )
+
+
+def _field_value(source: Any, field: str, default: str) -> str:
+    if source is None:
+        return default
+    if isinstance(source, Mapping):
+        return str(source.get(field) or default)
+    return str(getattr(source, field, None) or default)
+
+
+def _bucket_add_error_message(result: Any, typename: str) -> str:
+    if typename == "BucketDoesNotExist":
+        return (
+            "The stack cannot access this bucket; check the stack's IAM role "
+            "or the bucket's public-access settings."
+        )
+    if typename == "InsufficientPermissions":
+        detail = _field_value(result, "message", "")
+        if detail:
+            return f"Insufficient permissions for stack bucket access: {detail}"
+        return "Insufficient permissions for stack bucket access."
+    if typename in {
+        "NotificationConfigurationError",
+        "NotificationTopicNotFound",
+        "SnsInvalid",
+        "SubscriptionInvalid",
+        "BucketFileExtensionsToIndexInvalid",
+        "BucketIndexContentBytesInvalid",
+    }:
+        detail = _field_value(result, "message", "")
+        return f"{typename}: {detail}" if detail else typename
+    return f"bucketAdd returned {typename or 'an unknown error'}: {result}"
 
 
 def _merge_policy_statements(

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -491,14 +491,14 @@ def _field_value(source: Any, field: str, default: str) -> str:
 def _bucket_add_error_message(result: Any, typename: str) -> str:
     if typename == "BucketDoesNotExist":
         return (
-            "The stack cannot access this bucket; check the stack's IAM role "
-            "or the bucket's public-access settings."
+            "BucketDoesNotExist: The stack cannot access this bucket; check "
+            "the stack's IAM role or the bucket's public-access settings."
         )
     if typename == "InsufficientPermissions":
         detail = _field_value(result, "message", "")
         if detail:
-            return f"Insufficient permissions for stack bucket access: {detail}"
-        return "Insufficient permissions for stack bucket access."
+            return f"InsufficientPermissions: {detail}"
+        return "InsufficientPermissions: stack lacks required access to this bucket."
     if typename in {
         "NotificationConfigurationError",
         "NotificationTopicNotFound",

--- a/quiltx/cli_common.py
+++ b/quiltx/cli_common.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import os
+
+
+def env_flag(name: str) -> bool:
+    """Return True if env var *name* is set to a truthy value (1/true/yes/on)."""
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def add_catalog_args(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -61,6 +61,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Skip the post-add registration/read verification.",
     )
     add_parser.add_argument(
+        "--no-preflight",
+        action="store_true",
+        help=(
+            "Skip local AWS preflight/setup and submit bucketAdd directly, "
+            "letting the catalog stack probe the bucket."
+        ),
+    )
+    add_parser.add_argument(
         "--force",
         action="store_true",
         help=(
@@ -196,6 +204,10 @@ def _print_exception(exc: BaseException) -> None:
     print(f"Error: {type(exc).__name__}: {exc}", file=sys.stderr)
     if os.environ.get("QUILTX_VERBOSE"):
         traceback.print_exception(exc, file=sys.stderr)
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
@@ -363,7 +375,12 @@ def _lightweight_stack_payload(
 @stack_lib.catalog_command
 def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
     try:
-        if getattr(args, "no_prompt", False) and not getattr(args, "yes", False):
+        no_preflight = bool(args.no_preflight or _env_flag("QUILTX_NO_PREFLIGHT"))
+        if (
+            getattr(args, "no_prompt", False)
+            and not getattr(args, "yes", False)
+            and not no_preflight
+        ):
             print(
                 "Error: --no-prompt requires --yes (or --dry-run) to avoid interactive prompts.",
                 file=sys.stderr,
@@ -381,6 +398,9 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return 1
+
+        if no_preflight:
+            return _cmd_add_no_preflight(stack, args)
 
         catalog_name = stack.catalog_name
         stack_payload = _ensure_stack_payload(stack)
@@ -532,6 +552,52 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             raise
         _print_exception(exc)
         return 1
+
+
+def _cmd_add_no_preflight(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
+    bucket_title = args.title or args.bucket_name
+    if args.dry_run:
+        _print_no_preflight_dry_run(stack, args.bucket_name, bucket_title)
+        return 0
+
+    existing_bucket = stack.admin.buckets.get(args.bucket_name)
+    if existing_bucket is not None and args.force:
+        print(
+            f"Bucket {args.bucket_name}: already registered in Quilt; "
+            "removing and re-adding (--force) via GraphQL only."
+        )
+        stack.admin.buckets.remove(args.bucket_name)
+    elif existing_bucket is not None:
+        print(
+            f"Bucket {args.bucket_name}: already registered in Quilt; "
+            "local preflight/setup skipped."
+        )
+        return 0
+
+    try:
+        result = bucket_lib.add_bucket_without_preflight(
+            stack,
+            args.bucket_name,
+            title=bucket_title,
+        )
+    except bucket_lib.BucketAddError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if result.already_registered:
+        print(
+            f"Bucket {args.bucket_name}: already registered in Quilt; "
+            "local preflight/setup skipped."
+        )
+    else:
+        print(
+            f"Registered bucket {result.bucket} as {result.title} "
+            "via GraphQL only; local AWS preflight/setup skipped."
+        )
+    print(
+        f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
+    )
+    return 0
 
 
 @stack_lib.catalog_command
@@ -877,6 +943,34 @@ def _print_dry_run_plan(
             ],
         },
     )
+
+
+def _print_no_preflight_dry_run(
+    stack: stack_lib.Catalog, bucket_name: str, bucket_title: str
+) -> None:
+    console = Console(width=120)
+    table = Table(
+        title="Bucket add dry-run (--no-preflight)",
+        show_header=True,
+        header_style="bold cyan",
+        border_style="cyan",
+        expand=False,
+    )
+    table.add_column("Resource", style="green", overflow="fold")
+    table.add_column("Action", overflow="fold")
+    table.add_row(stack.catalog_name, "use catalog API key for GraphQL bucketAdd")
+    table.add_row(f"s3://{bucket_name}", f"register as {bucket_title!r}")
+    console.print(table)
+    print()
+    print("Skipped local AWS preflight/setup:")
+    for item in (
+        "GetBucketLocation",
+        "GetBucketPolicy / PutBucketPolicy",
+        "SNS topic creation and policy configuration",
+        "bucket-notification configuration",
+        "post-add verification (--no-preflight implies --no-test)",
+    ):
+        print(f"  - {item}")
 
 
 def _print_context_table(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -386,7 +386,7 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             and not no_preflight
         ):
             print(
-                "Error: --no-prompt requires --yes (or --dry-run) to avoid interactive prompts.",
+                "Error: --no-prompt requires --yes (or --no-preflight) to avoid interactive prompts.",
                 file=sys.stderr,
             )
             return 1

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -53,7 +53,10 @@ def build_parser() -> argparse.ArgumentParser:
     add_parser.add_argument(
         "--yes",
         action="store_true",
-        help="Apply changes without prompting for confirmation.",
+        help=(
+            "Apply changes without prompting for confirmation. "
+            "Not needed with --no-preflight, which never prompts."
+        ),
     )
     add_parser.add_argument(
         "--no-test",
@@ -65,7 +68,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Skip local AWS preflight/setup and submit bucketAdd directly, "
-            "letting the catalog stack probe the bucket."
+            "letting the catalog stack probe the bucket. Never prompts for "
+            "confirmation (--yes is not required)."
         ),
     )
     add_parser.add_argument(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -16,7 +16,7 @@ from rich.table import Table
 
 from quiltx import bucket as bucket_lib
 from quiltx import stack as stack_lib
-from quiltx.cli_common import add_catalog_args
+from quiltx.cli_common import add_catalog_args, env_flag as _env_flag
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -208,10 +208,6 @@ def _print_exception(exc: BaseException) -> None:
     print(f"Error: {type(exc).__name__}: {exc}", file=sys.stderr)
     if os.environ.get("QUILTX_VERBOSE"):
         traceback.print_exception(exc, file=sys.stderr)
-
-
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
@@ -559,12 +555,15 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
 
 
 def _cmd_add_no_preflight(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
-    bucket_title = args.title or args.bucket_name
+    existing_bucket = stack.admin.buckets.get(args.bucket_name)
+    prior_title = (
+        getattr(existing_bucket, "title", None) if existing_bucket is not None else None
+    )
+    bucket_title = args.title or prior_title or args.bucket_name
     if args.dry_run:
         _print_no_preflight_dry_run(stack, args.bucket_name, bucket_title)
         return 0
 
-    existing_bucket = stack.admin.buckets.get(args.bucket_name)
     if existing_bucket is not None and args.force:
         print(
             f"Bucket {args.bucket_name}: already registered in Quilt; "

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from quiltx import acl as acl_lib
@@ -38,6 +39,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="Show planned changes without applying them.",
+    )
+    parser.add_argument(
+        "--no-preflight",
+        action="store_true",
+        help=(
+            "Register new buckets via GraphQL only, skipping local AWS "
+            "bucket-owner setup."
+        ),
     )
     return parser
 
@@ -86,15 +95,31 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             return 1
 
         print("Applying...")
+        no_preflight = bool(
+            args.no_preflight
+            or os.environ.get("QUILTX_NO_PREFLIGHT", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
         warnings = acl_lib.apply_acl(
-            stack, diff, current, verbose=args.verbose, assume_yes=args.yes
+            stack,
+            diff,
+            current,
+            verbose=args.verbose,
+            assume_yes=args.yes,
+            no_preflight=no_preflight,
         )
 
         post_current = acl_lib.fetch_current_state(stack)
         drift = acl_lib.detect_policy_drift(desired, post_current)
         if drift:
             reset_warnings, post_current = _handle_policy_drift(
-                stack, drift, desired, post_current, auto=args.yes, verbose=args.verbose
+                stack,
+                drift,
+                desired,
+                post_current,
+                auto=args.yes,
+                verbose=args.verbose,
+                no_preflight=no_preflight,
             )
             warnings.extend(reset_warnings)
 
@@ -128,6 +153,7 @@ def _handle_policy_drift(
     *,
     auto: bool,
     verbose: bool,
+    no_preflight: bool = False,
 ) -> tuple[list[str], acl_lib.CurrentState]:
     """Prompt for (or auto-apply) policy resets when server state has drifted.
 
@@ -212,7 +238,12 @@ def _handle_policy_drift(
         print("Reapplying after reset...")
         warnings.extend(
             acl_lib.apply_acl(
-                stack, new_diff, post_reset, verbose=verbose, assume_yes=auto
+                stack,
+                new_diff,
+                post_reset,
+                verbose=verbose,
+                assume_yes=auto,
+                no_preflight=no_preflight,
             )
         )
         post_reset = acl_lib.fetch_current_state(stack)

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 from quiltx import acl as acl_lib
 from quiltx import stack as stack_lib
 from quiltx.cli_common import add_catalog_args
+from quiltx.tools.bucket import _env_flag
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -84,19 +84,13 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
         diff = acl_lib.compute_diff(desired, current)
         acl_lib.print_diff(diff, verbose=args.verbose, desired=desired, current=current)
 
-        no_preflight = bool(
-            args.no_preflight
-            or os.environ.get("QUILTX_NO_PREFLIGHT", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        )
+        no_preflight = bool(args.no_preflight or _env_flag("QUILTX_NO_PREFLIGHT"))
 
         if not diff.has_changes():
-            if args.dry_run and no_preflight:
-                _print_no_preflight_dry_run_notice()
             return 0
 
         if args.dry_run:
-            if no_preflight:
+            if no_preflight and diff.buckets_to_add:
                 _print_no_preflight_dry_run_notice()
             return 0
 

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -84,10 +84,20 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
         diff = acl_lib.compute_diff(desired, current)
         acl_lib.print_diff(diff, verbose=args.verbose, desired=desired, current=current)
 
+        no_preflight = bool(
+            args.no_preflight
+            or os.environ.get("QUILTX_NO_PREFLIGHT", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
+
         if not diff.has_changes():
+            if args.dry_run and no_preflight:
+                _print_no_preflight_dry_run_notice()
             return 0
 
         if args.dry_run:
+            if no_preflight:
+                _print_no_preflight_dry_run_notice()
             return 0
 
         if not args.yes and not _confirm_apply():
@@ -95,11 +105,6 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             return 1
 
         print("Applying...")
-        no_preflight = bool(
-            args.no_preflight
-            or os.environ.get("QUILTX_NO_PREFLIGHT", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        )
         warnings = acl_lib.apply_acl(
             stack,
             diff,
@@ -143,6 +148,22 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
 
 def _confirm_apply() -> bool:
     return input("Apply ACL changes? [y/N]: ").strip().lower() in {"y", "yes"}
+
+
+def _print_no_preflight_dry_run_notice() -> None:
+    print()
+    print(
+        "--no-preflight: new buckets would be registered via GraphQL only; "
+        "skipped local AWS steps per bucket:"
+    )
+    for item in (
+        "GetBucketLocation",
+        "GetBucketPolicy / PutBucketPolicy",
+        "SNS topic creation and policy configuration",
+        "bucket-notification configuration",
+        "post-add verification",
+    ):
+        print(f"  - {item}")
 
 
 def _handle_policy_drift(

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -7,8 +7,7 @@ import sys
 
 from quiltx import acl as acl_lib
 from quiltx import stack as stack_lib
-from quiltx.cli_common import add_catalog_args
-from quiltx.tools.bucket import _env_flag
+from quiltx.cli_common import add_catalog_args, env_flag
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -84,7 +83,7 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
         diff = acl_lib.compute_diff(desired, current)
         acl_lib.print_diff(diff, verbose=args.verbose, desired=desired, current=current)
 
-        no_preflight = bool(args.no_preflight or _env_flag("QUILTX_NO_PREFLIGHT"))
+        no_preflight = bool(args.no_preflight or env_flag("QUILTX_NO_PREFLIGHT"))
 
         if not diff.has_changes():
             return 0

--- a/spec/7-no-preflight.md
+++ b/spec/7-no-preflight.md
@@ -1,0 +1,233 @@
+# No-Preflight Bucket Registration
+
+## Problem
+
+quiltx and the catalog admin UI both register buckets by submitting the same
+`bucketAdd` GraphQL mutation to the registry. They differ in **what they do
+before that submission** — and that pre-submission difference is what fails
+today.
+
+**The two credential systems quiltx holds, and what neither one is:**
+
+| Credential | Source | Used for | What it is *not* |
+| --- | --- | --- | --- |
+| `qk_...` catalog API key | minted by `quiltx catalog login`; stored per-DNS in the OS keyring | authenticating the GraphQL `bucketAdd` call | **not** AWS credentials |
+| local AWS profile (`AWS_PROFILE`, `~/.aws/...`) | standard boto3 chain; falls back across every other configured profile via [`resolve_bucket_session`](../quiltx/bucket.py#L30-L92) | `GetBucketLocation`, `GetBucketPolicy`, `PutBucketPolicy`, SNS topic create + subscribe, bucket-notification config | **not** the stack's IAM |
+
+**The stack's IAM role is server-side only.** quiltx can ask the stack to do
+things on its behalf via GraphQL, but it cannot *become* the stack for direct
+S3 calls. That's the asymmetry: the admin UI doesn't make direct S3 calls at
+all — it submits the mutation, and the stack probes the bucket using its own
+IAM. quiltx makes direct S3 calls *first*, using your local profile, and
+only then submits the mutation.
+
+**Why quiltx does that today (and why it's right in one specific case):**
+the local AWS routine is *bucket-owner setup* — it merges
+`QuiltCrossAccountAccess` into the bucket policy and wires up an SNS topic
+so the stack can subscribe to object-change events. This is necessary and
+correct when the caller **owns the bucket in a separate AWS account** and
+needs to grant the Quilt control account access. In that case, the stack
+*cannot* set up access for itself — only the bucket owner can — so quiltx
+must do it client-side with the owner's creds.
+
+**The cases where it's wrong:**
+
+1. **Public AWS Open Data buckets** (e.g. `igvf-public`). The caller cannot
+   modify the bucket policy and does not need to — the stack already has
+   read access via public anonymous reads or the AWS Open Data program.
+   Local `GetBucketLocation` fails with `AccessDenied` *even with
+   `--no-sign-request`*, because the bucket's policy doesn't grant
+   bucket-metadata operations to external callers.
+2. **Buckets owned by the Quilt org's central account** (e.g.
+   `quilt-example-bucket`). Cross-account access is plumbed once by Quilt
+   infrastructure and applies to every catalog stack. The local user has
+   no `GetBucketPolicy` permission on someone else's bucket and shouldn't.
+   Local probe fails with `AccessDenied`.
+
+In both cases the error message blames the wrong thing: the user sees
+"AccessDenied" against a bucket the catalog can actually read, with no
+indication that the failure is in quiltx's *local* pre-flight and not in
+the registry's actual ability to register the bucket.
+
+**The Alexion dev stack incident** that surfaced this:
+`quiltx catalog acl alexion-acl.yaml --catalog alexion.dev.quilttest.com --yes`
+failed midway on `igvf-public` and `quilt-example-bucket`. The local IAM
+user `arn:aws:iam::712023778557:user/ernest-staging` lacks
+`s3:GetBucketLocation` and `s3:GetBucketPolicy` on those buckets. The
+catalog admin UI, by contrast, registers both buckets fine in a few clicks
+— because it never runs the local pre-flight. The half-completed
+reconciliation triggered an auto-reset cascade that detached the operator
+from their roles and left SSO config drifted, requiring manual recovery.
+
+The fix is to give quiltx a path that **mirrors the admin UI**: submit the
+GraphQL `bucketAdd` mutation directly, let the stack probe with its own
+IAM, and surface the structured GraphQL error union (`BucketDoesNotExist`,
+`InsufficientPermissions`, etc.) verbatim. The local owner-setup routine
+stays available for the genuine cross-account-grant case where it is the
+only thing that can work — but it stops being the only option.
+
+## Goal
+
+Add a `--no-preflight` flag that **skips the local pre-flight
+bucket-owner setup** (`GetBucketLocation`, `GetBucketPolicy` /
+`PutBucketPolicy`, SNS topic creation, bucket-notification configuration)
+and registers the bucket via the registry's `bucketAdd` GraphQL mutation
+alone — letting the stack probe the bucket using its own IAM, exactly like
+the catalog admin UI does today.
+
+The current default is bucket-owner-mode: quiltx assumes the caller owns the
+target bucket in a separate AWS account and needs to grant the Quilt control
+account cross-account access. That fails (with opaque AccessDenied) for the
+two cases described in **Problem** above. `--no-preflight` opts out of that
+routine and yields the admin-UI behavior.
+
+## Naming
+
+Chosen: **`--no-preflight`**. The term names what's skipped: the local
+pre-flight pass (probe + policy edits + SNS plumbing) that runs *before* the
+GraphQL submission. Alternatives considered:
+
+| Name | Implies | Reason rejected |
+| --- | --- | --- |
+| `--no-probe` | Just the `GetBucketLocation` call | Understates — we skip the entire pre-flight, not just the probe. |
+| `--register-only` | GraphQL `bucketAdd` only | Accurate but reads as a verb-mode rather than a skip flag; less obviously paired with `--no-test`. |
+| `--via-stack` | Delegate to stack | Indirect; doesn't name the thing being skipped. |
+| `--no-setup` | Skip owner setup | Vague — "setup" overloaded across the CLI. |
+
+`--no-preflight` is symmetric with the existing `--no-test`
+(skip post-add verification) in `quiltx bucket add`: one skips pre-add work,
+the other skips post-add work.
+
+## (a) Where the flag must be available as an option
+
+### CLI surfaces
+
+- [ ] [`quiltx bucket add`](../quiltx/tools/bucket.py#L33-L72) — primary user
+      of the local setup routine; flag must be acceptable here.
+- [ ] [`quiltx catalog acl`](../quiltx/tools/catalog/acl.py#L13-L43) — the ACL
+      reconciler registers buckets indirectly via
+      [`_register_bucket_with_retry`](../quiltx/acl.py#L500-L537);
+      flag applies to *every* bucket that needs adding during this run.
+- [ ] [`quiltx bucket test`](../quiltx/tools/bucket.py#L118-L124) — exempt:
+      this command is the explicit post-add verification path, so accepting
+      a flag that skips preflight would be misleading and has no useful
+      behavior.
+- [ ] [`quiltx bucket profile`](../quiltx/tools/bucket.py#L105-L116) — exempt:
+      this command exists to *find* a probe-capable profile, so
+      `--no-preflight` is nonsensical here.
+
+### Non-CLI affordances
+
+- [ ] **Environment variable** — `QUILTX_NO_PREFLIGHT=1` is the current
+      global override for CI / `uvx` contexts where adding the flag to every
+      invocation is awkward.
+- [ ] **ACL YAML — per-bucket opt-in** *(future, out of scope for this
+      change but called out so the flag name doesn't paint us in)*: a
+      bucket-level marker in the policies-only ACL YAML, e.g. an entry under
+      `buckets.read` that carries a `no-preflight: true` annotation, so a
+      single `quiltx catalog acl` run can register some buckets with owner
+      setup and others without.
+
+### Interaction with existing flags
+
+- [ ] **`--no-test`** (`bucket add` only) — `--no-preflight` implies
+      `--no-test`, because post-add verification is another stack/access
+      probe that can fail for the same reason. Users can run
+      `quiltx bucket test` later when they explicitly want that check.
+- [ ] **`--force`** (`bucket add`) — `--force` removes + re-adds. With
+      `--no-preflight`, removal still goes via GraphQL; the re-add must
+      also skip preflight. No conflict, but verify the combined behavior.
+- [ ] **`--dry-run`** — the dry-run plan must say registration will be
+      GraphQL-only and list the skipped local steps: bucket-location probe,
+      bucket-policy read/write, SNS setup, bucket-notification config, and
+      post-add verification.
+- [ ] **`--no-prompt`** — independent; `--no-preflight` should not need or
+      trigger prompts in any case.
+
+## (b) Where it must be implemented and tested
+
+### Library-level entry points
+
+- [ ] [`quiltx/bucket.py`](../quiltx/bucket.py) — keep
+      `resolve_bucket_session`, `find_profile_for_bucket`, `get_bucket_policy`,
+      `apply_bucket_policy`, `ensure_sns_topic`, `configure_sns_topic_policy`,
+      `configure_bucket_notifications` for the owner path. Add a new
+      sibling helper that performs only the GraphQL `bucketAdd` and maps
+      its union-type result to a structured return value. Both paths feed
+      the same downstream consumers.
+- [ ] [`quiltx/acl.py:_register_bucket_with_retry`](../quiltx/acl.py#L500-L537)
+      — route through the new helper when the caller passed
+      `no_preflight=True`. Skip steps 1–5 (probe → policy merge → SNS
+      plumbing) and call the GraphQL helper directly.
+
+### CLI plumbing
+
+- [ ] [`quiltx/tools/bucket.py`](../quiltx/tools/bucket.py) — add
+      `--no-preflight` to the `add` subparser (next to `--no-test` for
+      symmetry), thread it into `_cmd_add`, then into the library entry
+      point.
+- [ ] [`quiltx/tools/catalog/acl.py`](../quiltx/tools/catalog/acl.py) — add
+      `--no-preflight` to the `acl` parser, thread into `_run`, then down
+      to every `_register_bucket_with_retry` call site.
+- [ ] **Env-var resolution** — wherever the CLI converts argparse args to
+      booleans, fall back to `os.environ["QUILTX_NO_PREFLIGHT"]` when the
+      flag was not passed explicitly.
+
+### Error mapping (the substantive new logic)
+
+The GraphQL `bucketAdd` returns a union — when we no longer probe locally,
+these become the *only* signal that something is wrong. Each must produce a
+human-readable error on stderr:
+
+- [ ] `BucketAddSuccess` — happy path, registered.
+- [ ] `BucketAlreadyAdded` — no-op (currently surfaced as "already registered").
+- [ ] `BucketDoesNotExist` — stack cannot reach bucket. Surface explicitly:
+      "The stack cannot access this bucket; check the stack's IAM role or
+      the bucket's public-access settings."
+- [ ] `InsufficientPermissions` — stack reached the bucket but lacks
+      necessary actions. Surface the actions needed.
+- [ ] `NotificationConfigurationError`, `NotificationTopicNotFound`,
+      `SnsInvalid`, `SubscriptionInvalid` — only relevant if an SNS ARN is
+      passed; under `--no-preflight` we omit the SNS ARN so these should
+      not occur. If they do, surface verbatim.
+- [ ] `BucketFileExtensionsToIndexInvalid`, `BucketIndexContentBytesInvalid`
+      — input-validation errors; surface verbatim.
+
+### Tests
+
+- [ ] [`tests/test_bucket.py`](../tests/test_bucket.py) —
+  - `bucket add --no-preflight` happy path (mocked GraphQL returns
+    `BucketAddSuccess`); verify no boto3 S3/SNS calls were made.
+  - Each non-success union variant maps to a distinct stderr message
+    and non-zero exit code.
+  - `--no-preflight` combined with `--no-test` (no-op overlap).
+  - `--no-preflight` combined with `--force` (remove + re-add, both via
+    GraphQL).
+  - `QUILTX_NO_PREFLIGHT=1` env var triggers the same path without the flag.
+- [ ] [`tests/test_acl.py`](../tests/test_acl.py) —
+  - `catalog acl <file> --no-preflight` registers all new buckets via the
+    GraphQL-only path; no boto3 calls.
+  - Drift detection still works when some buckets are owner-set-up and
+    others are no-preflight (registration mode is local, not a server-side
+    property).
+  - Failure of one bucket's no-preflight add (e.g. `BucketDoesNotExist`)
+    does not roll back successfully-added buckets.
+
+### Documentation
+
+- [ ] [`README.md`](../README.md) — `## Bucket registration` section: when
+      to use `--no-preflight` (public Open Data buckets; buckets already
+      plumbed in the central account; quick read-only registrations).
+- [ ] [`README_DEV.md`](../README_DEV.md) — design notes: why two paths
+      exist, when each is appropriate, what guarantees each makes.
+- [ ] [`CHANGELOG.md`](../CHANGELOG.md) — entry under the next version.
+- [ ] [`AGENTS.md`](../AGENTS.md) — if it lists user-facing flags, update.
+
+## Decisions to lock in before implementation
+
+- [x] `--no-preflight` implies `--no-test`.
+- [x] `quiltx bucket test` does not accept `--no-preflight`.
+- [x] `QUILTX_NO_PREFLIGHT=1` is the current global override; per-bucket
+      YAML opt-in remains future/out of scope.
+- [x] Dry-run output shows the skipped local steps; normal output states
+      that registration used the GraphQL-only admin-UI path.

--- a/spec/7-no-preflight.md
+++ b/spec/7-no-preflight.md
@@ -62,7 +62,9 @@ from their roles and left SSO config drifted, requiring manual recovery.
 The fix is to give quiltx a path that **mirrors the admin UI**: submit the
 GraphQL `bucketAdd` mutation directly, let the stack probe with its own
 IAM, and surface the structured GraphQL error union (`BucketDoesNotExist`,
-`InsufficientPermissions`, etc.) verbatim. The local owner-setup routine
+`InsufficientPermissions`, etc.) — mapping each union typename to a
+typename-tagged, actionable CLI message rather than dropping it on the
+floor. The local owner-setup routine
 stays available for the genuine cross-account-grant case where it is the
 only thing that can work — but it stops being the only option.
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1721,3 +1721,33 @@ def test_describe_policy_state_reports_refetch_failure() -> None:
     out = acl._describe_policy_state(stack, "internal")
     assert out.startswith("refetch failed: ")
     assert "graphql down" in out
+
+
+def test_acl_tool_dry_run_no_preflight_lists_skipped_steps(monkeypatch, capsys) -> None:
+    diff = acl.AclDiff(buckets_to_add=["bucket-a"])
+    current = _empty_current_state()
+    _install_acl_tool_stack(monkeypatch)
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "parse_acl_config",
+        lambda path: acl.AclConfig(policies=[], roles={}),
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda _stack: current)
+    monkeypatch.setattr(acl_tool.acl_lib, "compute_diff", lambda desired, state: diff)
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "apply_acl",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("apply_acl should not be called")
+        ),
+    )
+
+    result = acl_tool.main(["config.yml", "--dry-run", "--no-preflight"])
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "--no-preflight" in out
+    assert "GraphQL only" in out
+    assert "GetBucketPolicy" in out
+    assert "SNS topic" in out

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1129,6 +1129,56 @@ def test_apply_acl_uses_cross_account_registration_when_stack_available(
     assert calls == [("register", "bucket-a", "111", True)]
 
 
+def test_apply_acl_no_preflight_uses_graphql_only(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_add_without_preflight(
+        stack: Any, bucket: str, *, title: str | None = None
+    ):
+        calls.append((bucket, title or ""))
+
+    monkeypatch.setattr(
+        "quiltx.bucket.add_bucket_without_preflight", fake_add_without_preflight
+    )
+    stack = _fake_stack(payload={"account_id": "111"})
+
+    warnings = acl.apply_acl(
+        stack,
+        acl.AclDiff(buckets_to_add=["bucket-a", "bucket-b"]),
+        _empty_current_state(),
+        no_preflight=True,
+    )
+
+    assert warnings == []
+    assert calls == [("bucket-a", "bucket-a"), ("bucket-b", "bucket-b")]
+
+
+def test_apply_acl_no_preflight_failure_does_not_rollback(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_add_without_preflight(
+        stack: Any, bucket: str, *, title: str | None = None
+    ):
+        calls.append(bucket)
+        if bucket == "bad-bucket":
+            raise RuntimeError("BucketDoesNotExist")
+
+    monkeypatch.setattr(
+        "quiltx.bucket.add_bucket_without_preflight", fake_add_without_preflight
+    )
+    stack = _fake_stack(payload={"account_id": "111"})
+
+    warnings = acl.apply_acl(
+        stack,
+        acl.AclDiff(buckets_to_add=["good-bucket", "bad-bucket"]),
+        _empty_current_state(),
+        no_preflight=True,
+    )
+
+    assert calls == ["good-bucket", "bad-bucket"]
+    assert warnings == ["Bucket 'bad-bucket' could not be added: BucketDoesNotExist"]
+
+
 def test_acl_tool_dry_run_does_not_apply(monkeypatch, capsys) -> None:
     diff = acl.AclDiff(buckets_to_add=["bucket-a"])
     current = _empty_current_state()
@@ -1193,6 +1243,85 @@ def test_acl_tool_yes_flag_applies_without_prompt(monkeypatch) -> None:
 
     assert result == 0
     assert applied == ["applied"]
+
+
+def test_acl_tool_no_preflight_threads_to_apply(monkeypatch) -> None:
+    current = _empty_current_state()
+    no_preflight_values: list[bool] = []
+    _install_acl_tool_stack(monkeypatch)
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "parse_acl_config",
+        lambda path: acl.AclConfig(policies=[], roles={}),
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda _stack: current)
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "compute_diff",
+        lambda desired, state: acl.AclDiff(buckets_to_add=["bucket-a"]),
+    )
+    monkeypatch.setattr(acl_tool.acl_lib, "print_diff", lambda *args, **kwargs: None)
+
+    def _apply_acl(*_args: Any, **kwargs: Any) -> list[str]:
+        no_preflight_values.append(kwargs["no_preflight"])
+        return []
+
+    monkeypatch.setattr(acl_tool.acl_lib, "apply_acl", _apply_acl)
+
+    result = acl_tool.main(["config.yml", "--yes", "--no-preflight"])
+
+    assert result == 0
+    assert no_preflight_values == [True]
+
+
+def test_policy_drift_reapply_preserves_no_preflight(monkeypatch) -> None:
+    desired = acl.AclConfig(policies=[], roles={})
+    current = _empty_current_state()
+    post_reset = _empty_current_state()
+    new_diff = acl.AclDiff(buckets_to_add=["bucket-a"])
+    no_preflight_values: list[bool] = []
+    stack = _fake_stack(users=SimpleNamespace(list=lambda: []))
+
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "reset_policy",
+        lambda *args, **kwargs: ([], []),
+    )
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "fetch_current_state",
+        lambda _stack: post_reset,
+    )
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "compute_diff",
+        lambda _desired, _current: new_diff,
+    )
+    monkeypatch.setattr(
+        acl_tool.acl_lib,
+        "detect_policy_drift",
+        lambda _desired, _current: [],
+    )
+
+    def _apply_acl(*_args: Any, **kwargs: Any) -> list[str]:
+        no_preflight_values.append(kwargs["no_preflight"])
+        return []
+
+    monkeypatch.setattr(acl_tool.acl_lib, "apply_acl", _apply_acl)
+
+    warnings, _ = acl_tool._handle_policy_drift(
+        stack,
+        [acl.PolicyDrift(title="public", desired=[], actual=[])],
+        desired,
+        current,
+        auto=True,
+        verbose=False,
+        no_preflight=True,
+    )
+
+    assert warnings == []
+    assert no_preflight_values == [True]
 
 
 def test_acl_tool_no_config_shows_current_state(monkeypatch, capsys) -> None:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -10,6 +10,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import boto3
+import pytest
 from botocore.stub import Stubber
 
 from quiltx import bucket as bucket_lib
@@ -601,6 +602,147 @@ def test_add_already_registered_skips_post_test_when_no_test_flag(monkeypatch) -
     s3_stubber.deactivate()
     sns_stubber.deactivate()
     sts_stubber.deactivate()
+
+
+def test_add_no_preflight_registers_without_boto3(monkeypatch, capsys) -> None:
+    add_calls: list[tuple[str, str | None]] = []
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    _install_stack_context(monkeypatch)
+    monkeypatch.setattr(
+        bucket_tool.boto3,
+        "Session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("boto3 should not be used")
+        ),
+    )
+    monkeypatch.setattr(
+        bucket_tool,
+        "_verify_bucket_registration_and_access",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("post-add test should not run")
+        ),
+    )
+
+    def fake_add_without_preflight(stack, bucket, *, title=None):
+        add_calls.append((bucket, title))
+        return AddBucketResult(bucket, title or bucket, "", False)
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        fake_add_without_preflight,
+    )
+
+    assert bucket_tool.main(["add", "bucket", "--yes", "--no-preflight"]) == 0
+    captured = capsys.readouterr()
+    assert "via GraphQL only" in captured.out
+    assert "local AWS preflight/setup skipped" in captured.out
+    assert add_calls == [("bucket", "bucket")]
+
+
+def test_add_no_preflight_env_var(monkeypatch) -> None:
+    add_calls: list[str] = []
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    _install_stack_context(monkeypatch)
+    monkeypatch.setenv("QUILTX_NO_PREFLIGHT", "1")
+    monkeypatch.setattr(
+        bucket_tool.boto3,
+        "Session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("boto3 should not be used")
+        ),
+    )
+
+    def fake_add_without_preflight(stack, bucket, *, title=None):
+        add_calls.append(bucket)
+        return AddBucketResult(bucket, title or bucket, "", False)
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        fake_add_without_preflight,
+    )
+
+    assert bucket_tool.main(["add", "bucket", "--yes"]) == 0
+    assert add_calls == ["bucket"]
+
+
+def test_add_no_preflight_no_prompt_does_not_require_yes(monkeypatch) -> None:
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    _install_stack_context(monkeypatch)
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: AddBucketResult(
+            bucket, title or bucket, "", False
+        ),
+    )
+
+    assert bucket_tool.main(["add", "bucket", "--no-preflight", "--no-prompt"]) == 0
+
+
+def test_add_no_preflight_force_removes_then_adds(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+    _install_stack_context(monkeypatch)
+
+    buckets = SimpleNamespace()
+    buckets.get = lambda name: FakeBucket(name, "Existing")
+    buckets.remove = lambda name: calls.append(("remove", name))
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "resolve_catalog_context",
+        lambda _catalog=None, **kw: make_fake_catalog("demo", buckets=buckets),
+    )
+
+    def fake_add_without_preflight(stack, bucket, *, title=None):
+        calls.append(("add", bucket))
+        return AddBucketResult(bucket, title or bucket, "", False)
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        fake_add_without_preflight,
+    )
+
+    assert (
+        bucket_tool.main(["add", "bucket", "--yes", "--no-preflight", "--force"]) == 0
+    )
+    assert calls == [("remove", "bucket"), ("add", "bucket")]
+
+
+@pytest.mark.parametrize(
+    ("typename", "message", "expected"),
+    [
+        (
+            "BucketDoesNotExist",
+            "",
+            "The stack cannot access this bucket",
+        ),
+        (
+            "InsufficientPermissions",
+            "missing s3:ListBucket",
+            "missing s3:ListBucket",
+        ),
+        ("NotificationConfigurationError", "", "NotificationConfigurationError"),
+        ("NotificationTopicNotFound", "", "NotificationTopicNotFound"),
+        ("SnsInvalid", "", "SnsInvalid"),
+        ("SubscriptionInvalid", "", "SubscriptionInvalid"),
+        (
+            "BucketFileExtensionsToIndexInvalid",
+            "",
+            "BucketFileExtensionsToIndexInvalid",
+        ),
+        (
+            "BucketIndexContentBytesInvalid",
+            "",
+            "BucketIndexContentBytesInvalid",
+        ),
+    ],
+)
+def test_bucket_add_union_error_messages(typename, message, expected) -> None:
+    result = SimpleNamespace(typename__=typename, message=message)
+
+    assert expected in bucket_lib._bucket_add_error_message(result, typename)
 
 
 def _stub_s3_for_full_add():

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -2159,3 +2159,46 @@ def test_reindex_rejects_non_s3_uri(capsys) -> None:
     assert rc == 2
     err = capsys.readouterr().err
     assert "s3://" in err
+
+
+def test_add_no_preflight_bucket_add_error_exits_nonzero(monkeypatch, capsys) -> None:
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    _install_stack_context(monkeypatch)
+
+    def boom(stack, bucket, *, title=None):
+        raise bucket_lib.BucketAddError("BucketDoesNotExist: cannot reach bucket")
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        boom,
+    )
+
+    rc = bucket_tool.main(["add", "bucket", "--no-preflight"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "BucketDoesNotExist" in captured.err
+    assert captured.err.startswith("Error: ")
+    assert "BucketDoesNotExist" not in captured.out
+
+
+def test_add_no_preflight_does_not_prompt_without_yes(monkeypatch) -> None:
+    """Spec 7-no-preflight §144: --no-preflight should not need or trigger prompts."""
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    _install_stack_context(monkeypatch)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": (_ for _ in ()).throw(
+            AssertionError("--no-preflight must not prompt")
+        ),
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: AddBucketResult(
+            bucket, title or bucket, "", False
+        ),
+    )
+
+    assert bucket_tool.main(["add", "bucket", "--no-preflight"]) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- Add `--no-preflight` to `quiltx bucket add` and `quiltx catalog acl` so bucket registration can skip local S3/SNS owner setup and let the catalog stack probe via GraphQL.
- Add a GraphQL-only `bucketAdd` helper that preserves structured union error messages.
- Document the two registration paths and capture the no-preflight spec decisions.

## Review fixes (v0.16.1)
- Document `--no-preflight`'s no-prompt contract in `--yes` help, `--no-preflight` help, and the README example (spec/7-no-preflight.md §144). `--yes` is now explicitly unnecessary for `bucket add --no-preflight`.
- `catalog acl --no-preflight --dry-run` now lists the skipped local AWS steps (spec §140) instead of returning before no-preflight is evaluated.
- New CLI-boundary tests:
  - `test_add_no_preflight_bucket_add_error_exits_nonzero` — asserts `BucketAddError` from `add_bucket_without_preflight` is rendered to stderr with a non-zero exit.
  - `test_add_no_preflight_does_not_prompt_without_yes` — asserts the spec §144 no-prompt contract.
  - `test_acl_tool_dry_run_no_preflight_lists_skipped_steps` — covers the dry-run output for `catalog acl --no-preflight --dry-run`.

## Validation
- `./poe lint` — black + mypy clean.
- `./poe test` — 333 passed, 1 skipped.
- push hooks: black, mypy, poe test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--no-preflight` flag to `quiltx bucket add` and `quiltx catalog acl`, providing a GraphQL-only registration path that mirrors the catalog admin UI — skipping local S3/SNS bucket-owner setup and letting the catalog stack probe with its own IAM. A new `add_bucket_without_preflight` library helper maps the full GraphQL union-error type to structured, human-readable messages.

- New `quiltx/bucket.py` helper (`add_bucket_without_preflight`, `BucketAddError`, `_bucket_add_typename`, `_bucket_add_error_message`) covers all documented union variants including `BucketDoesNotExist`, `InsufficientPermissions`, and SNS/validation errors.
- `--no-preflight` is threaded through `_cmd_add` → `_cmd_add_no_preflight` (bucket tool) and `_run` → `apply_acl` → `_register_bucket_with_retry` (ACL tool), with `QUILTX_NO_PREFLIGHT=1` as a scripted override; the dry-run path lists the skipped local AWS steps.
- New CLI-boundary tests assert no-boto3 invocation, env-var activation, no-prompt contract, force remove+re-add, all error-union messages, and non-zero exit on `BucketAddError`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the no-preflight path is well-isolated and the full owner-setup path is unchanged.

The core logic — skipping local S3/SNS setup and delegating to the GraphQL union — is correct and well-tested. The three findings are all style/maintainability issues: a duplicated env-var check, a dry-run notice that fires when no bucket registrations are actually planned, and a stale pragma comment. None of them affect the happy path or the error path in production.

quiltx/tools/catalog/acl.py — env-var duplication and the no-changes dry-run notice condition; quiltx/acl.py — stale pragma on the exception block.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| quiltx/bucket.py | Adds `add_bucket_without_preflight`, `BucketAddError`, and private helpers `_bucket_add_typename`, `_field_value`, `_bucket_add_error_message`. Logic is sound; union-error mapping covers all documented variants. |
| quiltx/tools/bucket.py | Adds `--no-preflight` CLI flag, `_env_flag` helper, `_cmd_add_no_preflight` handler, and `_print_no_preflight_dry_run` rich table; no-preflight path is correctly gated behind the outer try-except in `_cmd_add`. |
| quiltx/acl.py | Threads `no_preflight` through `apply_acl` and `_register_bucket_with_retry`; the no-preflight branch passes `control_account_id or ""` but that value is ignored inside `_register_bucket_with_retry` when `no_preflight=True`, which is harmless but slightly misleading. |
| quiltx/tools/catalog/acl.py | Adds `--no-preflight` to the ACL tool; env-var check is inlined instead of reusing `_env_flag`, and the dry-run notice is shown even when no changes exist (buckets_to_add is empty). |
| tests/test_bucket.py | Good new coverage: no-boto3 path, env-var activation, no-prompt contract, force remove+re-add, all union error variants, BucketAddError exit code, and no-prompt spec assertion. |
| tests/test_acl.py | New tests cover no-preflight threading, failure non-rollback, dry-run notice output, policy-drift reapply with no_preflight preserved; stale `# pragma: no cover` in the exception block it now exercises. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["quiltx bucket add BUCKET"] --> B{no-preflight flag\nor env var?}
    B -- No --> C[bucket-owner path\nresolve session\nmerge bucket policy\nensure SNS topic\nGraphQL bucketAdd with SNS ARN]
    B -- Yes --> D[_cmd_add_no_preflight]
    D --> E{dry-run?}
    E -- Yes --> F[print skipped AWS steps\nreturn 0]
    E -- No --> G{already registered?}
    G -- Yes and force --> H[admin.buckets.remove]
    G -- Yes no force --> I[print already-registered\nreturn 0]
    H --> J[add_bucket_without_preflight\nGraphQL bucketAdd\nsns_notification_arn is None]
    G -- No --> J
    J --> K{GraphQL typename}
    K -- BucketAddSuccess --> L[return AddBucketResult\nalready_registered=False]
    K -- BucketAlreadyAdded --> M[return AddBucketResult\nalready_registered=True]
    K -- error typename --> N[raise BucketAddError\nhuman-readable message]
    N --> O[print to stderr\nreturn 1]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `quiltx/acl.py`, line 656-659 ([link](https://github.com/quiltdata/quiltx/blob/bbf1f4c9d5d6c708f7bfe929ef8e5a0f4a66b77a/quiltx/acl.py#L656-L659)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `# pragma: no cover` after new test**

   The `except Exception` block here is now exercised by `test_apply_acl_no_preflight_failure_does_not_rollback`, which injects a `RuntimeError` through the mocked `add_bucket_without_preflight`. The pragma was correct before this PR, but keeping it means the coverage report will under-report actual test coverage and the comment "external API surface" no longer accurately describes why the branch exists.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["CHANGELOG: 0.16.1"](https://github.com/quiltdata/quiltx/commit/bbf1f4c9d5d6c708f7bfe929ef8e5a0f4a66b77a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32271804)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->