### PR TITLE
Preserve registry canary ACL resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-08-10
+
+### Fixed
+
+- `quiltx catalog acl` preserves the registry-managed `Canary` role and `CanaryBucketAccess` policy during reconciliation, preventing disruption to the `_canary` service user.
+
 ## [0.16.1] - 2026-05-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.1"
+version = "0.16.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -22,6 +22,8 @@ ACL_ENTRY_KEYS = {
 }
 CONFIG_POLICIES_KEY = "config.policies"
 EVERYONE_GROUP = "Everyone"
+REGISTRY_MANAGED_POLICY_EXCLUSIONS = frozenset({"CanaryBucketAccess"})
+REGISTRY_MANAGED_ROLE_EXCLUSIONS = frozenset({"Canary"})
 
 
 @dataclass(frozen=True)
@@ -350,6 +352,7 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
         title
         for title in current.managed_policies
         if title not in desired_policy_titles
+        and title not in REGISTRY_MANAGED_POLICY_EXCLUSIONS
     )
 
     desired_role_names = set(desired_state.role_updates)
@@ -375,7 +378,10 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
             )
 
     diff.roles_to_delete = sorted(
-        name for name in current.managed_roles if name not in desired_role_names
+        name
+        for name in current.managed_roles
+        if name not in desired_role_names
+        and name not in REGISTRY_MANAGED_ROLE_EXCLUSIONS
     )
 
     desired_sso_text = build_sso_config(desired)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -630,6 +630,50 @@ def test_compute_diff_is_idempotent_against_matching_current_state() -> None:
     assert diff.warnings == []
 
 
+def test_compute_diff_preserves_registry_managed_canary_resources() -> None:
+    desired = acl.AclConfig(policies=[], roles={})
+    current = _empty_current_state()
+    current.managed_policies.update(
+        {
+            "CanaryBucketAccess": FakePolicy(
+                id="id-canary-policy",
+                title="CanaryBucketAccess",
+                managed=True,
+                permissions=[],
+                roles=[],
+            ),
+            "other-policy": FakePolicy(
+                id="id-other-policy",
+                title="other-policy",
+                managed=True,
+                permissions=[],
+                roles=[],
+            ),
+        }
+    )
+    current.managed_roles.update(
+        {
+            "Canary": FakeRole(
+                id="id-canary-role",
+                name="Canary",
+                policies=[],
+                permissions=[],
+            ),
+            "other-role": FakeRole(
+                id="id-other-role",
+                name="other-role",
+                policies=[],
+                permissions=[],
+            ),
+        }
+    )
+
+    diff = acl.compute_diff(desired, current)
+
+    assert diff.policies_to_delete == ["other-policy"]
+    assert diff.roles_to_delete == ["other-role"]
+
+
 def test_compute_diff_warns_and_skips_unmanaged_name_collisions() -> None:
     desired = acl.parse_acl_config(Path("stack-acl.example.yaml"))
     current = _empty_current_state()

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- exclude the registry-managed `Canary` role and `CanaryBucketAccess` policy from ACL deletion diffs
- retain authoritative deletion of other undeclared managed resources
- bump the patch release to 0.16.2 and update the changelog

## Testing
- `uv run pytest tests/test_acl.py -q`
- `./poe lint-check`
- `./poe test`

Closes #59

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents ACL reconciliation from deleting the registry-managed canary role and policy while retaining deletion of other undeclared managed resources.

- Adds fixed exclusions for the `Canary` role and `CanaryBucketAccess` policy.
- Adds a regression test covering preservation alongside deletion of ordinary resources.
- Bumps the package version to 0.16.2 and updates the changelog and lockfile.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The deletion exclusions are limited to the two intended registry canary resource names, ordinary undeclared resources remain authoritative deletions, and the regression test exercises both behaviors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Excludes the two registry-owned canary resource names from authoritative deletion while leaving normal reconciliation behavior unchanged. |
| tests/test_acl.py | Verifies that canary resources are preserved and unrelated undeclared managed resources remain scheduled for deletion. |
| pyproject.toml | Bumps the project patch version from 0.16.1 to 0.16.2. |
| quiltx/_version.py | Keeps the runtime version constant synchronized with the project metadata. |
| uv.lock | Synchronizes the editable root package version without changing dependency versions. |
| CHANGELOG.md | Documents the canary-resource preservation fix in the 0.16.2 release. |

<sub>Reviews (1): Last reviewed commit: ["Preserve registry canary ACL resources"](https://github.com/quiltdata/quiltx/commit/a81b0339e652a1642da0a7fe3c0ac746333cedbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52016099)</sub>

<!-- /greptile_comment -->