### PR TITLE
ACL synthetic role aliases (v0.16.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-08-10
+
+### Added
+
+- Policy entries in `quiltx catalog acl` accept a `name` field that gives the cumulative synthesized role a short display name without creating duplicate roles or SSO mappings.
+
 ## [0.16.2] - 2026-08-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.2"
+version = "0.16.3"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -210,10 +210,10 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             )
         entry = _parse_acl_entry(value, f"policies.{name}")
         role_name = value.get(POLICY_ROLE_NAME_KEY)
-        if role_name is not None and (
-            not isinstance(role_name, str) or not role_name.strip()
-        ):
-            raise ValueError(f"policies.{name}.name must be a non-empty string")
+        if role_name is not None:
+            if not isinstance(role_name, str) or not role_name.strip():
+                raise ValueError(f"policies.{name}.name must be a non-empty string")
+            role_name = role_name.strip()
         policy = AclPolicy(
             name=name,
             sso=entry.sso,

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -20,6 +20,7 @@ ACL_ENTRY_KEYS = {
     "config.default_role",
     "config.is_admin",
 }
+POLICY_ROLE_NAME_KEY = "name"
 CONFIG_POLICIES_KEY = "config.policies"
 EVERYONE_GROUP = "Everyone"
 REGISTRY_MANAGED_POLICY_EXCLUSIONS = frozenset({"CanaryBucketAccess"})
@@ -34,6 +35,7 @@ class AclPolicy:
     read_write: list[str] = field(default_factory=list)
     default_role: bool = False
     is_admin: bool | None = None
+    role_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -207,6 +209,11 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 "inline-role policies"
             )
         entry = _parse_acl_entry(value, f"policies.{name}")
+        role_name = value.get(POLICY_ROLE_NAME_KEY)
+        if role_name is not None and (
+            not isinstance(role_name, str) or not role_name.strip()
+        ):
+            raise ValueError(f"policies.{name}.name must be a non-empty string")
         policy = AclPolicy(
             name=name,
             sso=entry.sso,
@@ -214,6 +221,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             read_write=entry.read_write,
             is_admin=entry.is_admin,
             default_role=entry.default_role,
+            role_name=role_name,
         )
         policies.append(policy)
         policy_names.add(name)
@@ -1424,7 +1432,9 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
         cumulative_policy_titles.append(policy.name)
         if policy.is_admin is not None:
             cumulative_admin_votes.append((policy.name, policy.is_admin))
-        synthesized_role_name = _synthesized_role_name(cumulative_policy_titles)
+        synthesized_role_name = policy.role_name or _synthesized_role_name(
+            cumulative_policy_titles
+        )
         synthesized_admin = _resolve_policy_admin_vote(
             cumulative_admin_votes,
             synthesized_role_name,
@@ -1534,6 +1544,8 @@ def _validate_top_level_keys(raw: dict[str, Any]) -> None:
 
 def _validate_acl_entry_keys(value: dict[str, Any], *, section: str, name: str) -> None:
     allowed_keys = set(ACL_ENTRY_KEYS)
+    if section == "policies":
+        allowed_keys.add(POLICY_ROLE_NAME_KEY)
     if section == "roles":
         allowed_keys.add(CONFIG_POLICIES_KEY)
     unknown_keys = sorted(
@@ -1617,15 +1629,24 @@ def _validate_synthetic_role_names(
     policies: list[AclPolicy], declared_role_names: set[str]
 ) -> None:
     cumulative_policy_titles: list[str] = []
+    generated_role_sources: dict[str, list[str]] = {}
     for policy in policies:
         cumulative_policy_titles.append(policy.name)
-        role_name = _synthesized_role_name(cumulative_policy_titles)
+        role_name = policy.role_name or _synthesized_role_name(cumulative_policy_titles)
         if role_name in declared_role_names:
             raise ValueError(
                 f"Synthesized role '{role_name}' from policy ladder "
                 f"{', '.join(cumulative_policy_titles)} conflicts with declared role "
                 f"'{role_name}'"
             )
+        previous_source = generated_role_sources.get(role_name)
+        if previous_source is not None:
+            raise ValueError(
+                f"Synthesized role '{role_name}' from policy ladder "
+                f"{', '.join(cumulative_policy_titles)} conflicts with the role "
+                f"generated from {', '.join(previous_source)}"
+            )
+        generated_role_sources[role_name] = list(cumulative_policy_titles)
 
 
 def _synthesized_role_name(policy_titles: list[str]) -> str:

--- a/stack-acl.example.yaml
+++ b/stack-acl.example.yaml
@@ -8,6 +8,8 @@
 #
 # A user qualifies for a policy if they belong to any of its listed groups.
 # Their synthetic role is the union of all policies they qualify for.
+# Set `name` on a policy to replace that ladder rung's synthesized role name
+# with a shorter display name without creating a duplicate static role.
 
 policies:
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -360,6 +360,47 @@ roles:
         acl.parse_acl_config(config_path)
 
 
+def test_policy_role_alias_is_normalized_and_propagated(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+  leadership:
+    name: "  executives  "
+    sso.groups: [Executives]
+    config.default_role: true
+""")
+
+    config = acl.parse_acl_config(config_path)
+    desired = acl._build_desired_acl_state(config)
+    sso = yaml.safe_load(acl.build_sso_config(config) or "")
+
+    assert config.policies[1].role_name == "executives"
+    assert list(desired.role_updates) == ["public", "executives"]
+    assert desired.default_role_name == "executives"
+    assert [mapping["roles"] for mapping in sso["mappings"]] == [
+        ["public"],
+        ["executives"],
+    ]
+
+
+def test_policy_role_alias_rejects_generated_role_collision(tmp_path: Path) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    name: shared
+    sso.groups: [Everyone]
+  internal:
+    name: shared
+    sso.groups: [Employees]
+""")
+
+    with pytest.raises(ValueError, match="Synthesized role 'shared'.*conflicts"):
+        acl.parse_acl_config(config_path)
+
+
 def test_all_buckets_includes_inline_role_buckets() -> None:
     config = acl.AclConfig(
         policies=[

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- accept a policy-level `name` override for cumulative synthesized roles
- use the alias consistently for role creation, SSO mappings, and default-role selection
- reject aliases that collide with static or generated roles
- release as 0.16.3

Closes #57

## Validation
- `./poe lint-check`
- `./poe test` (334 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds policy-level aliases for cumulative synthesized ACL roles and applies those aliases consistently during role generation and collision validation.
- Accepts and validates a non-empty policy `name` field.
- Uses aliases for desired roles, SSO mappings, and default-role selection.
- Rejects aliases colliding with declared or previously generated roles.
- Updates release metadata, changelog, lockfile, and example documentation to version 0.16.3.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking caveat that the new alias flow lacks direct regression coverage.

The implementation derives role creation, SSO mappings, and default-role selection from the same resolved alias and validates collisions, leaving only a test-coverage weakness rather than a demonstrated runtime defect.

**Files Needing Attention:** quiltx/acl.py and tests/test_acl.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds parsing, propagation, and collision validation for synthetic-role aliases; the behavior is internally consistent but lacks alias-specific regression tests. |
| stack-acl.example.yaml | Documents the new policy-level `name` option without changing executable behavior. |
| CHANGELOG.md | Records the synthetic-role alias feature in the 0.16.3 release notes. |
| pyproject.toml | Bumps the project version from 0.16.2 to 0.16.3. |
| quiltx/_version.py | Keeps the runtime version constant synchronized at 0.16.3. |
| uv.lock | Updates only the editable QuiltX package version to 0.16.3. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Policy YAML name] --> B[parse_acl_config]
    B --> C[AclPolicy.role_name]
    C --> D{Alias present?}
    D -->|Yes| E[Use alias]
    D -->|No| F[Generate cumulative role name]
    E --> G[Validate role-name collisions]
    F --> G
    G --> H[Desired role updates]
    G --> I[SSO role mappings]
    G --> J[Default-role selection]
```

<sub>Reviews (1): Last reviewed commit: ["Bump version to 0.16.3"](https://github.com/quiltdata/quiltx/commit/d5a92d63662029fb9ab10fb3bbf54990745ea76e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52021920)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->