### PR TITLE
Export ACL users and state (v0.16.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-08-10
+
+### Added
+
+- `quiltx catalog acl` current-state output now includes users and role assignments, and `--json` exports the complete ACL state for automation and migration.
+
 ## [0.16.3] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,9 +116,17 @@ Unset is neutral, `true` grants admin, and an explicit `false` vetoes any prior
 
 ### Usage
 
+With no config file, the command reports the complete server ACL state, including
+users and their active and extra role assignments. Pass `--json` for a
+machine-readable export of the catalog, buckets, policies, roles, users, SSO
+configuration, and default role.
+
 ```bash
 # Show current server ACL state
 uvx quiltx catalog acl
+
+# Export the current server ACL state as JSON
+uvx quiltx catalog acl --json
 
 # Preview changes (dry run)
 uvx quiltx catalog acl config.yml --dry-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.3"
+version = "0.16.4"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -521,6 +521,12 @@ def print_current_state(current: CurrentState) -> None:
             f"admin={user.is_admin}, active={user.is_active}, "
             f"sso_only={user.is_sso_only}, service={user.is_service}"
         )
+        date_joined = _json_value(user.date_joined)
+        last_login = _json_value(user.last_login)
+        print(
+            f"    date joined: {date_joined if date_joined is not None else '(none)'}"
+        )
+        print(f"    last login: {last_login if last_login is not None else '(none)'}")
 
     if current.sso_config_text:
         print("  sso config")

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -66,6 +66,7 @@ class CurrentState:
     all_roles: dict[str, Any]
     sso_config_text: str | None
     default_role_name: str | None
+    users: list[Any] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -318,6 +319,7 @@ def fetch_current_state(stack: stack_lib.Catalog) -> CurrentState:
 
     sso_config = stack.admin.sso_config.get()
     default_role = stack.admin.roles.get_default()
+    users = list(stack.admin.users.list())
     return CurrentState(
         buckets=bucket_items,
         managed_policies=managed_policies,
@@ -328,6 +330,7 @@ def fetch_current_state(stack: stack_lib.Catalog) -> CurrentState:
         all_roles={**unmanaged_roles, **managed_roles},
         sso_config_text=None if sso_config is None else sso_config.text,
         default_role_name=None if default_role is None else default_role.name,
+        users=users,
     )
 
 
@@ -504,11 +507,153 @@ def print_current_state(current: CurrentState) -> None:
         print(f"  role {name}{default_tag} (unmanaged)")
         print(f"    policies: {policy_names}")
 
+    for user in sorted(current.users, key=lambda item: item.name):
+        primary_role = user.role.name if user.role else "(none)"
+        extra_roles = ", ".join(role.name for role in (user.extra_roles or [])) or (
+            "(none)"
+        )
+        print(f"  user {user.name}")
+        print(f"    email: {user.email or '(none)'}")
+        print(f"    active role: {primary_role}")
+        print(f"    extra roles: {extra_roles}")
+        print(
+            "    flags: "
+            f"admin={user.is_admin}, active={user.is_active}, "
+            f"sso_only={user.is_sso_only}, service={user.is_service}"
+        )
+
     if current.sso_config_text:
         print("  sso config")
         _print_sso_summary(current.sso_config_text)
     else:
         print("  sso config: (none)")
+
+
+def current_state_as_dict(
+    current: CurrentState, *, catalog: str | None = None
+) -> dict[str, Any]:
+    """Return the complete current ACL state as JSON-compatible data."""
+    payload: dict[str, Any] = {
+        "buckets": [
+            _bucket_as_dict(bucket) for _name, bucket in sorted(current.buckets.items())
+        ],
+        "policies": [
+            _policy_as_dict(policy, managed=title in current.managed_policies)
+            for title, policy in sorted(current.all_policies.items())
+        ],
+        "roles": [
+            _role_as_dict(
+                role,
+                managed=name in current.managed_roles,
+                is_default=name == current.default_role_name,
+            )
+            for name, role in sorted(current.all_roles.items())
+        ],
+        "users": [
+            _user_as_dict(user) for user in sorted(current.users, key=lambda u: u.name)
+        ],
+        "sso_config": current.sso_config_text,
+        "default_role": current.default_role_name,
+    }
+    if catalog is not None:
+        payload = {"catalog": catalog, **payload}
+    return payload
+
+
+def _bucket_as_dict(bucket: Any) -> dict[str, Any]:
+    fields = (
+        "name",
+        "title",
+        "icon_url",
+        "description",
+        "overview_url",
+        "tags",
+        "relevance_score",
+        "last_indexed",
+        "sns_notification_arn",
+        "scanner_parallel_shards_depth",
+        "skip_meta_data_indexing",
+        "file_extensions_to_index",
+        "index_content_bytes",
+        "prefixes",
+    )
+    return {
+        field_name: _json_value(getattr(bucket, field_name))
+        for field_name in fields
+        if hasattr(bucket, field_name)
+    }
+
+
+def _policy_as_dict(policy: Any, *, managed: bool) -> dict[str, Any]:
+    return {
+        "id": _json_value(getattr(policy, "id", None)),
+        "title": policy.title,
+        "arn": _json_value(getattr(policy, "arn", None)),
+        "managed": managed,
+        "permissions": [
+            {
+                "bucket": permission.bucket,
+                "level": _json_value(permission.level),
+            }
+            for permission in (getattr(policy, "permissions", None) or [])
+        ],
+        "roles": [role.name for role in (getattr(policy, "roles", None) or [])],
+    }
+
+
+def _role_as_dict(role: Any, *, managed: bool, is_default: bool) -> dict[str, Any]:
+    policies = getattr(role, "policies", None)
+    permissions = getattr(role, "permissions", None)
+    return {
+        "id": _json_value(getattr(role, "id", None)),
+        "name": role.name,
+        "arn": _json_value(getattr(role, "arn", None)),
+        "managed": managed,
+        "default": is_default,
+        "policies": None if policies is None else [policy.title for policy in policies],
+        "permissions": (
+            None
+            if permissions is None
+            else [
+                {
+                    "bucket": permission.bucket,
+                    "level": _json_value(permission.level),
+                }
+                for permission in permissions
+            ]
+        ),
+    }
+
+
+def _user_as_dict(user: Any) -> dict[str, Any]:
+    return {
+        "name": user.name,
+        "email": user.email,
+        "role": None if user.role is None else user.role.name,
+        "extra_roles": [role.name for role in (user.extra_roles or [])],
+        "is_admin": user.is_admin,
+        "is_active": user.is_active,
+        "is_sso_only": user.is_sso_only,
+        "is_service": user.is_service,
+        "date_joined": _json_value(user.date_joined),
+        "last_login": _json_value(user.last_login),
+    }
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_value(item) for item in value]
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, (str, int, float, bool)):
+        return enum_value
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    return str(value)
 
 
 def _register_bucket_with_retry(

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 
 from quiltx import acl as acl_lib
@@ -47,12 +48,22 @@ def build_parser() -> argparse.ArgumentParser:
             "bucket-owner setup."
         ),
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit the complete current ACL state as JSON. "
+            "Only valid when config_file is omitted."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.json and args.config_file is not None:
+        parser.error("--json is only valid when config_file is omitted")
 
     try:
         return _run(args)
@@ -70,12 +81,23 @@ def main(argv: list[str] | None = None) -> int:
 @stack_lib.catalog_command
 def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
     try:
-        header = stack_lib.current_stack_header(stack)
-        if header:
-            print(header)
+        if not args.json:
+            header = stack_lib.current_stack_header(stack)
+            if header:
+                print(header)
         if args.config_file is None:
             current = acl_lib.fetch_current_state(stack)
-            acl_lib.print_current_state(current)
+            if args.json:
+                print(
+                    json.dumps(
+                        acl_lib.current_state_as_dict(
+                            current, catalog=stack.catalog_name
+                        ),
+                        indent=2,
+                    )
+                )
+            else:
+                acl_lib.print_current_state(current)
             return 0
 
         desired = acl_lib.parse_acl_config(args.config_file)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -825,12 +827,31 @@ def test_print_current_state_summarizes_server_acl(capsys) -> None:
     current = _current_state_for_config(
         acl.parse_acl_config(Path("stack-acl.example.yaml"))
     )
+    current.users.append(
+        SimpleNamespace(
+            name="alice",
+            email="alice@example.com",
+            role=current.managed_roles["exec"],
+            extra_roles=[current.managed_roles["internal_public"]],
+            is_admin=True,
+            is_active=True,
+            is_sso_only=False,
+            is_service=False,
+            date_joined=datetime(2026, 8, 1, tzinfo=timezone.utc),
+            last_login=None,
+        )
+    )
 
     acl.print_current_state(current)
     out = capsys.readouterr().out
 
     assert "policy public (managed)" in out
     assert "role internal_public (default) (managed)" in out
+    assert "user alice" in out
+    assert "active role: exec" in out
+    assert "extra roles: internal_public" in out
+    assert "date joined: 2026-08-01T00:00:00+00:00" in out
+    assert "last login: (none)" in out
     assert "default_role: internal_public" in out
     assert "groups=Executives -> [exec] (admin)" in out
 
@@ -1419,6 +1440,61 @@ def test_acl_tool_no_config_shows_current_state(monkeypatch, capsys) -> None:
 
     assert result == 0
     assert "bucket bucket-a" in capsys.readouterr().out
+
+
+def test_acl_tool_json_exports_valid_json_without_header(monkeypatch, capsys) -> None:
+    current = replace(_empty_current_state(), default_role_name="readers")
+    role = FakeRole(id="role-1", name="readers", policies=[], permissions=[])
+    current.managed_roles[role.name] = role
+    current.all_roles[role.name] = role
+    current.users.append(
+        SimpleNamespace(
+            name="alice",
+            email="alice@example.com",
+            role=role,
+            extra_roles=[],
+            is_admin=False,
+            is_active=True,
+            is_sso_only=False,
+            is_service=False,
+            date_joined=datetime(2026, 8, 1, tzinfo=timezone.utc),
+            last_login=None,
+        )
+    )
+    _install_acl_tool_stack(monkeypatch)
+    monkeypatch.setattr(acl_tool.acl_lib, "fetch_current_state", lambda _stack: current)
+    monkeypatch.setattr(
+        acl_tool.stack_lib, "current_stack_header", lambda _stack: "HUMAN HEADER"
+    )
+
+    result = acl_tool.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["catalog"] == "catalog"
+    assert payload["default_role"] == "readers"
+    assert payload["users"] == [
+        {
+            "name": "alice",
+            "email": "alice@example.com",
+            "role": "readers",
+            "extra_roles": [],
+            "is_admin": False,
+            "is_active": True,
+            "is_sso_only": False,
+            "is_service": False,
+            "date_joined": "2026-08-01T00:00:00+00:00",
+            "last_login": None,
+        }
+    ]
+
+
+def test_acl_tool_json_rejects_config_file(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        acl_tool.main(["--json", "config.yml"])
+
+    assert exc_info.value.code == 2
+    assert "--json is only valid when config_file is omitted" in capsys.readouterr().err
 
 
 def test_acl_tool_missing_file_reports_error(capsys) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- include users, active roles, extra roles, account flags, and timestamps in current ACL state
- add `quiltx catalog acl --json` for a complete machine-readable export
- identify managed versus unmanaged roles and policies in the export
- release as 0.16.4

Closes #58

## Stack
Depends on #63. Merge after the 0.16.3 PR.

## Validation
- `./poe lint-check`
- `./poe test` (334 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release expands current ACL-state reporting with users, role assignments, account flags, and timestamps, and adds a header-free `--json` export intended for automation and migration.
- Fetches users as part of the current ACL state.
- Serializes buckets, policies, roles, users, SSO configuration, and the default role.
- Adds CLI validation limiting `--json` to current-state queries.
- Bumps the package release from 0.16.3 to 0.16.4.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The JSON path preserves clean stdout, uses a guaranteed catalog name, validates incompatible CLI arguments, and no supported current-state input was shown to violate the new serialization assumptions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Extends CurrentState with users and adds JSON-compatible serializers for the complete reported ACL state; no concrete changed-code defect was established. |
| quiltx/tools/catalog/acl.py | Adds the `--json` mode, rejects its use with a config file, suppresses the human-readable header, and emits the serialized state. |
| README.md | Documents complete current-state reporting and the new JSON export command. |
| pyproject.toml | Bumps the project version to 0.16.4 without changing dependency constraints. |
| uv.lock | Updates only the editable quiltx package version to 0.16.4. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    CLI[quiltx catalog acl] --> Mode{--json?}
    Mode -->|No| Fetch[Fetch current ACL state]
    Mode -->|Yes| Fetch
    Fetch --> APIs[Catalog admin APIs]
    APIs --> State[CurrentState]
    State -->|Human output| Print[print_current_state]
    State -->|JSON output| Serialize[current_state_as_dict]
    Serialize --> JSON[Machine-readable ACL export]
```

<sub>Reviews (1): Last reviewed commit: ["Bump version to 0.16.4"](https://github.com/quiltdata/quiltx/commit/53d1a8e91bdbf45dbc021b391f5bfc2d39d85890) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52024194)</sub>

<!-- /greptile_comment -->