### PR TITLE
Allow static ACL roles without SSO selectors (v0.16.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.6] - 2026-08-10
+
+### Added
+
+- Top-level static roles may omit SSO selectors while retaining their managed role and policy grants without emitting SSO mappings.
+
 ## [0.16.5] - 2026-08-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.5"
+version = "0.16.6"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.5"
+__version__ = "0.16.6"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -852,6 +852,25 @@ def apply_acl(
                 f"  ! policy {policy.title}: {detail}{suffix}",
                 file=sys.stderr,
             )
+            # A registry mutation may persist successfully and still return a
+            # generic 500. Refetch so dependent roles can use the real policy
+            # ID instead of being skipped until a second run.
+            try:
+                persisted = next(
+                    (
+                        item
+                        for item in stack.admin.policies.list()
+                        if getattr(item, "title", None) == policy.title
+                        and bool(getattr(item, "managed", False))
+                    ),
+                    None,
+                )
+            except Exception:
+                persisted = None
+            if persisted is None:
+                continue
+            known_policies[policy.title] = persisted
+            print(f"  ~ policy {policy.title} (found after failed create)")
             continue
         known_policies[policy.title] = created
         print(f"  + policy {policy.title}")
@@ -1148,6 +1167,10 @@ def detect_policy_drift(desired: AclConfig, current: CurrentState) -> list[Polic
     desired_state = _build_desired_acl_state(desired)
     drift: list[PolicyDrift] = []
     for title, policy_update in desired_state.policy_updates.items():
+        # Name collisions with unmanaged policies are intentionally skipped by
+        # reconciliation and must never be escalated into delete/reset recovery.
+        if title in current.unmanaged_policies:
+            continue
         current_policy = current.managed_policies.get(title)
         actual_permissions = (
             list(current_policy.permissions) if current_policy is not None else []
@@ -1181,7 +1204,7 @@ def _role_ref(role_name: str, current: CurrentState) -> str:
 
 
 def _policy_ref(policy_title: str, current: CurrentState) -> str:
-    policy = current.all_policies.get(policy_title)
+    policy = current.managed_policies.get(policy_title)
     if policy is None:
         raise ValueError(
             f"Policy '{policy_title}' was not present in the fetched current state"
@@ -1536,6 +1559,10 @@ def reset_policy(
     """
     warnings: list[str] = []
     user_snapshot: list[UserRoleBinding] = []
+    # A missing policy is the normal failed-create drift case. There is
+    # nothing destructive to reset; the caller's reapply will create it.
+    if title not in current.managed_policies:
+        return warnings, user_snapshot
     deleted = already_deleted_roles if already_deleted_roles is not None else set()
     roles_to_delete = [
         r for r in managed_roles_using_policy(title, current) if r not in deleted
@@ -1557,7 +1584,7 @@ def reset_policy(
     for role_name in roles_to_delete:
         try:
             _print_apply_step(f"delete role {role_name}", verbose=verbose)
-            stack.admin.roles.delete(role_name)
+            stack.admin.roles.delete(_role_ref(role_name, current))
             print(f"  - role {role_name}")
         except Exception as exc:
             detail = format_exception(exc)

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -243,7 +243,17 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 f"Role '{name}' conflicts with reserved generated inline policy "
                 f"'{reserved_inline_policy}'"
             )
-        entry = _parse_acl_entry(value, f"roles.{name}")
+        entry = _parse_acl_entry(value, f"roles.{name}", require_sso_selector=False)
+        if not entry.sso and entry.default_role:
+            raise ValueError(
+                f"roles.{name}.config.default_role cannot be true without an "
+                "sso.<claim> selector"
+            )
+        if not entry.sso and entry.is_admin:
+            raise ValueError(
+                f"roles.{name}.config.is_admin cannot be true without an "
+                "sso.<claim> selector"
+            )
         policy_refs = _coerce_string_list(
             value.get(CONFIG_POLICIES_KEY, []), f"roles.{name}.{CONFIG_POLICIES_KEY}"
         )
@@ -1731,8 +1741,13 @@ def _validate_acl_entry_keys(value: dict[str, Any], *, section: str, name: str) 
     )
 
 
-def _parse_acl_entry(value: dict[str, Any], field_name: str) -> _ParsedAclEntry:
-    sso = _coerce_sso_selectors(value, field_name)
+def _parse_acl_entry(
+    value: dict[str, Any],
+    field_name: str,
+    *,
+    require_sso_selector: bool = True,
+) -> _ParsedAclEntry:
+    sso = _coerce_sso_selectors(value, field_name, required=require_sso_selector)
     read = _coerce_string_list(
         value.get("buckets.read", []), f"{field_name}.buckets.read"
     )
@@ -1919,7 +1934,7 @@ def _print_sso_summary(sso_text: str) -> None:
 
 
 def _coerce_sso_selectors(
-    value: dict[str, Any], section_name: str
+    value: dict[str, Any], section_name: str, *, required: bool = True
 ) -> dict[str, list[str]]:
     sso: dict[str, list[str]] = {}
     for key, raw_values in value.items():
@@ -1930,7 +1945,7 @@ def _coerce_sso_selectors(
             raise ValueError(f"'{section_name}.{key}' must include a claim name")
         values = _coerce_non_empty_string_list(raw_values, f"{section_name}.{key}")
         sso[claim] = _dedupe_preserve_order(values)
-    if not sso:
+    if required and not sso:
         raise ValueError(
             f"'{section_name}' must include at least one sso.<claim> selector"
         )

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -483,6 +483,34 @@ roles:
     assert payload["mappings"][2]["schema"]["required"] == ["email"]
 
 
+def test_static_role_without_sso_manages_role_without_sso_update(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+roles:
+  password-users:
+    config.policies: [public]
+    buckets.read: [private]
+""")
+
+    config = acl.parse_acl_config(config_path)
+    desired = acl._build_desired_acl_state(config)
+
+    assert config.roles["password-users"].sso == {}
+    assert desired.role_updates["password-users"].policy_titles == [
+        "public",
+        "password-users__inline",
+    ]
+    sso_text = acl.build_sso_config(config)
+    assert sso_text is not None
+    sso = yaml.safe_load(sso_text)
+    assert all(mapping["roles"] != ["password-users"] for mapping in sso["mappings"])
+
+
 def test_static_role_can_be_default_role(tmp_path: Path) -> None:
     config_path = tmp_path / "acl.yml"
     config_path.write_text("""
@@ -747,6 +775,63 @@ def test_compute_diff_warns_and_skips_unmanaged_name_collisions() -> None:
     )
     assert "public" not in [policy.title for policy in diff.policies_to_create]
     assert "exec" not in [role.name for role in diff.roles_to_create]
+
+
+def test_policy_drift_skips_unmanaged_name_collision() -> None:
+    desired = acl.AclConfig(
+        policies=[acl.AclPolicy(name="public", sso={"groups": ["Everyone"]})],
+        roles={},
+    )
+    current = _empty_current_state()
+    unmanaged = FakePolicy(
+        id="u-policy", title="public", managed=False, permissions=[], roles=[]
+    )
+    current.unmanaged_policies["public"] = unmanaged
+    current.all_policies["public"] = unmanaged
+
+    assert acl.detect_policy_drift(desired, current) == []
+
+
+def test_apply_acl_refetches_policy_after_failed_create() -> None:
+    persisted = FakePolicy(
+        id="policy-id", title="public", managed=True, permissions=[], roles=[]
+    )
+    role_policy_ids: list[list[str]] = []
+
+    def fail_create(_title: str, *, permissions: list[Any]) -> None:
+        raise RuntimeError("Internal Server Error")
+
+    stack = _fake_stack(
+        policies=SimpleNamespace(
+            create_managed=fail_create,
+            list=lambda: [persisted],
+        ),
+        roles=SimpleNamespace(
+            create_managed=lambda _name, *, policies: role_policy_ids.append(policies)
+        ),
+    )
+    diff = acl.AclDiff(
+        policies_to_create=[acl.PolicyUpdate(title="public", permissions=[])],
+        roles_to_create=[acl.RoleUpdate(name="public", policy_titles=["public"])],
+    )
+
+    warnings = acl.apply_acl(stack, diff, _empty_current_state())
+
+    assert role_policy_ids == [["policy-id"]]
+    assert any("could not be created" in warning for warning in warnings)
+
+
+def test_reset_policy_missing_on_server_is_directly_reapplied() -> None:
+    stack = _fake_stack(
+        policies=SimpleNamespace(
+            delete=lambda _ref: pytest.fail("missing policy must not be deleted")
+        )
+    )
+
+    warnings, users = acl.reset_policy(stack, "missing", _empty_current_state())
+
+    assert warnings == []
+    assert users == []
 
 
 def test_changing_policy_groups_updates_sso_config() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- allow static `roles:` entries without `sso.*` selectors
- keep selector-less roles and their policy grants managed without emitting SSO mappings
- reject selector-less default/admin SSO settings and preserve existing SSO state when none is requested
- release as 0.16.6

Closes #67

## Stack
First requested layer; targets `main`. Temporarily depends on #65 for the 0.16.5 baseline and should merge after it. The next layer will target this branch.

## Validation
- `uv run pytest tests/test_acl.py` (69 passed)
- `./poe lint-check`
- `./poe test` (338 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release allows static ACL roles without SSO selectors while preserving role and policy management and existing SSO state. It also changes policy mutations to use UUIDs resolved from fetched state.
- Permits selector-less top-level static roles while rejecting selector-less default or administrator roles.
- Avoids emitting an SSO configuration when no mappings or default role are requested.
- Uses fetched policy IDs for updates, resets, and deletes.
- Bumps the package and lockfile version to 0.16.6 and updates release notes.

<h3>Confidence Score: 4/5</h3>

The drift-recovery crash after a managed policy creation failure should be fixed before merging.

A failed policy creation is intentionally retained as drift, but the changed strict policy lookup raises before reset_policy reaches its guarded delete operation, aborting the recovery pass.

**Files Needing Attention:** quiltx/acl.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds selector-less static roles and UUID-based policy mutation, but strict UUID resolution crashes drift recovery after a policy creation failure. |
| tests/test_acl.py | Expands coverage for selector-less roles and UUID policy references but does not cover failed creation followed by drift recovery. |
| pyproject.toml | Bumps the project version from 0.16.4 to 0.16.6. |
| uv.lock | Updates only the editable quiltx package version; locked third-party dependency versions remain unchanged. |
| CHANGELOG.md | Documents releases 0.16.5 and 0.16.6, including selector-less static role support. |
| quiltx/_version.py | Keeps the runtime version constant synchronized at 0.16.6. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Parse ACL roles] --> B{Role has SSO selector?}
  B -->|Yes| C[Manage role and policy grants]
  C --> D[Generate SSO mappings]
  B -->|No| E{Default or admin enabled?}
  E -->|Yes| F[Reject configuration]
  E -->|No| G[Manage role and policy grants]
  G --> H[Do not request an SSO update]
```

<sub>Reviews (1): Last reviewed commit: ["Allow static ACL roles without SSO selec..."](https://github.com/quiltdata/quiltx/commit/2783a9b75f5c51cd421b124f59bc1f89e69692cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52049530)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->