### PR TITLE
Add reusable ACL policies without role synthesis (v0.16.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.7] - 2026-08-10
+
+### Added
+
+- Policies may set `config.synthesize: false` to remain reusable managed policies without contributing to the cumulative role ladder or SSO mappings.
+
 ## [0.16.6] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.6"
+version = "0.16.7"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.6"
+__version__ = "0.16.7"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -22,6 +22,7 @@ ACL_ENTRY_KEYS = {
 }
 POLICY_ROLE_NAME_KEY = "name"
 CONFIG_POLICIES_KEY = "config.policies"
+CONFIG_SYNTHESIZE_KEY = "config.synthesize"
 EVERYONE_GROUP = "Everyone"
 REGISTRY_MANAGED_POLICY_EXCLUSIONS = frozenset({"CanaryBucketAccess"})
 REGISTRY_MANAGED_ROLE_EXCLUSIONS = frozenset({"Canary"})
@@ -36,6 +37,7 @@ class AclPolicy:
     default_role: bool = False
     is_admin: bool | None = None
     role_name: str | None = None
+    synthesize: bool = True
 
 
 @dataclass(frozen=True)
@@ -209,7 +211,37 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 f"'{INLINE_POLICY_SUFFIX}'; that suffix is reserved for generated "
                 "inline-role policies"
             )
-        entry = _parse_acl_entry(value, f"policies.{name}")
+        synthesize = value.get(CONFIG_SYNTHESIZE_KEY, True)
+        if not isinstance(synthesize, bool):
+            raise ValueError(
+                f"policies.{name}.{CONFIG_SYNTHESIZE_KEY} must be a boolean"
+            )
+        entry = _parse_acl_entry(
+            value,
+            f"policies.{name}",
+            require_sso_selector=synthesize,
+        )
+        if not synthesize:
+            if POLICY_ROLE_NAME_KEY in value:
+                raise ValueError(
+                    f"policies.{name}.{POLICY_ROLE_NAME_KEY} is not valid when "
+                    f"{CONFIG_SYNTHESIZE_KEY} is false because no role is synthesized"
+                )
+            if entry.sso:
+                raise ValueError(
+                    f"policies.{name} cannot include sso.<claim> selectors when "
+                    f"{CONFIG_SYNTHESIZE_KEY} is false"
+                )
+            if entry.default_role:
+                raise ValueError(
+                    f"policies.{name}.config.default_role cannot be true when "
+                    f"{CONFIG_SYNTHESIZE_KEY} is false"
+                )
+            if "config.is_admin" in value:
+                raise ValueError(
+                    f"policies.{name}.config.is_admin is not valid when "
+                    f"{CONFIG_SYNTHESIZE_KEY} is false because no role is synthesized"
+                )
         role_name = value.get(POLICY_ROLE_NAME_KEY)
         if role_name is not None:
             if not isinstance(role_name, str) or not role_name.strip():
@@ -223,6 +255,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
             is_admin=entry.is_admin,
             default_role=entry.default_role,
             role_name=role_name,
+            synthesize=synthesize,
         )
         policies.append(policy)
         policy_names.add(name)
@@ -1596,6 +1629,8 @@ def _build_desired_acl_state(config: AclConfig) -> _DesiredAclState:
             title=policy.name,
             permissions=_permissions_for_buckets(policy.read, policy.read_write),
         )
+        if not policy.synthesize:
+            continue
         cumulative_policy_titles.append(policy.name)
         if policy.is_admin is not None:
             cumulative_admin_votes.append((policy.name, policy.is_admin))
@@ -1712,7 +1747,7 @@ def _validate_top_level_keys(raw: dict[str, Any]) -> None:
 def _validate_acl_entry_keys(value: dict[str, Any], *, section: str, name: str) -> None:
     allowed_keys = set(ACL_ENTRY_KEYS)
     if section == "policies":
-        allowed_keys.add(POLICY_ROLE_NAME_KEY)
+        allowed_keys.update({POLICY_ROLE_NAME_KEY, CONFIG_SYNTHESIZE_KEY})
     if section == "roles":
         allowed_keys.add(CONFIG_POLICIES_KEY)
     unknown_keys = sorted(
@@ -1770,7 +1805,8 @@ def _parse_acl_entry(
 
 
 def _validate_policy_ladder(policies: list[AclPolicy]) -> None:
-    for previous, current in zip(policies, policies[1:]):
+    synthesized_policies = [policy for policy in policies if policy.synthesize]
+    for previous, current in zip(synthesized_policies, synthesized_policies[1:]):
         if _policy_audience_is_compatible(current.sso, previous.sso):
             continue
         raise ValueError(
@@ -1803,6 +1839,8 @@ def _validate_synthetic_role_names(
     cumulative_policy_titles: list[str] = []
     generated_role_sources: dict[str, list[str]] = {}
     for policy in policies:
+        if not policy.synthesize:
+            continue
         cumulative_policy_titles.append(policy.name)
         role_name = policy.role_name or _synthesized_role_name(cumulative_policy_titles)
         if role_name in declared_role_names:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -531,6 +531,49 @@ roles: {{}}
         acl.parse_acl_config(config_path)
 
 
+def test_reusable_policy_is_excluded_from_mixed_synthesized_ladder() -> None:
+    config = acl.AclConfig(
+        policies=[
+            acl.AclPolicy(name="public", sso={"groups": ["Everyone"]}),
+            acl.AclPolicy(name="SharedPolicy", synthesize=False),
+        ],
+        roles={
+            "Analysts": acl.AclStaticRole(name="Analysts", policies=["SharedPolicy"])
+        },
+    )
+
+    desired = acl._build_desired_acl_state(config)
+
+    assert [role.name for role in desired.synthesized_roles] == ["public"]
+    assert desired.role_updates["public"].policy_titles == ["public"]
+    assert desired.role_updates["Analysts"].policy_titles == ["SharedPolicy"]
+
+
+def test_switching_synthesized_policy_to_reusable_deletes_old_role() -> None:
+    original = acl.AclConfig(
+        policies=[
+            acl.AclPolicy(
+                name="SharedPolicy",
+                sso={"groups": ["Everyone"]},
+                read=["shared"],
+            )
+        ],
+        roles={},
+    )
+    desired = acl.AclConfig(
+        policies=[
+            acl.AclPolicy(name="SharedPolicy", read=["shared"], synthesize=False)
+        ],
+        roles={},
+    )
+
+    diff = acl.compute_diff(desired, _current_state_for_config(original))
+
+    assert diff.roles_to_delete == ["SharedPolicy"]
+    assert diff.policies_to_delete == []
+    assert diff.roles_to_create == []
+
+
 def test_static_role_without_sso_manages_role_without_sso_update(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -507,6 +507,30 @@ roles:
     assert acl.build_sso_config(config) is None
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("sso.groups", "[Everyone]", "cannot include sso"),
+        ("config.is_admin", "true", "config.is_admin is not valid"),
+        ("name", "CustomRole", "name is not valid"),
+    ],
+)
+def test_non_synthesizing_policy_rejects_role_only_fields(
+    tmp_path: Path, field: str, value: str, message: str
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text(f"""
+policies:
+  SharedPolicy:
+    config.synthesize: false
+    {field}: {value}
+roles: {{}}
+""")
+
+    with pytest.raises(ValueError, match=message):
+        acl.parse_acl_config(config_path)
+
+
 def test_static_role_without_sso_manages_role_without_sso_update(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -483,6 +483,30 @@ roles:
     assert payload["mappings"][2]["schema"]["required"] == ["email"]
 
 
+def test_non_synthesizing_policy_is_reusable_without_ladder_role(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "acl.yml"
+    config_path.write_text("""
+policies:
+  SharedPolicy:
+    config.synthesize: false
+    buckets.read: [shared]
+roles:
+  Analysts:
+    config.policies: [SharedPolicy]
+""")
+
+    config = acl.parse_acl_config(config_path)
+    desired = acl._build_desired_acl_state(config)
+
+    assert config.policies[0].synthesize is False
+    assert list(desired.policy_updates) == ["SharedPolicy"]
+    assert list(desired.role_updates) == ["Analysts"]
+    assert desired.role_updates["Analysts"].policy_titles == ["SharedPolicy"]
+    assert acl.build_sso_config(config) is None
+
+
 def test_static_role_without_sso_manages_role_without_sso_update(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.6"
+version = "0.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- add `config.synthesize: false` for reusable named managed policies
- keep shared policies out of ladder roles, nesting validation, and SSO mappings
- allow static roles to attach shared policies through `config.policies`
- release as 0.16.7

Closes #68

## Stack
Depends on #71 and targets `67-static-roles-0.16.6`. Merge after the v0.16.6 layer.

## Validation
- `uv run pytest tests/test_acl.py` (69 passed)
- `./poe lint-check`
- `./poe test` (338 passed, 1 skipped)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds reusable managed ACL policies that can be attached to static roles without generating ladder roles or SSO mappings, and releases the change as version 0.16.7.
- Adds and validates `config.synthesize: false` on policy entries.
- Excludes reusable policies from cumulative role construction, ladder validation, generated-name validation, and SSO mappings while retaining their managed policy resources.
- Updates package metadata, lockfile metadata, and the changelog for version 0.16.7.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking concern that its defining reusable-policy paths and reconciliation transitions lack targeted regression coverage.

The parsing, desired-state, cleanup, and static-role attachment paths are consistent with the stated feature contract, but no test directly exercises `config.synthesize: false`.

**Files Needing Attention:** quiltx/acl.py, tests/test_acl.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds reusable-policy parsing, validation, and desired-state behavior; implementation is internally consistent, but the new branch and transition behavior lack targeted tests. |
| pyproject.toml | Updates the project version from 0.16.6 to 0.16.7. |
| quiltx/_version.py | Keeps the runtime version constant synchronized at 0.16.7. |
| uv.lock | Updates only the editable quiltx package metadata to version 0.16.7. |
| CHANGELOG.md | Documents reusable non-synthesizing managed policies in the 0.16.7 release entry. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Parse policy] --> B{config.synthesize?}
  B -->|true| C[Create managed policy]
  C --> D[Add to cumulative ladder]
  D --> E[Generate role and SSO mappings]
  B -->|false| F[Create reusable managed policy]
  F --> G[Exclude from ladder and SSO]
  G --> H[Attach through static role config.policies]
```

<sub>Reviews (1): Last reviewed commit: ["Support shared ACL policies without synt..."](https://github.com/quiltdata/quiltx/commit/c6cdf1b139a1106b89467695050417d445da441f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52051069)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->