### PR TITLE
Reconcile ACL user role assignments (v0.16.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.8] - 2026-08-10
+
+### Added
+
+- Declarative reconciliation of existing users' primary role, ordered extra roles, and optional administrator status through a top-level `users:` mapping.
+
 ## [0.16.7] - 2026-08-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.7"
+version = "0.16.8"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/__init__.py
+++ b/quiltx/__init__.py
@@ -6,6 +6,8 @@ from quiltx._version import __version__ as __version__
 from quiltx.acl import (
     AclConfig as AclConfig,
     AclDiff as AclDiff,
+    AclUserConfig as AclUserConfig,
+    AclUserUpdate as AclUserUpdate,
     CurrentState as CurrentState,
     all_buckets as all_buckets,
     apply_acl as apply_acl,
@@ -25,6 +27,8 @@ __all__ = [
     "__version__",
     "AclConfig",
     "AclDiff",
+    "AclUserConfig",
+    "AclUserUpdate",
     "Catalog",
     "CurrentState",
     "all_buckets",

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.7"
+__version__ = "0.16.8"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -13,13 +13,14 @@ from quilt3.admin.types import Permission
 from quiltx import stack as stack_lib
 
 INLINE_POLICY_SUFFIX = "__inline"
-ACL_TOP_LEVEL_KEYS = {"policies", "roles"}
+ACL_TOP_LEVEL_KEYS = {"policies", "roles", "users"}
 ACL_ENTRY_KEYS = {
     "buckets.read",
     "buckets.read_write",
     "config.default_role",
     "config.is_admin",
 }
+USER_ENTRY_KEYS = {"role", "extra_roles", "admin"}
 POLICY_ROLE_NAME_KEY = "name"
 CONFIG_POLICIES_KEY = "config.policies"
 CONFIG_SYNTHESIZE_KEY = "config.synthesize"
@@ -52,9 +53,17 @@ class AclStaticRole:
 
 
 @dataclass(frozen=True)
+class AclUserConfig:
+    role: str
+    extra_roles: tuple[str, ...] = ()
+    admin: bool | None = None
+
+
+@dataclass(frozen=True)
 class AclConfig:
     policies: list[AclPolicy]
     roles: dict[str, AclStaticRole]
+    users: dict[str, AclUserConfig] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -83,6 +92,16 @@ class RoleUpdate:
     policy_titles: list[str]
 
 
+@dataclass(frozen=True)
+class AclUserUpdate:
+    name: str
+    role: str
+    extra_roles: tuple[str, ...] = ()
+    role_changed: bool = False
+    admin: bool | None = None
+    admin_changed: bool = False
+
+
 @dataclass
 class AclDiff:
     buckets_to_add: list[str] = field(default_factory=list)
@@ -96,6 +115,8 @@ class AclDiff:
     sso_is_create: bool = False
     sso_needs_update: bool = False
     warnings: list[str] = field(default_factory=list)
+    users_to_update: list[AclUserUpdate] = field(default_factory=list)
+    notices: list[str] = field(default_factory=list)
 
     def has_changes(self) -> bool:
         return any(
@@ -107,6 +128,7 @@ class AclDiff:
                 self.roles_to_create,
                 self.roles_to_update,
                 self.roles_to_delete,
+                self.users_to_update,
                 self.sso_needs_update,
             )
         )
@@ -190,11 +212,14 @@ def parse_acl_config(path: str | Path) -> AclConfig:
 
     raw_policies = raw.get("policies") or {}
     raw_roles = raw.get("roles") or {}
+    raw_users = raw.get("users", {})
 
     if not isinstance(raw_policies, dict):
         raise ValueError("'policies' must be a mapping")
     if not isinstance(raw_roles, dict):
         raise ValueError("'roles' must be a mapping")
+    if not isinstance(raw_users, dict):
+        raise ValueError("'users' must be a mapping")
 
     policies: list[AclPolicy] = []
     policy_names: set[str] = set()
@@ -312,6 +337,43 @@ def parse_acl_config(path: str | Path) -> AclConfig:
         if entry.default_role:
             default_role_sources.append(f"roles.{name}")
 
+    users: dict[str, AclUserConfig] = {}
+    for name, value in raw_users.items():
+        if not isinstance(name, str):
+            raise ValueError("User names must be strings")
+        if not isinstance(value, dict):
+            raise ValueError(f"User '{name}' must be a mapping")
+        unknown_fields = set(value) - USER_ENTRY_KEYS
+        if unknown_fields:
+            raise ValueError(
+                f"Unknown fields in users.{name}: "
+                + ", ".join(sorted(str(field) for field in unknown_fields))
+            )
+        if "role" not in value:
+            raise ValueError(f"users.{name}.role is required")
+        role = value["role"]
+        if not isinstance(role, str) or not role.strip():
+            raise ValueError(f"users.{name}.role must be a non-empty string")
+        role = role.strip()
+        extra_roles = _coerce_string_list(
+            value.get("extra_roles", []), f"users.{name}.extra_roles"
+        )
+        extra_roles = _dedupe_preserve_order(extra_roles)
+        if role in extra_roles:
+            raise ValueError(
+                f"users.{name}.extra_roles must not include primary role '{role}'"
+            )
+        admin: bool | None = None
+        if "admin" in value:
+            admin = value["admin"]
+            if not isinstance(admin, bool):
+                raise ValueError(f"users.{name}.admin must be a boolean")
+        users[name] = AclUserConfig(
+            role=role,
+            extra_roles=tuple(extra_roles),
+            admin=admin,
+        )
+
     if len(default_role_sources) > 1:
         raise ValueError(
             "Only one ACL entry may set config.default_role: true; found "
@@ -324,6 +386,7 @@ def parse_acl_config(path: str | Path) -> AclConfig:
     return AclConfig(
         policies=policies,
         roles=roles,
+        users=users,
     )
 
 
@@ -438,6 +501,37 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
         and name not in REGISTRY_MANAGED_ROLE_EXCLUSIONS
     )
 
+    current_users = {user.name: user for user in current.users}
+    for name, configured_user in desired.users.items():
+        current_user = current_users.get(name)
+        if current_user is None:
+            diff.notices.append(
+                f"Configured user '{name}' does not exist on the server; skipping."
+            )
+            continue
+        current_role = current_user.role.name if current_user.role else None
+        current_extras = tuple(
+            role.name for role in (current_user.extra_roles or []) if role is not None
+        )
+        role_changed = (
+            current_role != configured_user.role
+            or current_extras != configured_user.extra_roles
+        )
+        admin_changed = configured_user.admin is not None and (
+            bool(current_user.is_admin) != configured_user.admin
+        )
+        if role_changed or admin_changed:
+            diff.users_to_update.append(
+                AclUserUpdate(
+                    name=name,
+                    role=configured_user.role,
+                    extra_roles=configured_user.extra_roles,
+                    role_changed=role_changed,
+                    admin=configured_user.admin,
+                    admin_changed=admin_changed,
+                )
+            )
+
     desired_sso_text = build_sso_config(desired)
     if desired_sso_text is not None and not _same_yaml(
         current.sso_config_text, desired_sso_text
@@ -489,9 +583,11 @@ def print_diff(
     """Print a readable summary of ACL changes."""
     if verbose and desired is not None:
         _print_verbose_state(diff, desired, current)
+        for notice in diff.notices:
+            print(f"NONFATAL: {notice}")
         for warning in diff.warnings:
             print(f"! {warning}")
-        if not diff.has_changes() and not diff.warnings:
+        if not diff.has_changes() and not diff.warnings and not diff.notices:
             print("Stack ACL is up to date")
         return
 
@@ -512,6 +608,14 @@ def print_diff(
     for name in diff.roles_to_delete:
         print(f"- role {name}")
 
+    for user in diff.users_to_update:
+        changes: list[str] = []
+        if user.role_changed:
+            changes.append("roles")
+        if user.admin_changed:
+            changes.append("admin")
+        print(f"~ user {user.name} ({', '.join(changes)})")
+
     if diff.sso_needs_update:
         prefix = "+" if diff.sso_is_create else "~"
         print(f"{prefix} sso config")
@@ -519,10 +623,12 @@ def print_diff(
             for line in diff.sso_config_text.rstrip().splitlines():
                 print(f"    {line}")
 
+    for notice in diff.notices:
+        print(f"NONFATAL: {notice}")
     for warning in diff.warnings:
         print(f"! {warning}")
 
-    if not diff.has_changes() and not diff.warnings:
+    if not diff.has_changes() and not diff.warnings and not diff.notices:
         print("Stack ACL is up to date")
 
 
@@ -811,6 +917,57 @@ def _prune_sso_config_for_missing_roles(
     return yaml.safe_dump(payload, sort_keys=False), dropped
 
 
+def _apply_user_updates(
+    stack: stack_lib.Catalog,
+    updates: list[AclUserUpdate],
+    failed_roles: set[str],
+    *,
+    verbose: bool,
+) -> list[str]:
+    """Apply configured existing-user changes without creating or deleting users."""
+    warnings: list[str] = []
+    for update in updates:
+        if update.role_changed:
+            unavailable = failed_roles & {update.role, *update.extra_roles}
+            if unavailable:
+                detail = "desired role creation failed: " + ", ".join(
+                    sorted(unavailable)
+                )
+                warnings.append(
+                    f"User '{update.name}' role assignment skipped: {detail}"
+                )
+                print(f"  ! user {update.name}: {detail}", file=sys.stderr)
+            else:
+                _print_apply_step(f"update user {update.name} roles", verbose=verbose)
+                try:
+                    stack.admin.users.set_role(
+                        update.name,
+                        update.role,
+                        extra_roles=list(update.extra_roles) or None,
+                        append=False,
+                    )
+                    print(f"  ~ user {update.name} (roles)")
+                except Exception as exc:
+                    detail = format_exception(exc)
+                    warnings.append(
+                        f"User '{update.name}' roles could not be updated: {detail}"
+                    )
+                    print(f"  ! user {update.name}: {detail}", file=sys.stderr)
+
+        if update.admin_changed:
+            _print_apply_step(f"update user {update.name} admin", verbose=verbose)
+            try:
+                stack.admin.users.set_admin(update.name, bool(update.admin))
+                print(f"  ~ user {update.name} (admin={update.admin})")
+            except Exception as exc:
+                detail = format_exception(exc)
+                warnings.append(
+                    f"User '{update.name}' admin status could not be updated: {detail}"
+                )
+                print(f"  ! user {update.name}: {detail}", file=sys.stderr)
+    return warnings
+
+
 def apply_acl(
     stack: stack_lib.Catalog,
     diff: AclDiff,
@@ -993,7 +1150,32 @@ def apply_acl(
             continue
         print(f"  ~ role {role.name}")
 
+    user_role_updates = [
+        update for update in diff.users_to_update if update.role_changed
+    ]
+    applicable_user_role_updates = [
+        update
+        for update in user_role_updates
+        if not failed_roles.intersection({update.role, *update.extra_roles})
+    ]
+    sso_cleared_for_user_roles = False
+    if applicable_user_role_updates and current.sso_config_text is not None:
+        clear_warnings = clear_sso_config(stack, verbose=verbose)
+        warnings.extend(clear_warnings)
+        sso_cleared_for_user_roles = not clear_warnings
+
+    if diff.users_to_update:
+        warnings.extend(
+            _apply_user_updates(
+                stack,
+                diff.users_to_update,
+                failed_roles,
+                verbose=verbose,
+            )
+        )
+
     sso_text_to_restore = current.sso_config_text
+    sso_update_succeeded = False
     if diff.sso_needs_update and diff.sso_config_text is not None:
         _print_apply_step("update sso config", verbose=verbose)
         # Failed roles would make the registry reject the entire SSO config
@@ -1039,9 +1221,23 @@ def apply_acl(
                 warnings.append(f"SSO config could not be updated: {detail}")
                 print(f"  ! sso config: {detail}", file=sys.stderr)
             else:
+                sso_update_succeeded = True
                 sso_text_to_restore = pruned_text
                 prefix = "+" if diff.sso_is_create else "~"
                 print(f"  {prefix} sso config")
+
+    if sso_cleared_for_user_roles and not sso_update_succeeded:
+        _print_apply_step("restore sso config after user updates", verbose=verbose)
+        try:
+            stack.admin.sso_config.set(sso_text_to_restore)
+        except Exception as exc:
+            detail = format_exception(exc)
+            warnings.append(
+                f"SSO config could not be restored after user updates: {detail}"
+            )
+            print(f"  ! sso config: {detail}", file=sys.stderr)
+        else:
+            print("  ~ sso config (restored after user updates)")
 
     sso_cleared_for_role_delete = False
     roles_to_delete = set(diff.roles_to_delete)
@@ -1928,6 +2124,22 @@ def _print_verbose_state(
             print(f"    inline policy: {role.inline_policy_title}")
         if role.is_admin:
             print("    admin: true")
+
+    updated_users = {user.name for user in diff.users_to_update}
+    current_user_names = (
+        {user.name for user in current.users} if current is not None else set()
+    )
+    for name, user in desired.users.items():
+        prefix = (
+            "~"
+            if name in updated_users
+            else "=" if current is None or name in current_user_names else "?"
+        )
+        print(f"{prefix} user {name}")
+        print(f"    role: {user.role}")
+        print(f"    extra_roles: {', '.join(user.extra_roles) or '(none)'}")
+        if user.admin is not None:
+            print(f"    admin: {str(user.admin).lower()}")
 
     desired_sso_text = build_sso_config(desired)
     if desired_sso_text is not None:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -502,7 +502,18 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
     )
 
     current_users = {user.name: user for user in current.users}
+    available_user_roles = set(desired_state.role_updates) | set(
+        current.unmanaged_roles
+    )
     for name, configured_user in desired.users.items():
+        requested_roles = {configured_user.role, *configured_user.extra_roles}
+        unknown_roles = sorted(requested_roles - available_user_roles)
+        if unknown_roles:
+            diff.warnings.append(
+                f"Configured user '{name}' references unknown or unmanaged-for-deletion "
+                f"roles: {', '.join(unknown_roles)}; skipping."
+            )
+            continue
         current_user = current_users.get(name)
         if current_user is None:
             diff.notices.append(
@@ -923,13 +934,23 @@ def _apply_user_updates(
     failed_roles: set[str],
     *,
     verbose: bool,
+    role_updates_blocked: bool = False,
 ) -> list[str]:
     """Apply configured existing-user changes without creating or deleting users."""
     warnings: list[str] = []
     for update in updates:
+        role_assignment_failed = False
         if update.role_changed:
             unavailable = failed_roles & {update.role, *update.extra_roles}
-            if unavailable:
+            if role_updates_blocked:
+                role_assignment_failed = True
+                detail = "SSO config could not be cleared"
+                warnings.append(
+                    f"User '{update.name}' role assignment skipped: {detail}"
+                )
+                print(f"  ! user {update.name}: {detail}", file=sys.stderr)
+            elif unavailable:
+                role_assignment_failed = True
                 detail = "desired role creation failed: " + ", ".join(
                     sorted(unavailable)
                 )
@@ -948,6 +969,7 @@ def _apply_user_updates(
                     )
                     print(f"  ~ user {update.name} (roles)")
                 except Exception as exc:
+                    role_assignment_failed = True
                     detail = format_exception(exc)
                     warnings.append(
                         f"User '{update.name}' roles could not be updated: {detail}"
@@ -955,6 +977,13 @@ def _apply_user_updates(
                     print(f"  ! user {update.name}: {detail}", file=sys.stderr)
 
         if update.admin_changed:
+            if update.admin and role_assignment_failed:
+                detail = "role assignment failed"
+                warnings.append(
+                    f"User '{update.name}' admin elevation skipped: {detail}"
+                )
+                print(f"  ! user {update.name}: {detail}", file=sys.stderr)
+                continue
             _print_apply_step(f"update user {update.name} admin", verbose=verbose)
             try:
                 stack.admin.users.set_admin(update.name, bool(update.admin))
@@ -1178,10 +1207,12 @@ def apply_acl(
         if not failed_roles.intersection({update.role, *update.extra_roles})
     ]
     sso_cleared_for_user_roles = False
+    role_updates_blocked = False
     if applicable_user_role_updates and current.sso_config_text is not None:
         clear_warnings = clear_sso_config(stack, verbose=verbose)
         warnings.extend(clear_warnings)
         sso_cleared_for_user_roles = not clear_warnings
+        role_updates_blocked = bool(clear_warnings)
 
     if diff.users_to_update:
         warnings.extend(
@@ -1190,6 +1221,7 @@ def apply_acl(
                 diff.users_to_update,
                 failed_roles,
                 verbose=verbose,
+                role_updates_blocked=role_updates_blocked,
             )
         )
 

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -16,7 +16,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="quiltx catalog acl",
         description=(
             "Reconcile Quilt ACLs from flat YAML with top-level "
-            "'policies:' and 'roles:' blocks."
+            "'policies:', 'roles:', and optional 'users:' blocks."
         ),
     )
     add_catalog_args(parser, auth_required=True)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -483,6 +483,125 @@ roles:
     assert payload["mappings"][2]["schema"]["required"] == ["email"]
 
 
+def test_user_block_reconciles_primary_extra_roles_and_admin() -> None:
+    roles = {
+        "Old": acl.AclStaticRole(name="Old"),
+        "New": acl.AclStaticRole(name="New"),
+        "Extra": acl.AclStaticRole(name="Extra"),
+    }
+    current = _current_state_for_config(acl.AclConfig(policies=[], roles=roles))
+    current.users.append(
+        SimpleNamespace(
+            name="alice",
+            role=current.managed_roles["Old"],
+            extra_roles=[],
+            is_admin=False,
+        )
+    )
+    desired = acl.AclConfig(
+        policies=[],
+        roles=roles,
+        users={
+            "alice": acl.AclUserConfig(role="New", extra_roles=("Extra",), admin=True)
+        },
+    )
+
+    diff = acl.compute_diff(desired, current)
+
+    assert diff.users_to_update == [
+        acl.AclUserUpdate(
+            name="alice",
+            role="New",
+            extra_roles=("Extra",),
+            role_changed=True,
+            admin=True,
+            admin_changed=True,
+        )
+    ]
+
+
+def test_user_role_update_is_skipped_when_sso_clear_fails() -> None:
+    role_calls: list[Any] = []
+    admin_calls: list[Any] = []
+    stack = _fake_stack(
+        users=SimpleNamespace(
+            set_role=lambda *args, **kwargs: role_calls.append((args, kwargs)),
+            set_admin=lambda *args: admin_calls.append(args),
+        ),
+        sso_config=SimpleNamespace(
+            set=lambda _text: (_ for _ in ()).throw(RuntimeError("clear failed"))
+        ),
+    )
+    current = replace(_empty_current_state(), sso_config_text="version: '1.0'")
+    diff = acl.AclDiff(
+        users_to_update=[
+            acl.AclUserUpdate(
+                name="alice",
+                role="New",
+                role_changed=True,
+                admin=True,
+                admin_changed=True,
+            )
+        ]
+    )
+
+    warnings = acl.apply_acl(stack, diff, current)
+
+    assert role_calls == []
+    assert admin_calls == []
+    assert any("SSO config could not be cleared" in warning for warning in warnings)
+    assert any("role assignment skipped" in warning for warning in warnings)
+    assert any("admin elevation skipped" in warning for warning in warnings)
+
+
+def test_user_admin_elevation_is_skipped_when_role_update_fails() -> None:
+    admin_calls: list[Any] = []
+
+    def fail_role(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("role update failed")
+
+    stack = _fake_stack(
+        users=SimpleNamespace(
+            set_role=fail_role,
+            set_admin=lambda *args: admin_calls.append(args),
+        )
+    )
+    diff = acl.AclDiff(
+        users_to_update=[
+            acl.AclUserUpdate(
+                name="alice",
+                role="New",
+                role_changed=True,
+                admin=True,
+                admin_changed=True,
+            )
+        ]
+    )
+
+    warnings = acl.apply_acl(stack, diff, _empty_current_state())
+
+    assert admin_calls == []
+    assert any("roles could not be updated" in warning for warning in warnings)
+    assert any("admin elevation skipped" in warning for warning in warnings)
+
+
+def test_user_block_skips_unknown_role() -> None:
+    current = _empty_current_state()
+    current.users.append(
+        SimpleNamespace(name="alice", role=None, extra_roles=[], is_admin=False)
+    )
+    desired = acl.AclConfig(
+        policies=[],
+        roles={},
+        users={"alice": acl.AclUserConfig(role="Missing")},
+    )
+
+    diff = acl.compute_diff(desired, current)
+
+    assert diff.users_to_update == []
+    assert any("roles: Missing; skipping" in warning for warning in diff.warnings)
+
+
 def test_non_synthesizing_policy_is_reusable_without_ladder_role(
     tmp_path: Path,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.7"
+version = "0.16.8"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- add an optional top-level `users:` mapping for existing accounts
- reconcile primary role, ordered extra roles, and optional administrator status
- leave unlisted and unknown users untouched, and never create or delete accounts
- release as 0.16.8

Closes #69

## Stack
Depends on #72 and targets `68-shared-policies-0.16.7`. Merge after the v0.16.7 layer. The next layer targets this branch.

## Validation
- `uv run pytest tests/test_acl.py tests/test_cli.py -q` (84 passed)
- pre-push hooks: Black, mypy, `poe test` (passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds declarative reconciliation of existing users' primary role, ordered extra roles, and optional administrator status, and releases the package as 0.16.8.
- Parses and validates an optional top-level `users` mapping.
- Computes and displays user role and administrator changes without creating or deleting accounts.
- Temporarily clears and restores SSO configuration around user role mutations.
- Updates package metadata, exports, CLI help, changelog, and lockfile version.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until failed role operations can no longer produce stale or partially elevated user assignments.

A failed managed-role update does not block users from being assigned to that stale role, and a failed per-user role assignment does not prevent the same account's administrator elevation.

**Files Needing Attention:** quiltx/acl.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds user parsing, diffing, output, and application logic; role-update and per-user failures can leave user permissions partially reconciled. |
| quiltx/__init__.py | Exports the new public user configuration and update data classes consistently. |
| quiltx/tools/catalog/acl.py | Updates CLI help to advertise the optional users block. |
| pyproject.toml | Bumps the project version to 0.16.8 consistently with release metadata. |
| quiltx/_version.py | Updates the runtime version constant to 0.16.8. |
| uv.lock | Synchronizes the editable package version with the project release. |
| CHANGELOG.md | Documents declarative existing-user reconciliation in the 0.16.8 release. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant ACL as apply_acl
    participant Roles as Role API
    participant SSO as SSO API
    participant Users as User API
    CLI->>ACL: Apply computed ACL diff
    ACL->>Roles: Create/update managed roles
    alt User role updates and SSO exists
        ACL->>SSO: Clear configuration
    end
    ACL->>Users: set_role for configured users
    ACL->>Users: set_admin when requested
    ACL->>SSO: Update or restore configuration
    ACL-->>CLI: Warnings and applied changes
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `quiltx/acl.py`, line 1138-1150 ([link](https://github.com/quiltdata/quiltx/blob/a0ec4effae1fd938d295aaf9663e832a8675e118/quiltx/acl.py#L1138-L1150)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed updates leave stale roles**

   When a managed-role policy update fails, the exception path does not add that role to `failed_roles`, so user reconciliation can still assign an existing user to the role by name, causing the user to receive its stale policy set instead of the permissions declared in the ACL configuration.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Reconcile ACL user role assignments (#69..."](https://github.com/quiltdata/quiltx/commit/a0ec4effae1fd938d295aaf9663e832a8675e118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52065339)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->