### PR TITLE
Reconcile settings-level default role (v0.16.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.10] - 2026-08-10
+
+### Fixed
+
+- `quiltx catalog acl` now captures and reconciles the settings-level default role, including selector-less roles used by password-auth stacks.
+
 ## [0.16.9] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `quiltx catalog acl` now captures and reconciles the settings-level default role, including selector-less roles used by password-auth stacks.
+- `quiltx catalog acl` now captures and reconciles the settings-level default role, including selector-less roles used by password-auth stacks, and rejects SSO selectors without a declared default role.
 
 ## [0.16.9] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Unset is neutral, `true` grants admin, and an explicit `false` vetoes any prior
 `config.default_role: true` reconciles the settings-level role assigned to new
 password signups. A selector-less static role may be the default; when the file
 also generates SSO configuration, the same role is used as its fallback default.
+Files with any `sso.<claim>` selectors must declare exactly one default role.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Policy `config.is_admin` also composes cumulatively for synthesized roles.
 Unset is neutral, `true` grants admin, and an explicit `false` vetoes any prior
 `true` in that generated role and is reported as a warning.
 
+`config.default_role: true` reconciles the settings-level role assigned to new
+password signups. A selector-less static role may be the default; when the file
+also generates SSO configuration, the same role is used as its fallback default.
+
 ### Usage
 
 With no config file, the command reports the complete server ACL state, including

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.9"
+version = "0.16.10"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.9"
+__version__ = "0.16.10"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -381,6 +381,15 @@ def parse_acl_config(path: str | Path) -> AclConfig:
     _validate_policy_ladder(policies)
     _validate_synthetic_role_names(policies, role_names)
 
+    has_sso_selectors = any(policy.sso for policy in policies) or any(
+        role.sso for role in roles.values()
+    )
+    if has_sso_selectors and not default_role_sources:
+        raise ValueError(
+            "ACL configs with sso.<claim> selectors must set "
+            "config.default_role: true on exactly one policy or role"
+        )
+
     return AclConfig(
         policies=policies,
         roles=roles,
@@ -564,6 +573,11 @@ def build_sso_config(config: AclConfig) -> str | None:
     desired_state = _build_desired_acl_state(config)
     if not desired_state.sso_mappings:
         return None
+    if desired_state.default_role_name is None:
+        raise ValueError(
+            "ACL configs with sso.<claim> selectors must set "
+            "config.default_role: true on exactly one policy or role"
+        )
 
     payload: dict[str, Any] = {"version": "1.0", "union_roles": True, "mappings": []}
     if desired_state.default_role_name is not None:

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -114,6 +114,8 @@ class AclDiff:
     sso_config_text: str | None = None
     sso_is_create: bool = False
     sso_needs_update: bool = False
+    default_role_name: str | None = None
+    default_role_needs_update: bool = False
     warnings: list[str] = field(default_factory=list)
     users_to_update: list[AclUserUpdate] = field(default_factory=list)
     notices: list[str] = field(default_factory=list)
@@ -130,6 +132,7 @@ class AclDiff:
                 self.roles_to_delete,
                 self.users_to_update,
                 self.sso_needs_update,
+                self.default_role_needs_update,
             )
         )
 
@@ -302,11 +305,6 @@ def parse_acl_config(path: str | Path) -> AclConfig:
                 f"'{reserved_inline_policy}'"
             )
         entry = _parse_acl_entry(value, f"roles.{name}", require_sso_selector=False)
-        if not entry.sso and entry.default_role:
-            raise ValueError(
-                f"roles.{name}.config.default_role cannot be true without an "
-                "sso.<claim> selector"
-            )
         if not entry.sso and entry.is_admin:
             raise ValueError(
                 f"roles.{name}.config.is_admin cannot be true without an "
@@ -501,6 +499,13 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
         and name not in REGISTRY_MANAGED_ROLE_EXCLUSIONS
     )
 
+    if (
+        desired_state.default_role_name is not None
+        and desired_state.default_role_name != current.default_role_name
+    ):
+        diff.default_role_name = desired_state.default_role_name
+        diff.default_role_needs_update = True
+
     current_users = {user.name: user for user in current.users}
     available_user_roles = set(desired_state.role_updates) | set(
         current.unmanaged_roles
@@ -557,7 +562,7 @@ def compute_diff(desired: AclConfig, current: CurrentState) -> AclDiff:
 def build_sso_config(config: AclConfig) -> str | None:
     """Translate the flat ACL config into Quilt's schema-based SSO YAML."""
     desired_state = _build_desired_acl_state(config)
-    if not desired_state.sso_mappings and desired_state.default_role_name is None:
+    if not desired_state.sso_mappings:
         return None
 
     payload: dict[str, Any] = {"version": "1.0", "union_roles": True, "mappings": []}
@@ -618,6 +623,9 @@ def print_diff(
         print(f"~ role {role.name}")
     for name in diff.roles_to_delete:
         print(f"- role {name}")
+
+    if diff.default_role_needs_update and diff.default_role_name is not None:
+        print(f"~ default role {diff.default_role_name}")
 
     for user in diff.users_to_update:
         changes: list[str] = []
@@ -803,19 +811,39 @@ def current_state_as_acl_yaml(
             policy_entry["buckets.read_write"] = read_write
         policy_entries[title] = policy_entry
 
-    sso_notes, selectors, admin_roles, default_role = _acl_sso_fields(
+    sso_notes, selectors, admin_roles, sso_default_role = _acl_sso_fields(
         current, set(role_entries)
     )
     notes.extend(sso_notes)
-    # If any part of SSO is not representable, leave the complete server SSO
-    # document unmanaged rather than emitting a partial, destructive rewrite.
-    if not sso_notes:
+
+    settings_default_role = current.default_role_name
+    if settings_default_role is not None:
+        if settings_default_role in role_entries:
+            role_entries[settings_default_role]["config.default_role"] = True
+        else:
+            notes.append(
+                f"settings default role {settings_default_role!r} is not captured"
+            )
+
+    defaults_disagree = (
+        current.sso_config_text is not None
+        and not sso_notes
+        and sso_default_role != settings_default_role
+    )
+    if defaults_disagree:
+        notes.append(
+            f"SSO default role {sso_default_role!r} differs from settings default "
+            f"role {settings_default_role!r}; existing SSO left untouched"
+        )
+
+    # If any part of SSO is not representable, or its default differs from the
+    # operative settings default, leave the complete server SSO document
+    # unmanaged rather than emitting a partial, destructive rewrite.
+    if not sso_notes and not defaults_disagree:
         for role_name, role_selectors in selectors.items():
             role_entries[role_name].update(role_selectors)
         for role_name in admin_roles:
             role_entries[role_name]["config.is_admin"] = True
-        if default_role is not None:
-            role_entries[default_role]["config.default_role"] = True
 
     user_entries: dict[str, dict[str, Any]] = {}
     for user in sorted(current.users, key=lambda item: item.name):
@@ -1446,6 +1474,30 @@ def apply_acl(
             print(f"  ! role {role.name}: {detail}", file=sys.stderr)
             continue
         print(f"  ~ role {role.name}")
+
+    if diff.default_role_needs_update and diff.default_role_name is not None:
+        default_role_name = diff.default_role_name
+        if default_role_name in failed_roles:
+            detail = "desired role creation failed"
+            warnings.append(
+                f"Default role '{default_role_name}' could not be updated: {detail}"
+            )
+            print(f"  ! default role {default_role_name}: {detail}", file=sys.stderr)
+        else:
+            _print_apply_step(f"set default role {default_role_name}", verbose=verbose)
+            try:
+                stack.admin.roles.set_default(default_role_name)
+            except Exception as exc:
+                detail = format_exception(exc)
+                warnings.append(
+                    f"Default role '{default_role_name}' could not be updated: {detail}"
+                )
+                print(
+                    f"  ! default role {default_role_name}: {detail}",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"  ~ default role {default_role_name}")
 
     user_role_updates = [
         update for update in diff.users_to_update if update.role_changed

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -721,26 +721,37 @@ roles:
     assert all(mapping["roles"] != ["password-users"] for mapping in sso["mappings"])
 
 
-def test_static_role_can_be_default_role(tmp_path: Path) -> None:
+def test_static_role_can_be_default_role(tmp_path: Path, capsys) -> None:
     config_path = tmp_path / "acl.yml"
     config_path.write_text("""
-policies:
-  public:
-    sso.groups: [Everyone]
+policies: {}
 roles:
-  exec:
-    sso.groups: [Executives]
-    config.policies: [public]
+  password-users:
     config.default_role: true
 """)
 
     config = acl.parse_acl_config(config_path)
-    sso_config = acl.build_sso_config(config)
-    assert sso_config is not None
-    payload = yaml.safe_load(sso_config)
+    diff = acl.compute_diff(config, _empty_current_state())
 
-    assert config.roles["exec"].default_role is True
-    assert payload["default_role"] == "exec"
+    assert config.roles["password-users"].default_role is True
+    assert acl.build_sso_config(config) is None
+    assert diff.default_role_name == "password-users"
+    assert diff.default_role_needs_update is True
+    acl.print_diff(diff)
+    assert "~ default role password-users" in capsys.readouterr().out
+
+    config_with_sso = acl.AclConfig(
+        policies=[],
+        roles={
+            **config.roles,
+            "employees": acl.AclStaticRole(
+                name="employees", sso={"groups": ["Employees"]}
+            ),
+        },
+    )
+    sso_config = acl.build_sso_config(config_with_sso)
+    assert sso_config is not None
+    assert yaml.safe_load(sso_config)["default_role"] == "password-users"
 
 
 def test_policy_config_is_admin_marks_synthesized_role_admin(tmp_path: Path) -> None:
@@ -1188,6 +1199,7 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         roles=SimpleNamespace(
             create_managed=role_create,
             update_managed=lambda *args, **kwargs: None,
+            set_default=lambda name: calls.append(("default_role", name)),
             delete=lambda name: calls.append(("role_delete", name)),
         ),
         sso_config=SimpleNamespace(set=sso_set),
@@ -1201,6 +1213,8 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
             )
         ],
         roles_to_create=[acl.RoleUpdate(name="public", policy_titles=["public"])],
+        default_role_name="public",
+        default_role_needs_update=True,
         roles_to_delete=["legacy_role"],
         policies_to_delete=["legacy_policy"],
         sso_config_text=acl.build_sso_config(
@@ -1235,6 +1249,7 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         ("bucket_add", "bucket-a", "bucket-a"),
         ("policy_create", "public"),
         ("role_create", "public", ["id-public"]),
+        ("default_role", "public"),
         ("sso_set", "public"),
         ("role_delete", "legacy_role"),
         ("policy_delete", "id-legacy-policy"),
@@ -1814,6 +1829,7 @@ roles:
   Analysts:
     config.policies: [SharedPolicy]
     buckets.read_write: [bucket-b]
+    config.default_role: true
   Observers: {}
 users:
   alice:
@@ -1852,6 +1868,7 @@ users:
     assert payload["roles"]["Analysts"] == {
         "buckets.read_write": ["bucket-b"],
         "config.policies": ["SharedPolicy"],
+        "config.default_role": True,
     }
     assert payload["users"]["alice"] == {
         "role": "Analysts",

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -88,6 +88,7 @@ policies:
   public:
     sso.groups: [Everyone]
     buckets.read: [bucket-a]
+    config.default_role: true
 roles: {}
 """)
 
@@ -169,6 +170,7 @@ def test_parse_acl_config_accepts_arbitrary_sso_claims(tmp_path: Path) -> None:
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
   sales:
     sso.department: [Sales]
 roles:
@@ -191,6 +193,7 @@ def test_parse_acl_config_accepts_user_policy_after_group_policy(
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
   exec:
     sso.users: [ernest@quilt.bio]
 roles: {}
@@ -268,7 +271,9 @@ roles:
         acl.parse_acl_config(config_path)
 
 
-def test_parse_acl_config_rejects_multiple_default_entries(tmp_path: Path) -> None:
+def test_parse_acl_config_rejects_missing_or_multiple_sso_defaults(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "acl.yml"
     config_path.write_text("""
 policies:
@@ -287,6 +292,28 @@ roles:
         ValueError, match="Only one ACL entry may set config.default_role"
     ):
         acl.parse_acl_config(config_path)
+
+    config_path.write_text("""
+policies:
+  public:
+    sso.groups: [Everyone]
+roles: {}
+""")
+
+    with pytest.raises(
+        ValueError, match="sso.<claim> selectors must set config.default_role"
+    ):
+        acl.parse_acl_config(config_path)
+
+    with pytest.raises(
+        ValueError, match="sso.<claim> selectors must set config.default_role"
+    ):
+        acl.build_sso_config(
+            acl.AclConfig(
+                policies=[acl.AclPolicy(name="public", sso={"groups": ["Everyone"]})],
+                roles={},
+            )
+        )
 
 
 def test_parse_acl_config_rejects_broken_policy_ladder(tmp_path: Path) -> None:
@@ -450,6 +477,7 @@ def test_build_sso_config_emits_arbitrary_sso_claim_schema(tmp_path: Path) -> No
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
   sales:
     sso.department: [Sales]
 roles:
@@ -675,6 +703,7 @@ def test_switching_synthesized_policy_to_reusable_deletes_old_role() -> None:
                 name="SharedPolicy",
                 sso={"groups": ["Everyone"]},
                 read=["shared"],
+                default_role=True,
             )
         ],
         roles={},
@@ -701,6 +730,7 @@ def test_static_role_without_sso_manages_role_without_sso_update(
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
 roles:
   password-users:
     config.policies: [public]
@@ -760,6 +790,7 @@ def test_policy_config_is_admin_marks_synthesized_role_admin(tmp_path: Path) -> 
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
     config.is_admin: true
 roles: {}
 """)
@@ -782,6 +813,7 @@ def test_policy_config_is_admin_false_vetoes_generated_role_admin_and_warns(
 policies:
   public:
     sso.groups: [Everyone]
+    config.default_role: true
     config.is_admin: true
   internal:
     sso.groups: [Employees]
@@ -869,7 +901,10 @@ def test_reordering_policies_changes_synthesized_role_names() -> None:
     first = acl.AclConfig(
         policies=[
             acl.AclPolicy(
-                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+                name="public",
+                sso={"groups": ["Everyone"]},
+                read=["bucket-a"],
+                default_role=True,
             ),
             acl.AclPolicy(
                 name="internal", sso={"groups": ["Everyone"]}, read=["bucket-b"]
@@ -880,7 +915,10 @@ def test_reordering_policies_changes_synthesized_role_names() -> None:
     second = acl.AclConfig(
         policies=[
             acl.AclPolicy(
-                name="internal", sso={"groups": ["Everyone"]}, read=["bucket-b"]
+                name="internal",
+                sso={"groups": ["Everyone"]},
+                read=["bucket-b"],
+                default_role=True,
             ),
             acl.AclPolicy(
                 name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
@@ -1059,7 +1097,10 @@ def test_changing_policy_groups_updates_sso_config() -> None:
     original = acl.AclConfig(
         policies=[
             acl.AclPolicy(
-                name="public", sso={"groups": ["Everyone"]}, read=["bucket-a"]
+                name="public",
+                sso={"groups": ["Everyone"]},
+                read=["bucket-a"],
+                default_role=True,
             )
         ],
         roles={},
@@ -1067,7 +1108,10 @@ def test_changing_policy_groups_updates_sso_config() -> None:
     updated = acl.AclConfig(
         policies=[
             acl.AclPolicy(
-                name="public", sso={"groups": ["Employees"]}, read=["bucket-a"]
+                name="public",
+                sso={"groups": ["Employees"]},
+                read=["bucket-a"],
+                default_role=True,
             )
         ],
         roles={},

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.9"
+version = "0.16.10"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- capture the operative settings-level default role in `catalog acl --yaml`
- allow selector-less static roles to declare `config.default_role: true`
- reconcile changed defaults through `roles.set_default`, warning instead of aborting when rejected
- continue emitting the same default into SSO configuration when mappings exist
- reject SSO selectors without a declared default before an invalid payload reaches the registry
- release as 0.16.10

Closes #75

## Stack
Depends on #74 and targets `70-acl-yaml-export-0.16.9`. Merge after the v0.16.9 layer. This is the final layer in the stack.

## Validation
- `uv run pytest tests/test_acl.py -q` (88 passed)
- `./poe test` (357 passed, 1 skipped)
- `./poe lint-check` (Black and mypy passed)
- pre-push hooks: Black, mypy, `poe test` (passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reconciles the operative settings-level default role through ACL capture and apply flows and releases the behavior as version 0.16.10.
- Allows selector-less static roles to declare `config.default_role: true`.
- Captures the settings default while avoiding destructive SSO rewrites when SSO and settings defaults disagree.
- Applies changed defaults through `roles.set_default` and reports rejected updates as warnings.
- Keeps generated SSO defaults aligned with the settings default whenever mappings exist.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The settings default is diffed and applied before dependent SSO and deletion operations, selector-less defaults no longer generate empty SSO documents, and capture avoids replaying inconsistent SSO state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds settings-level default-role diffing, capture, display, and application while preserving SSO configuration when defaults cannot be represented safely. |
| tests/test_acl.py | Covers selector-less defaults, SSO fallback generation, captured default-role metadata, and apply ordering. |
| README.md | Documents selector-less settings defaults and their relationship to generated SSO fallback configuration. |
| pyproject.toml | Bumps the package release version to 0.16.10 without changing dependencies. |
| quiltx/_version.py | Keeps the runtime version constant aligned with the release metadata. |
| uv.lock | Updates only the editable quiltx package version; third-party dependency versions and edges remain unchanged. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as catalog acl
    participant Diff as ACL reconciliation
    participant Roles as Roles API
    participant SSO as SSO configuration
    CLI->>Diff: Parse desired ACL and current state
    Diff->>Diff: Compare settings default role
    alt Default changed
        Diff->>Roles: set_default(role)
        alt Update rejected
            Roles-->>Diff: Error
            Diff-->>CLI: Emit warning and continue
        else Update accepted
            Roles-->>Diff: Success
        end
    end
    opt SSO mappings exist
        Diff->>SSO: Emit/update config with same default
    end
```

<sub>Reviews (1): Last reviewed commit: ["Reconcile settings default role (#75)"](https://github.com/quiltdata/quiltx/commit/7da91d76d7d8be410ff5ed7264988ad52d202f6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52075761)</sub>

<!-- /greptile_comment -->