### PR TITLE
Release 0.17.0: formal ACL release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-10
+
+### Added
+
+- Formal release of declarative catalog ACL management, including managed policies and roles, SSO mappings, user assignments, default-role reconciliation, and replayable YAML export.
+
 ## [0.16.10] - 2026-08-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.16.10"
+version = "0.17.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.16.10"
+__version__ = "0.17.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.16.10"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- bump quiltx from 0.16.10 to 0.17.0
- mark 0.17.0 as the formal declarative catalog ACL release
- synchronize the runtime version and lockfile

## Validation
- `uv lock --check`
- runtime version assertion
- release notes generation
- pre-commit: black, mypy
- pre-push: black, mypy, `poe test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR consistently advances QuiltX from 0.16.10 to 0.17.0 and documents the formal declarative catalog ACL release.
- Adds the 0.17.0 changelog entry.
- Synchronizes package, runtime, and lockfile versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with all release-version metadata synchronized.

The changes are limited to consistent release metadata and changelog updates, with no accepted functional, security, or build failures.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a 0.17.0 release entry describing the declarative catalog ACL functionality. |
| pyproject.toml | Updates the project package version from 0.16.10 to 0.17.0. |
| quiltx/_version.py | Synchronizes the runtime version constant with the project release version. |
| uv.lock | Synchronizes the editable QuiltX package version without changing dependency resolution. |

<sub>Reviews (1): Last reviewed commit: ["Release 0.17.0"](https://github.com/quiltdata/quiltx/commit/cd68eae5d46d231453cda3e17384110ac7969cd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52086568)</sub>

<!-- /greptile_comment -->