### PR TITLE
Release 0.17.1: secure catalog login for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-08-11
+
 ### Added
 
 - `quiltx catalog login` accepts passwords through `QUILTX_PASSWORD` or `--password-stdin`, and `--no-store` prints a minted key without accessing persistent credential storage for secure CI use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `quiltx catalog login` accepts passwords through `QUILTX_PASSWORD` or `--password-stdin`, and `--no-store` prints a minted key without accessing persistent credential storage for secure CI use.
+
 ## [0.17.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,11 +19,26 @@ uvx quiltx catalog default open.quiltdata.com
 uvx quiltx <tool> --help
 ```
 
-`quiltx catalog login` accepts either `--username` / `--password` (admin
-catalogs) or `--api-key qk_...` (paste an existing key, or the only path
-for SSO-only catalogs — see below). Both DNS names (`open.quiltdata.com`)
-and full URLs (`https://open.quiltdata.com/`) are accepted as `--catalog`
-arguments and normalized to the bare DNS.
+`quiltx catalog login` accepts either `--username` with a password supplied by
+an interactive prompt, `--password-stdin`, `QUILTX_PASSWORD`, or the legacy
+`--password` flag (admin catalogs), or `--api-key qk_...` (paste an existing
+key, or the only path for SSO-only catalogs — see below). Both DNS names
+(`open.quiltdata.com`) and full URLs (`https://open.quiltdata.com/`) are
+accepted as `--catalog` arguments and normalized to the bare DNS.
+
+For CI, use `--no-store` to avoid keyring and plaintext-file persistence. The
+command prints only the minted key to stdout, so it can be captured for reuse:
+
+```bash
+export QUILTX_API_KEY="$(
+  printf '%s\n' "$CATALOG_PASSWORD" |
+    uvx quiltx catalog login --catalog open.quiltdata.com \
+      --username you@example.com --password-stdin --no-store
+)"
+```
+
+Alternatively, set `QUILTX_PASSWORD` and omit `--password-stdin`. Status
+messages go to stderr; the API key is the only stdout output in no-store mode.
 
 ### Tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.17.0"
+version = "0.17.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/quiltx/tools/catalog/login.py
+++ b/quiltx/tools/catalog/login.py
@@ -1,17 +1,20 @@
-"""quiltx catalog login: mint a qk_... API key and store it.
+"""quiltx catalog login: mint a qk_... API key.
 
 Three paths (in priority order):
 
 1. ``--api-key qk_...`` — paste an existing key; validated, then stored.
-2. ``--username`` (and/or ``--password``, or interactive prompt with
-   ``--no-browser``) — POST to ``/api/login``, then exchange refresh_token
-   → access_token → GraphQL ``apiKeyCreate``. SSO-only catalogs reject
-   this path at ``/api/login``.
+2. ``--username`` with a password from ``--password``, ``--password-stdin``,
+   ``QUILTX_PASSWORD``, or an interactive prompt — POST to ``/api/login``, then
+   exchange refresh_token → access_token → GraphQL ``apiKeyCreate``. SSO-only
+   catalogs reject this path at ``/api/login``.
 3. **Default** (interactive TTY, no ``--username``/``--api-key``,
    ``--no-browser`` not set): browser flow. Open ``<registry>/login`` in
    the user's browser, prompt them to paste back the code shown on that
    page (the refresh_token), then mint the API key. Works with any auth
    backend the catalog supports — including SSO.
+
+Keys are stored by default. ``--no-store`` skips all credential persistence and
+prints the key to stdout for use by automation.
 """
 
 from __future__ import annotations
@@ -19,6 +22,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import getpass
+import os
 import socket
 import sys
 
@@ -72,7 +76,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Default: open the catalog login page in a browser, then paste "
             "back the code shown there (works with SSO). Use --username for "
             "username/password bootstrap, or --api-key to store an existing "
-            "key directly."
+            "key directly. Use --no-store for ephemeral automation."
         ),
     )
     add_catalog_args(parser, auth_required=True)
@@ -80,11 +84,25 @@ def build_parser() -> argparse.ArgumentParser:
         "--username",
         help="Catalog admin username for U/P -> API-key bootstrap.",
     )
-    parser.add_argument(
+    password_group = parser.add_mutually_exclusive_group()
+    password_group.add_argument(
         "--password",
         help=(
             "Catalog admin password. INSECURE: visible in `ps`/process listings; "
-            "prefer omitting it so you are prompted via getpass on TTY."
+            "prefer --password-stdin, QUILTX_PASSWORD, or an interactive prompt."
+        ),
+    )
+    password_group.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the catalog admin password from the first line of stdin.",
+    )
+    parser.add_argument(
+        "--no-store",
+        action="store_true",
+        help=(
+            "Do not persist the API key; print only the key to stdout for "
+            "capture as QUILTX_API_KEY."
         ),
     )
     parser.add_argument(
@@ -180,8 +198,9 @@ def mint_api_key(
     no_prompt: bool = False,
     key_name: str | None = None,
     expires_in_days: int = 365,
+    store: bool = True,
 ) -> MintedApiKey:
-    """Mint and store a catalog API key using browser SSO or U/P fallback."""
+    """Mint a catalog API key and optionally store it."""
     interactive = not no_prompt and sys.stdin.isatty()
     name = key_name or _default_key_name()
 
@@ -190,7 +209,8 @@ def mint_api_key(
         if resolved_password is None:
             if not interactive:
                 raise LoginUsageError(
-                    "--password is required when --username is set headlessly."
+                    "A password is required when --username is set headlessly. "
+                    "Use --password-stdin, QUILTX_PASSWORD, or --password."
                 )
             try:
                 resolved_password = getpass.getpass(f"Password for {username}@{dns}: ")
@@ -214,7 +234,7 @@ def mint_api_key(
     else:
         if not interactive:
             raise LoginUsageError(
-                "--username/--password or interactive TTY is required "
+                "--username with a password source or interactive TTY is required "
                 "(browser flow needs a TTY for paste-back)."
             )
         try:
@@ -241,7 +261,8 @@ def mint_api_key(
 
     secret = str(result["secret"])
     expires_at = _parse_expires_at(result.get("expires_at"))
-    credentials.store(dns, secret, name=name, expires_at=expires_at)
+    if store:
+        credentials.store(dns, secret, name=name, expires_at=expires_at)
     return MintedApiKey(secret=secret, name=name, expires_at=expires_at)
 
 
@@ -251,6 +272,41 @@ def print_stored_message(minted: MintedApiKey, dns: str) -> None:
         expiry_dt = _dt.datetime.fromtimestamp(minted.expires_at, _dt.timezone.utc)
         pretty_expiry = f" (expires {expiry_dt.strftime('%Y-%m-%d')})"
     print(f"Stored API key '{minted.name}' for {dns}{pretty_expiry}.", file=sys.stderr)
+
+
+def print_unstored_message(minted: MintedApiKey, dns: str) -> None:
+    """Report a successful ephemeral mint without writing the secret to stderr."""
+    pretty_expiry = ""
+    if minted.expires_at:
+        expiry_dt = _dt.datetime.fromtimestamp(minted.expires_at, _dt.timezone.utc)
+        pretty_expiry = f" (expires {expiry_dt.strftime('%Y-%m-%d')})"
+    print(
+        f"Minted API key '{minted.name}' for {dns}{pretty_expiry}; not stored.",
+        file=sys.stderr,
+    )
+
+
+def _resolve_password(args: argparse.Namespace) -> str | None:
+    """Resolve a password using CLI, stdin, then environment precedence."""
+    if args.username is None:
+        if args.password is not None or args.password_stdin:
+            raise LoginUsageError("--username is required with a password option.")
+        return None
+
+    if args.password is not None:
+        return args.password
+
+    if args.password_stdin:
+        try:
+            password = sys.stdin.readline()
+        except (KeyboardInterrupt, OSError) as exc:
+            raise LoginUsageError("Could not read the password from stdin.") from exc
+        password = password.removesuffix("\n").removesuffix("\r")
+        if not password:
+            raise LoginUsageError("No password was provided on stdin.")
+        return password
+
+    return os.environ.get("QUILTX_PASSWORD") or None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -272,9 +328,8 @@ def main(argv: list[str] | None = None) -> int:
 
     catalog_url = build_catalog_url(dns, insecure=args.insecure)
 
-    # Path 1: explicit --api-key (paste). Validate against the catalog
-    # before persisting so a bad paste does not silently land in the
-    # keyring and surface as a confusing auth error on the next command.
+    # Path 1: explicit --api-key (paste). Validate against the catalog before
+    # optionally persisting so a bad paste never lands in credential storage.
     if args.api_key:
         if not args.api_key.startswith("qk_"):
             print("Error: API key must start with the 'qk_' prefix.", file=sys.stderr)
@@ -286,26 +341,36 @@ def main(argv: list[str] | None = None) -> int:
                 f"Error: pasted API key was rejected by {dns}: {exc}", file=sys.stderr
             )
             return 1
-        credentials.store(dns, args.api_key, name=None, expires_at=None)
-        print(f"Stored API key for {dns}.")
+        if args.no_store:
+            print(args.api_key)
+            print(f"Validated API key for {dns}; not stored.", file=sys.stderr)
+        else:
+            credentials.store(dns, args.api_key, name=None, expires_at=None)
+            print(f"Stored API key for {dns}.")
         return 0
 
     try:
+        password = _resolve_password(args)
         minted = mint_api_key(
             catalog_url,
             dns,
             username=args.username,
-            password=args.password,
+            password=password,
             no_browser=args.no_browser,
             no_prompt=args.no_prompt,
             key_name=args.key_name,
             expires_in_days=args.expires_in_days,
+            store=not args.no_store,
         )
     except LoginError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2 if isinstance(exc, LoginUsageError) else 1
 
-    print_stored_message(minted, dns)
+    if args.no_store:
+        print(minted.secret)
+        print_unstored_message(minted, dns)
+    else:
+        print_stored_message(minted, dns)
     return 0
 
 

--- a/quiltx/tools/catalog/login.py
+++ b/quiltx/tools/catalog/login.py
@@ -297,6 +297,8 @@ def _resolve_password(args: argparse.Namespace) -> str | None:
         return args.password
 
     if args.password_stdin:
+        if sys.stdin.isatty():
+            print("Reading password from stdin...", file=sys.stderr)
         try:
             password = sys.stdin.readline()
         except (KeyboardInterrupt, OSError) as exc:
@@ -306,7 +308,12 @@ def _resolve_password(args: argparse.Namespace) -> str | None:
             raise LoginUsageError("No password was provided on stdin.")
         return password
 
-    return os.environ.get("QUILTX_PASSWORD") or None
+    if "QUILTX_PASSWORD" not in os.environ:
+        return None
+    password = os.environ["QUILTX_PASSWORD"]
+    if not password:
+        raise LoginUsageError("QUILTX_PASSWORD is set but empty.")
+    return password
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -327,6 +334,14 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     catalog_url = build_catalog_url(dns, insecure=args.insecure)
+
+    if args.api_key and (args.password is not None or args.password_stdin):
+        print(
+            "Error: --api-key cannot be combined with --password or "
+            "--password-stdin.",
+            file=sys.stderr,
+        )
+        return 2
 
     # Path 1: explicit --api-key (paste). Validate against the catalog before
     # optionally persisting so a bad paste never lands in credential storage.

--- a/tests/test_catalog_login.py
+++ b/tests/test_catalog_login.py
@@ -505,3 +505,80 @@ def test_login_api_key_no_store_validates_without_persisting(monkeypatch, capsys
     assert validated == [("https://nightly.quilttest.com", "qk_existing")]
     assert captured.out == "qk_existing\n"
     assert "not stored" in captured.err
+
+
+def test_login_rejects_api_key_with_password_option(monkeypatch, capsys):
+    monkeypatch.setattr(
+        quilt_auth,
+        "validate_api_key",
+        lambda *_a, **_kw: pytest.fail("conflicting inputs reached validation"),
+    )
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--api-key",
+            "qk_existing",
+            "--password-stdin",
+        ]
+    )
+
+    assert rc == 2
+    assert "cannot be combined" in capsys.readouterr().err
+
+
+def test_login_password_stdin_announces_interactive_read(monkeypatch, capsys):
+    from io import StringIO
+
+    stdin = StringIO("stdin-secret\n")
+    monkeypatch.setattr(stdin, "isatty", lambda: True)
+    monkeypatch.setattr("sys.stdin", stdin)
+    monkeypatch.setattr(
+        quilt_auth,
+        "bootstrap_api_key",
+        lambda catalog_url, **kwargs: {
+            "secret": "qk_stdin",
+            "name": kwargs["name"],
+            "expires_at": None,
+        },
+    )
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--password-stdin",
+            "--no-store",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "qk_stdin\n"
+    assert "Reading password from stdin" in captured.err
+
+
+def test_login_rejects_empty_env_password(monkeypatch, capsys):
+    monkeypatch.setenv("QUILTX_PASSWORD", "")
+    monkeypatch.setattr(
+        quilt_auth,
+        "bootstrap_api_key",
+        lambda *_a, **_kw: pytest.fail("empty password reached bootstrap"),
+    )
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--no-prompt",
+            "--no-store",
+        ]
+    )
+
+    assert rc == 2
+    assert "QUILTX_PASSWORD is set but empty" in capsys.readouterr().err

--- a/tests/test_catalog_login.py
+++ b/tests/test_catalog_login.py
@@ -373,3 +373,135 @@ def test_login_insecure_rejected_for_non_localhost(tmp_path, monkeypatch, capsys
     )
     assert rc == 2
     assert "localhost" in capsys.readouterr().err
+
+
+def test_login_uses_env_password_without_storing(monkeypatch, capsys):
+    """CI can mint a key without exposing argv or touching credential storage."""
+    bootstrap_calls: list[dict] = []
+
+    def fake_bootstrap(catalog_url, *, username, password, name, expires_in_days):
+        bootstrap_calls.append({"username": username, "password": password})
+        return {
+            "secret": "qk_ephemeral",
+            "name": name,
+            "expires_at": "2027-05-04T00:00:00Z",
+        }
+
+    monkeypatch.setenv("QUILTX_PASSWORD", "env-secret")
+    monkeypatch.setattr(quilt_auth, "bootstrap_api_key", fake_bootstrap)
+    monkeypatch.setattr(
+        credentials,
+        "store",
+        lambda *_a, **_kw: pytest.fail("--no-store touched credential storage"),
+    )
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--no-prompt",
+            "--no-store",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert bootstrap_calls == [{"username": "admin", "password": "env-secret"}]
+    assert captured.out == "qk_ephemeral\n"
+    assert "not stored" in captured.err
+    assert "qk_ephemeral" not in captured.err
+
+
+def test_login_password_stdin_overrides_environment(monkeypatch, capsys):
+    from io import StringIO
+
+    received_passwords: list[str] = []
+
+    def fake_bootstrap(catalog_url, *, username, password, name, expires_in_days):
+        received_passwords.append(password)
+        return {"secret": "qk_stdin", "name": name, "expires_at": None}
+
+    monkeypatch.setenv("QUILTX_PASSWORD", "env-secret")
+    monkeypatch.setattr("sys.stdin", StringIO("stdin secret\n"))
+    monkeypatch.setattr(quilt_auth, "bootstrap_api_key", fake_bootstrap)
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--password-stdin",
+            "--no-store",
+        ]
+    )
+
+    assert rc == 0
+    assert received_passwords == ["stdin secret"]
+    assert capsys.readouterr().out == "qk_stdin\n"
+
+
+def test_login_password_stdin_rejects_empty_input(monkeypatch, capsys):
+    from io import StringIO
+
+    monkeypatch.setattr("sys.stdin", StringIO(""))
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--username",
+            "admin",
+            "--password-stdin",
+            "--no-store",
+        ]
+    )
+
+    assert rc == 2
+    assert "No password was provided on stdin" in capsys.readouterr().err
+
+
+def test_login_password_option_requires_username(capsys):
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--password-stdin",
+            "--no-store",
+        ]
+    )
+
+    assert rc == 2
+    assert "--username is required" in capsys.readouterr().err
+
+
+def test_login_api_key_no_store_validates_without_persisting(monkeypatch, capsys):
+    validated: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        quilt_auth,
+        "validate_api_key",
+        lambda url, key: validated.append((url, key)),
+    )
+    monkeypatch.setattr(
+        credentials,
+        "store",
+        lambda *_a, **_kw: pytest.fail("--no-store touched credential storage"),
+    )
+
+    rc = login_cmd.main(
+        [
+            "--catalog",
+            "nightly.quilttest.com",
+            "--api-key",
+            "qk_existing",
+            "--no-store",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert validated == [("https://nightly.quilttest.com", "qk_existing")]
+    assert captured.out == "qk_existing\n"
+    assert "not stored" in captured.err

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- accept catalog passwords through `QUILTX_PASSWORD` or `--password-stdin`
- add `--no-store` to mint/validate without touching credential storage
- emit the ephemeral API key alone on stdout for `QUILTX_API_KEY` capture
- reject conflicting credential inputs and provide clear empty-env/interactive-stdin feedback
- document the secure CI workflow and cover password precedence/error paths

## Release
- bump `quiltx` from `0.17.0` to `0.17.1` in package and lock metadata
- publish the feature under the `0.17.1` changelog section dated 2026-08-11

## Validation
- `./poe lint-check`
- `./poe test` (365 passed, 1 skipped)
- `./poe release-notes`
- imported package reports `quiltx.__version__ == "0.17.1"`
- pre-push hooks (black, mypy, tests)

Closes #78