### PR TITLE
Fix ACL default-role reconciliation (id lookup + SSO-governed lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-08-11
+
+### Fixed
+
+- `quiltx catalog acl` sets the default role by role **id** instead of name: passing a name made quilt3 query `role(id: <name>)`, which UUID-keyed registries answer with an Internal Server Error, failing every apply that reconciled the default role.
+- Settings-level default-role reconciliation no longer fails on catalogs where the registry locks that setting (SSO config present and password signup disabled, e.g. nightly): when the SSO config itself names the same default role, the conflict is reported as governed-by-SSO-config and the apply succeeds; a conflicting SSO config still warns.
+
 ## [0.17.1] - 2026-08-11
 
 ### Added

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import yaml
 
+from quilt3.admin import exceptions as quilt3_admin_exceptions
 from quilt3.admin.types import Permission
 from quiltx import stack as stack_lib
 
@@ -1288,6 +1289,26 @@ def _apply_user_updates(
     return warnings
 
 
+def _sso_config_declares_default(
+    diff: AclDiff, current: CurrentState, role_name: str
+) -> bool:
+    """True if the effective SSO config carries role_name as its default.
+
+    The registry locks the settings-level default role while an SSO config
+    exists and password signup is disabled (SsoConfigConflict); in that state
+    the SSO config's own ``default_role`` is what governs, so a conflict is
+    only a problem when that config names a different role.
+    """
+    text = diff.sso_config_text if diff.sso_needs_update else current.sso_config_text
+    if not text:
+        return False
+    try:
+        payload = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return False
+    return isinstance(payload, dict) and payload.get("default_role") == role_name
+
+
 def apply_acl(
     stack: stack_lib.Catalog,
     diff: AclDiff,
@@ -1500,7 +1521,41 @@ def apply_acl(
         else:
             _print_apply_step(f"set default role {default_role_name}", verbose=verbose)
             try:
-                stack.admin.roles.set_default(default_role_name)
+                # Resolve the id ourselves: set_default(name) falls back to a
+                # role(id: <name>) lookup, which registries answer with a 500
+                # (UUID primary-key column). Re-list so roles created earlier
+                # in this apply are visible.
+                resolved_role = next(
+                    (
+                        r
+                        for r in stack.admin.roles.list()
+                        if r.name == default_role_name
+                    ),
+                    None,
+                )
+                stack.admin.roles.set_default(
+                    default_role_name if resolved_role is None else resolved_role.id
+                )
+            except quilt3_admin_exceptions.RoleSsoConfigConflictError:
+                if _sso_config_declares_default(diff, current, default_role_name):
+                    print(
+                        f"  = default role {default_role_name} is governed by the "
+                        "SSO config; settings-level default left unchanged"
+                    )
+                else:
+                    detail = (
+                        "the registry locks the settings-level default role while "
+                        "an SSO config exists and password signup is disabled, and "
+                        f"the SSO config does not name '{default_role_name}' as its "
+                        "default"
+                    )
+                    warnings.append(
+                        f"Default role '{default_role_name}' could not be updated: {detail}"
+                    )
+                    print(
+                        f"  ! default role {default_role_name}: {detail}",
+                        file=sys.stderr,
+                    )
             except Exception as exc:
                 detail = format_exception(exc)
                 warnings.append(

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 import yaml
 
+from quilt3.admin import exceptions as quilt3_admin_exceptions
 from quilt3.admin.types import BucketPermissionLevel, Permission
 
 from quiltx import acl
@@ -1225,9 +1226,13 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
             roles=[],
         )
 
+    created_roles: list[FakeRole] = []
+
     def role_create(name: str, policies: list[str]) -> FakeRole:
         calls.append(("role_create", name, list(policies)))
-        return FakeRole(id=f"id-{name}", name=name, policies=[], permissions=[])
+        role = FakeRole(id=f"id-{name}", name=name, policies=[], permissions=[])
+        created_roles.append(role)
+        return role
 
     def sso_set(text: str) -> SimpleNamespace:
         calls.append(("sso_set", yaml.safe_load(text)["default_role"]))
@@ -1243,7 +1248,8 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         roles=SimpleNamespace(
             create_managed=role_create,
             update_managed=lambda *args, **kwargs: None,
-            set_default=lambda name: calls.append(("default_role", name)),
+            list=lambda: [*created_roles],
+            set_default=lambda ref: calls.append(("default_role", ref)),
             delete=lambda name: calls.append(("role_delete", name)),
         ),
         sso_config=SimpleNamespace(set=sso_set),
@@ -1293,7 +1299,7 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
         ("bucket_add", "bucket-a", "bucket-a"),
         ("policy_create", "public"),
         ("role_create", "public", ["id-public"]),
-        ("default_role", "public"),
+        ("default_role", "id-public"),
         ("sso_set", "public"),
         ("role_delete", "legacy_role"),
         ("policy_delete", "id-legacy-policy"),
@@ -2403,3 +2409,118 @@ def test_acl_tool_dry_run_no_preflight_lists_skipped_steps(monkeypatch, capsys) 
     assert "GraphQL only" in out
     assert "GetBucketPolicy" in out
     assert "SNS topic" in out
+
+
+def _default_role_diff(name: str = "demo") -> acl.AclDiff:
+    return acl.AclDiff(default_role_name=name, default_role_needs_update=True)
+
+
+def _demo_role() -> FakeRole:
+    return FakeRole(
+        id="11111111-2222-3333-4444-555555555555",
+        name="demo",
+        policies=None,
+        permissions=[],
+    )
+
+
+def test_apply_acl_sets_default_role_by_id() -> None:
+    """set_default must receive the role id: the name falls back to a
+    role(id: <name>) lookup that UUID-keyed registries answer with a 500."""
+    set_default_calls: list[str] = []
+    stack = _fake_stack(
+        roles=SimpleNamespace(
+            list=lambda: [_demo_role()],
+            set_default=lambda ref: set_default_calls.append(ref),
+        )
+    )
+
+    warnings = acl.apply_acl(stack, _default_role_diff(), _empty_current_state())
+
+    assert warnings == []
+    assert set_default_calls == ["11111111-2222-3333-4444-555555555555"]
+
+
+def test_apply_acl_default_role_sso_conflict_is_ok_when_sso_config_governs(
+    capsys,
+) -> None:
+    """SsoConfigConflict is a no-op when the SSO config names the same default
+    (registry locks the settings-level default while SSO governs it)."""
+
+    def conflict(_ref: str) -> None:
+        raise quilt3_admin_exceptions.RoleSsoConfigConflictError(None)
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(list=lambda: [_demo_role()], set_default=conflict)
+    )
+    current = replace(
+        _empty_current_state(),
+        sso_config_text="version: '1.0'\ndefault_role: demo\n",
+    )
+
+    warnings = acl.apply_acl(stack, _default_role_diff(), current)
+
+    captured = capsys.readouterr()
+    assert warnings == []
+    assert "governed by the SSO config" in captured.out
+    assert "! default role" not in captured.err
+
+
+def test_apply_acl_default_role_sso_conflict_warns_on_foreign_sso_config() -> None:
+    """A conflict from an SSO config that names a different default is real."""
+
+    def conflict(_ref: str) -> None:
+        raise quilt3_admin_exceptions.RoleSsoConfigConflictError(None)
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(list=lambda: [_demo_role()], set_default=conflict)
+    )
+    current = replace(
+        _empty_current_state(),
+        sso_config_text="version: '1.0'\ndefault_role: other\n",
+    )
+
+    warnings = acl.apply_acl(stack, _default_role_diff(), current)
+
+    assert any("could not be updated" in warning for warning in warnings)
+    assert any("does not name 'demo'" in warning for warning in warnings)
+
+
+def test_apply_acl_default_role_conflict_prefers_pending_sso_text(capsys) -> None:
+    """When this apply is also writing the SSO config, judge the conflict by
+    the pending text, not the stale current one."""
+
+    def conflict(_ref: str) -> None:
+        raise quilt3_admin_exceptions.RoleSsoConfigConflictError(None)
+
+    stack = _fake_stack(
+        roles=SimpleNamespace(list=lambda: [_demo_role()], set_default=conflict),
+        sso_config=SimpleNamespace(set=lambda text: SimpleNamespace(text=text)),
+    )
+    diff = _default_role_diff()
+    diff.sso_config_text = "version: '1.0'\ndefault_role: demo\n"
+    diff.sso_needs_update = True
+    current = replace(
+        _empty_current_state(),
+        sso_config_text="version: '1.0'\ndefault_role: other\n",
+    )
+
+    warnings = acl.apply_acl(stack, diff, current)
+
+    assert not [w for w in warnings if "Default role" in w]
+    assert "governed by the SSO config" in capsys.readouterr().out
+
+
+def test_apply_acl_default_role_falls_back_to_name_when_unlisted() -> None:
+    """A role missing from the fresh list still gets attempted by name."""
+    set_default_calls: list[str] = []
+    stack = _fake_stack(
+        roles=SimpleNamespace(
+            list=lambda: [],
+            set_default=lambda ref: set_default_calls.append(ref),
+        )
+    )
+
+    acl.apply_acl(stack, _default_role_diff(), _empty_current_state())
+
+    assert set_default_calls == ["demo"]


### PR DESCRIPTION
## Problem

Every nightly deploy since quiltx 0.17.0 fails at `quiltx catalog acl` with:

```
! default role demo: Internal Server Error (path: ['role'])
```

Root cause chain (verified against enterprise registry and quilt3 source):

1. `apply_acl` calls `roles.set_default("demo")` with a **name**. quilt3's `_resolve_role` tries id-lookup first: `role(id: "demo")`. The registry's `query_role` does `models.Role.query.get(id)` against a **Postgres UUID primary key**, so a non-UUID string raises an unhandled `DataError` → GraphQL 500 at path `['role']`.
2. Even with the id fixed, the mutation can never succeed on nightly-shaped stacks: `roleSetDefault` returns `SsoConfigConflict` whenever an SSO config exists and password signup is disabled (`is_default_role_setting_disabled`). Nightly has both, permanently. The SSO config that quiltx itself writes already carries `default_role: demo`, so the desired default *is* in force for SSO users — the settings-level setting is locked by design, not drifted.

## Fix

1. Resolve the role id from a fresh `roles.list()` (visible to roles created earlier in the same apply) and pass the **id** to `set_default`; fall back to the name only if unlisted.
2. Catch `RoleSsoConfigConflictError`: when the effective SSO config (the pending text if this apply is also writing it, else the current one) names the same default role, report `= default role ... governed by the SSO config` and continue cleanly. An SSO config naming a *different* default still warns (and fails `--require`d applies).

## Testing

- 5 new tests: id is passed to `set_default`; conflict-with-matching-SSO-default is clean; conflict-with-foreign-SSO-default warns; pending SSO text wins over stale current; name fallback when unlisted.
- Updated the operation-ordering test's fake to expose `roles.list()` and assert the id is what reaches `set_default`.
- `./poe test`: 370 passed, 1 skipped. `./poe lint-check`: clean.

## Follow-ups (not this PR)

- Registry: `query_role` should return null (or a typed error) on a non-UUID id instead of 500ing.
- quilt3: `_get_by_id` should guard non-UUID input before querying.

Unblocks quiltdata/deployment#2414 (nightly requires ACL convergence; deploys are red on this). Version bumped to 0.17.2 for release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes default-role reconciliation by resolving role names to IDs and recognizes matching defaults governed by locked SSO configuration.
- Re-lists roles before setting the default and passes the resolved role ID.
- Handles matching and conflicting SSO-governed defaults separately.
- Adds focused tests for ID resolution, SSO conflicts, pending configuration, fallback behavior, and operation ordering.
- Bumps the package version to 0.17.2 and documents the fixes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed reconciliation path uses role IDs when available, distinguishes matching from conflicting SSO-governed defaults, and its failure paths continue to surface warnings rather than silently reporting a successful apply.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Resolves default roles by ID and handles registry SSO-lock conflicts according to the effective SSO default. |
| tests/test_acl.py | Adds coverage for ID-based reconciliation, matching and mismatched SSO defaults, pending SSO text, fallback behavior, and operation ordering. |
| quiltx/_version.py | Bumps the package version from 0.17.1 to 0.17.2. |
| CHANGELOG.md | Documents the default-role ID lookup and SSO-governed reconciliation fixes in the 0.17.2 release. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Default role needs update] --> B[List roles]
    B --> C{Matching role found?}
    C -->|Yes| D[Call set_default with role ID]
    C -->|No| E[Call set_default with role name]
    D --> F{SSO conflict?}
    E --> F
    F -->|No| G[Report default updated]
    F -->|Yes| H{Effective SSO config names desired role?}
    H -->|Yes| I[Report default governed by SSO]
    H -->|No| J[Add reconciliation warning]
```

<sub>Reviews (1): Last reviewed commit: ["Fix default-role reconciliation: set by ..."](https://github.com/quiltdata/quiltx/commit/9d2fbf9ae57ee56354f41d3fcf013e95ef654853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52321103)</sub>

<!-- /greptile_comment -->