### PR TITLE
Release 0.17.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.17.1"
+version = "0.17.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary

- bump the project version in `pyproject.toml` to `0.17.2`
- align the root package entry in `uv.lock`
- allow the main-branch publish workflow to create `v0.17.2`

PR #80 updated `quiltx/_version.py` and `CHANGELOG.md`, but left `pyproject.toml` at `0.17.1`. Because the publish workflow reads `pyproject.toml`, it detected the existing `v0.17.1` tag and skipped publishing.

## Validation

- `uv lock --check`
- `uv build`
- pre-push hooks (`black`, `mypy`, `poe test`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the package metadata from version 0.17.1 to 0.17.2 so the publish workflow can create the intended release tag.
- Bumps the project version in `pyproject.toml`.
- Synchronizes the editable root package entry in `uv.lock`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it consistently updates only the project’s release version metadata.

The project manifest and lockfile root entry both declare version 0.17.2, with no dependency-resolution or runtime behavior changes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Bumps the declared project version to 0.17.2, matching the intended release. |
| uv.lock | Synchronizes the root editable package version with `pyproject.toml`. |

<sub>Reviews (1): Last reviewed commit: ["Release 0.17.2"](https://github.com/quiltdata/quiltx/commit/a7856a159b96da08dec79c47ed7ee566cf0c349d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52427087)</sub>

<!-- /greptile_comment -->