### PR TITLE
Add concise ACL YAML user export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.3] - 2026-08-12
+
+### Added
+
+- `quiltx catalog acl --yaml --omit-default-users` emits a concise declarative ACL export by excluding non-admin users assigned only to the catalog default role.
+
 ## [0.17.2] - 2026-08-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.17.2"
+version = "0.17.3"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -750,7 +750,11 @@ def current_state_as_dict(
 
 
 def current_state_as_acl_yaml(
-    current: CurrentState, *, catalog: str, captured_on: str
+    current: CurrentState,
+    *,
+    catalog: str,
+    captured_on: str,
+    omit_default_users: bool = False,
 ) -> str:
     """Return current state as replayable ACL YAML with capture metadata.
 
@@ -866,15 +870,23 @@ def current_state_as_acl_yaml(
         if not primary:
             notes.append(f"user {user.name!r} has no primary role")
             continue
-        user_entry: dict[str, Any] = {"role": primary}
         extras = [
             role.name
             for role in (getattr(user, "extra_roles", None) or [])
             if role is not None
         ]
+        is_admin = bool(getattr(user, "is_admin", False))
+        if (
+            omit_default_users
+            and primary == current.default_role_name
+            and not extras
+            and not is_admin
+        ):
+            continue
+        user_entry: dict[str, Any] = {"role": primary}
         if extras:
             user_entry["extra_roles"] = extras
-        user_entry["admin"] = bool(getattr(user, "is_admin", False))
+        user_entry["admin"] = is_admin
         user_entries[user.name] = user_entry
 
     for name in sorted(current.unmanaged_roles):

--- a/quiltx/tools/catalog/acl.py
+++ b/quiltx/tools/catalog/acl.py
@@ -66,12 +66,22 @@ def build_parser() -> argparse.ArgumentParser:
             "Only valid when config_file is omitted."
         ),
     )
+    parser.add_argument(
+        "--omit-default-users",
+        action="store_true",
+        help=(
+            "Emit a concise declarative YAML export by omitting users assigned "
+            "only to the default role. Requires --yaml and no config_file."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.omit_default_users and not args.yaml:
+        parser.error("--omit-default-users requires --yaml")
     if (args.json or args.yaml) and args.config_file is not None:
         output_flag = "--json" if args.json else "--yaml"
         parser.error(f"{output_flag} is only valid when config_file is omitted")
@@ -113,6 +123,7 @@ def _run(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
                         current,
                         catalog=stack.catalog_name,
                         captured_on=date.today().isoformat(),
+                        omit_default_users=args.omit_default_users,
                     ),
                     end="",
                 )

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1930,6 +1930,79 @@ users:
     assert diff.notices == []
 
 
+def test_current_state_yaml_can_omit_only_default_role_users(tmp_path: Path) -> None:
+    source = tmp_path / "source.yml"
+    source.write_text("""
+policies: {}
+roles:
+  Default:
+    config.default_role: true
+  Other: {}
+users: {}
+""")
+    current = _current_state_for_config(acl.parse_acl_config(source))
+    default_role = current.managed_roles["Default"]
+    other_role = current.managed_roles["Other"]
+    current.users.extend(
+        [
+            SimpleNamespace(
+                name="default-only",
+                role=default_role,
+                extra_roles=[],
+                is_admin=False,
+            ),
+            SimpleNamespace(
+                name="default-admin",
+                role=default_role,
+                extra_roles=[],
+                is_admin=True,
+            ),
+            SimpleNamespace(
+                name="default-extra",
+                role=default_role,
+                extra_roles=[other_role],
+                is_admin=False,
+            ),
+            SimpleNamespace(
+                name="other-only",
+                role=other_role,
+                extra_roles=[],
+                is_admin=False,
+            ),
+        ]
+    )
+
+    full = yaml.safe_load(
+        acl.current_state_as_acl_yaml(
+            current, catalog="catalog", captured_on="2026-08-12"
+        )
+    )
+    concise = yaml.safe_load(
+        acl.current_state_as_acl_yaml(
+            current,
+            catalog="catalog",
+            captured_on="2026-08-12",
+            omit_default_users=True,
+        )
+    )
+
+    assert set(full["users"]) == {
+        "default-only",
+        "default-admin",
+        "default-extra",
+        "other-only",
+    }
+    assert concise["users"] == {
+        "default-admin": {"role": "Default", "admin": True},
+        "default-extra": {
+            "role": "Default",
+            "extra_roles": ["Other"],
+            "admin": False,
+        },
+        "other-only": {"role": "Other", "admin": False},
+    }
+
+
 def test_current_state_yaml_round_trips_representable_sso(tmp_path: Path) -> None:
     source = tmp_path / "source.yml"
     source.write_text("""
@@ -1981,6 +2054,22 @@ def test_acl_tool_yaml_exports_valid_config_without_header(monkeypatch, capsys) 
 def test_acl_tool_yaml_rejects_config_file(capsys) -> None:
     with pytest.raises(SystemExit) as exc_info:
         acl_tool.main(["--yaml", "config.yml"])
+
+    assert exc_info.value.code == 2
+    assert "--yaml is only valid when config_file is omitted" in capsys.readouterr().err
+
+
+def test_acl_tool_omit_default_users_requires_yaml(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        acl_tool.main(["--omit-default-users"])
+
+    assert exc_info.value.code == 2
+    assert "--omit-default-users requires --yaml" in capsys.readouterr().err
+
+
+def test_acl_tool_omit_default_users_rejects_config_file(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        acl_tool.main(["--yaml", "--omit-default-users", "config.yml"])
 
     assert exc_info.value.code == 2
     assert "--yaml is only valid when config_file is omitted" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.17.2"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- add `quiltx catalog acl --yaml --omit-default-users`
- omit only non-admin users whose sole assignment is the catalog default role
- preserve full-fidelity behavior for ordinary `--yaml` exports
- reject the option without `--yaml` or when a config file is supplied
- bump the package to 0.17.3 and add the dated changelog entry

## Validation
- `./poe lint-check`
- `./poe test` (370 passed, 1 skipped)
- pre-commit and pre-push hooks

Closes #82

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional concise ACL YAML export that omits non-admin users assigned solely to the catalog default role while preserving ordinary YAML exports.
- Adds and validates the `--omit-default-users` CLI option.
- Filters eligible users during ACL YAML serialization.
- Bumps the package and lockfile version to 0.17.3 and records the release in the changelog.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only non-blocking missing regression coverage for the new omission and CLI-validation boundaries.

The omission predicate preserves administrators and users with extra roles, replay does not remove omitted users, and no dependency exposure changes; targeted tests should still lock in these new behaviors.

**Files Needing Attention:** quiltx/acl.py, quiltx/tools/catalog/acl.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds the concise-export predicate correctly, but the new boundary behavior lacks targeted regression coverage. |
| quiltx/tools/catalog/acl.py | Adds the CLI flag, rejects use without YAML, and forwards it to serialization; invalid combinations are not covered by new tests. |
| pyproject.toml | Updates the project version consistently to 0.17.3. |
| quiltx/_version.py | Keeps the runtime version aligned with project metadata. |
| uv.lock | Updates only the editable local package version; third-party dependencies are unchanged. |
| CHANGELOG.md | Documents the new concise ACL YAML export in the 0.17.3 release entry. |

<sub>Reviews (1): Last reviewed commit: ["Add concise ACL YAML user export"](https://github.com/quiltdata/quiltx/commit/35cabf83e0a585747dd99f3891df1278ad8caa29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52784921)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->