### PR TITLE
Add AWS-only bucket preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `quiltx bucket prepare` configures cross-account S3 access, SNS policy, and safe object notifications using bucket-owner AWS credentials only, with exact dry-run documents and a minimal JSON handoff for a separate catalog operator.
 
+### Changed
+
+- `quiltx bucket add` and ACL bucket reconciliation now run through the same preparation planner/applicator as `bucket prepare`, gaining its conflict detection, stale-destination validation (SNS, SQS, and Lambda), and per-write drift rechecks; `--force` re-registration only removes the catalog row after AWS preparation succeeds.
+
 ## [0.17.3] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `quiltx bucket prepare` configures cross-account S3 access, SNS policy, and safe object notifications using bucket-owner AWS credentials only, with exact dry-run documents and a minimal JSON handoff for a separate catalog operator.
+- `quiltx bucket prepare --catalog DNS` derives the control account ID from cached stack metadata or, failing that, by logging in as a regular catalog user (no admin role) and reading the account behind the catalog-minted credentials.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-12
+
+### Added
+
+- `quiltx bucket prepare` configures cross-account S3 access, SNS policy, and safe object notifications using bucket-owner AWS credentials only, with exact dry-run documents and a minimal JSON handoff for a separate catalog operator.
+
 ## [0.17.3] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ and stack APIs.
 AWS profile to probe the bucket, update the bucket policy, configure SNS, and
 wire S3 notifications before registering the bucket with the catalog.
 
+When the bucket owner and catalog operator are different people, split setup
+into two credential-isolated steps. The bucket owner needs AWS credentials only
+(no catalog configuration or API key):
+
+```bash
+uvx quiltx bucket prepare my-bucket \
+  --control-account-id 123456789012 \
+  --json --yes > bucket-handoff.json
+```
+
+Use repeatable `--principal arn:aws:iam::123456789012:role/...` options to grant
+specific Quilt roles instead of the control-account root. `--dry-run` prints the
+exact final S3 policy, SNS policy, and notification configuration without any
+writes. Preparation preserves unrelated policies and compatible notifications,
+and stops with actionable details when an object-event notification overlaps.
+The JSON handoff contains only the bucket, region, owning account, effective
+principals, and SNS topic ARN; it contains no credentials.
+
+The catalog operator then needs catalog-admin credentials only, not access to
+the bucket owner's AWS account:
+
+```bash
+uvx quiltx bucket add my-bucket --catalog example.quiltdata.com --no-preflight
+```
+
 Use `--no-preflight` when the catalog stack can already access the bucket but
 your local AWS identity cannot or should not modify it, such as public AWS Open
 Data buckets or buckets already plumbed by Quilt infrastructure:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ uvx quiltx bucket prepare my-bucket \
 ```
 
 Use repeatable `--principal arn:aws:iam::123456789012:role/...` options to grant
-specific Quilt roles instead of the control-account root. `--dry-run` prints the
+specific Quilt roles instead of the control-account root. If you don't know the
+control account ID, pass `--catalog example.quiltdata.com` instead: any
+logged-in catalog user (no admin role needed) can derive it from the catalog's
+minted credentials. `--dry-run` prints the
 exact final S3 policy, SNS policy, and notification configuration without any
 writes. Preparation preserves unrelated policies and compatible notifications,
 and stops with actionable details when an object-event notification overlaps.

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -26,8 +26,12 @@ topic ARN.
 
 `quiltx bucket prepare` calls that same planner/applicator but is AWS-only and must remain outside `catalog_command`.
 It reads and converges the final bucket policy, SNS policy, and notification
-document without loading catalog configuration, authenticating, or calling
-Quilt admin APIs. The bucket owner can emit a minimal `--json --yes` handoff;
+document without loading catalog configuration or calling Quilt admin APIs.
+An optional `--catalog DNS` derives the control account ID when
+`--control-account-id`/`--principal` are omitted: cached stack metadata wins;
+otherwise it logs in as a regular catalog user (no admin role) and asks STS
+which account minted the catalog credentials. That is the only catalog touch
+prepare is allowed. The bucket owner can emit a minimal `--json --yes` handoff;
 the catalog operator completes registration separately with
 `quiltx bucket add BUCKET --catalog DNS --no-preflight`. `--dry-run` performs
 AWS reads but no writes and prints the exact three final documents. Notification

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -18,12 +18,13 @@ print(stack["StackName"])
 
 ## Bucket registration paths
 
-Bucket registration has three explicit paths. The default bucket-owner path uses
-local AWS credentials to probe S3, merge the Quilt bucket-policy statement,
-configure SNS, configure bucket notifications, and then call GraphQL
-`bucketAdd` with the SNS topic ARN.
+Bucket registration has three explicit paths. The default bucket-owner path and
+ACL reconciliation both call the same AWS preparation planner/applicator to
+probe S3, merge the Quilt bucket-policy statement, configure SNS, and configure
+bucket notifications; they then call GraphQL `bucketAdd` with the planned SNS
+topic ARN.
 
-`quiltx bucket prepare` is AWS-only and must remain outside `catalog_command`.
+`quiltx bucket prepare` calls that same planner/applicator but is AWS-only and must remain outside `catalog_command`.
 It reads and converges the final bucket policy, SNS policy, and notification
 document without loading catalog configuration, authenticating, or calling
 Quilt admin APIs. The bucket owner can emit a minimal `--json --yes` handoff;

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -18,10 +18,20 @@ print(stack["StackName"])
 
 ## Bucket registration paths
 
-Bucket registration has two explicit paths. The default bucket-owner path uses
+Bucket registration has three explicit paths. The default bucket-owner path uses
 local AWS credentials to probe S3, merge the Quilt bucket-policy statement,
 configure SNS, configure bucket notifications, and then call GraphQL
 `bucketAdd` with the SNS topic ARN.
+
+`quiltx bucket prepare` is AWS-only and must remain outside `catalog_command`.
+It reads and converges the final bucket policy, SNS policy, and notification
+document without loading catalog configuration, authenticating, or calling
+Quilt admin APIs. The bucket owner can emit a minimal `--json --yes` handoff;
+the catalog operator completes registration separately with
+`quiltx bucket add BUCKET --catalog DNS --no-preflight`. `--dry-run` performs
+AWS reads but no writes and prints the exact three final documents. Notification
+overlap must fail before any write so unrelated Topic, Queue, Lambda, and
+EventBridge configuration is never replaced.
 
 The `--no-preflight` path is GraphQL-only. It skips local S3/SNS calls and
 submits `bucketAdd` without an SNS ARN so the catalog stack probes the bucket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.17.3"
+version = "0.18.0"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.17.3"
+__version__ = "0.18.0"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -1143,30 +1143,29 @@ def _register_bucket_with_retry(
         raise RuntimeError(f"no accessible AWS profile for bucket {bucket}")
 
     sns_client = session.client("sns", region_name=region)
+    sqs_client = session.client("sqs", region_name=region)
+    lambda_client = session.client("lambda", region_name=region)
     data_account_id = str(session.client("sts").get_caller_identity()["Account"])
 
-    existing_policy = bucket_lib.get_bucket_policy(bucket, s3_client=s3_client)
-    statement = bucket_lib.build_quilt_policy_statement(bucket, control_account_id)
-    merged = bucket_lib.merge_bucket_policy(existing_policy, statement)
-    bucket_lib.apply_bucket_policy(bucket, merged, s3_client=s3_client)
-
-    sns_topic_arn = bucket_lib.get_bucket_notification_sns(bucket, s3_client=s3_client)
-    if sns_topic_arn is None:
-        sns_topic_arn = bucket_lib.ensure_sns_topic(
-            bucket, region, sns_client=sns_client
-        )
-    bucket_lib.configure_sns_topic_policy(
+    plan = bucket_lib.build_bucket_preparation_plan(
         bucket,
-        sns_topic_arn,
+        region,
         data_account_id,
-        f"arn:aws:iam::{control_account_id}:root",
+        control_account_id=control_account_id,
+        s3_client=s3_client,
         sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
     )
-    bucket_lib.configure_bucket_notifications(
-        bucket, sns_topic_arn, s3_client=s3_client
+    bucket_lib.apply_bucket_preparation(
+        plan,
+        s3_client=s3_client,
+        sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
     )
     stack.admin.buckets.add(
-        name=bucket, title=bucket, sns_notification_arn=sns_topic_arn
+        name=bucket, title=bucket, sns_notification_arn=plan.sns_topic_arn
     )
 
 
@@ -1353,7 +1352,10 @@ def apply_acl(
 
                 bucket_lib.add_bucket_without_preflight(stack, bucket, title=bucket)
             elif control_account_id is None:
-                stack.admin.buckets.add(bucket, bucket)
+                raise ValueError(
+                    "control account metadata is required for AWS preparation; "
+                    "refresh the catalog stack cache or use --no-preflight explicitly"
+                )
             else:
                 _register_bucket_with_retry(
                     stack,

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
@@ -79,7 +80,7 @@ def resolve_bucket_session(
         return None, None, "", profile
 
     if assume_yes:
-        print(f"Retrying with profile {match}.")
+        print(f"Retrying with profile {match}.", file=err)
     else:
         response = ask(f"Try profile {match} instead? [y/N]: ").strip().lower()
         if response not in {"y", "yes"}:
@@ -118,6 +119,38 @@ QUILT_POLICY_ACTIONS = [
 ]
 
 BUCKET_NOTIFICATION_EVENTS = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+
+
+class NotificationConflictError(ValueError):
+    """Raised when Quilt notifications would overlap an existing destination."""
+
+
+@dataclass(frozen=True)
+class BucketPreparationPlan:
+    """Exact AWS documents and secure handoff produced by bucket preparation."""
+
+    bucket: str
+    region: str
+    owning_account: str
+    principals: tuple[str, ...]
+    sns_topic_arn: str
+    bucket_policy: dict[str, Any]
+    sns_policy: dict[str, Any]
+    notification_configuration: dict[str, Any]
+    topic_exists: bool
+    bucket_policy_changed: bool
+    sns_policy_changed: bool
+    notification_configuration_changed: bool
+
+    def handoff(self) -> dict[str, Any]:
+        """Return the minimal non-secret handoff for the catalog operator."""
+        return {
+            "bucket": self.bucket,
+            "region": self.region,
+            "owning_account": self.owning_account,
+            "principals": list(self.principals),
+            "sns_topic_arn": self.sns_topic_arn,
+        }
 
 
 def get_bucket_policy(bucket: str, s3_client: Any = None) -> dict[str, Any] | None:
@@ -226,14 +259,10 @@ def ensure_sns_topic(bucket: str, region: str, sns_client: Any = None) -> str:
     return str(response["TopicArn"])
 
 
-def configure_sns_topic_policy(
-    bucket: str,
-    sns_topic_arn: str,
-    data_account_id: str,
-    control_principal_arn: str | Sequence[str],
-    sns_client: Any = None,
-) -> None:
-    """Ensure the SNS topic policy allows S3 publish and Quilt subscribe access."""
+def get_sns_topic_policy(
+    sns_topic_arn: str, sns_client: Any = None
+) -> dict[str, Any] | None:
+    """Return the parsed SNS topic policy, or None when the topic has none."""
     if sns_client is None:
         import boto3
 
@@ -242,31 +271,356 @@ def configure_sns_topic_policy(
     attributes = sns_client.get_topic_attributes(TopicArn=sns_topic_arn).get(
         "Attributes", {}
     )
-    existing_policy = _parse_json_document(attributes.get("Policy"))
+    return _parse_json_document(attributes.get("Policy"))
+
+
+def _build_default_sns_owner_policy(
+    sns_topic_arn: str, data_account_id: str
+) -> dict[str, Any]:
+    """Return SNS's canonical owner-access policy for a topic."""
+    return {
+        "Version": "2008-10-17",
+        "Id": "__default_policy_ID",
+        "Statement": [
+            {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": [
+                    "SNS:GetTopicAttributes",
+                    "SNS:SetTopicAttributes",
+                    "SNS:AddPermission",
+                    "SNS:RemovePermission",
+                    "SNS:DeleteTopic",
+                    "SNS:Subscribe",
+                    "SNS:ListSubscriptionsByTopic",
+                    "SNS:Publish",
+                ],
+                "Resource": sns_topic_arn,
+                "Condition": {"StringEquals": {"AWS:SourceOwner": data_account_id}},
+            }
+        ],
+    }
+
+
+def build_sns_topic_policy(
+    existing: Mapping[str, Any] | None,
+    bucket: str,
+    sns_topic_arn: str,
+    data_account_id: str,
+    control_principal_arn: str | Sequence[str],
+) -> dict[str, Any]:
+    """Merge owner and Quilt statements into an SNS policy document."""
     publish_statement = _build_sns_topic_publish_policy_statement(
         bucket, sns_topic_arn, data_account_id
     )
     subscribe_statement = _build_sns_topic_subscribe_policy_statement(
         sns_topic_arn, control_principal_arn
     )
+    policy = dict(
+        existing
+        if existing is not None
+        else _build_default_sns_owner_policy(sns_topic_arn, data_account_id)
+    )
+    statements = _merge_policy_statements(policy.get("Statement"), publish_statement)
+    policy["Statement"] = _merge_policy_statements(statements, subscribe_statement)
+    return policy
 
-    if existing_policy is None:
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [publish_statement, subscribe_statement],
-        }
-    else:
-        policy = dict(existing_policy)
-        statements = _merge_policy_statements(
-            existing_policy.get("Statement"), publish_statement
-        )
-        policy["Statement"] = _merge_policy_statements(statements, subscribe_statement)
+
+def apply_sns_topic_policy(
+    sns_topic_arn: str, policy: Mapping[str, Any], sns_client: Any = None
+) -> None:
+    """Write an SNS topic policy document."""
+    if sns_client is None:
+        import boto3
+
+        sns_client = boto3.client("sns")
 
     sns_client.set_topic_attributes(
         TopicArn=sns_topic_arn,
         AttributeName="Policy",
         AttributeValue=json.dumps(policy),
     )
+
+
+def configure_sns_topic_policy(
+    bucket: str,
+    sns_topic_arn: str,
+    data_account_id: str,
+    control_principal_arn: str | Sequence[str],
+    sns_client: Any = None,
+) -> None:
+    """Ensure the SNS topic policy allows S3 publish and Quilt subscribe access."""
+    existing_policy = get_sns_topic_policy(sns_topic_arn, sns_client=sns_client)
+    # Preserve the legacy add-path output for backward compatibility. The
+    # preparation planner uses ``None`` to model SNS's owner policy explicitly.
+    policy_base = (
+        existing_policy
+        if existing_policy is not None
+        else {"Version": "2012-10-17", "Statement": []}
+    )
+    policy = build_sns_topic_policy(
+        policy_base,
+        bucket,
+        sns_topic_arn,
+        data_account_id,
+        control_principal_arn,
+    )
+    apply_sns_topic_policy(sns_topic_arn, policy, sns_client=sns_client)
+
+
+def _copy_notification_configuration(response: Mapping[str, Any]) -> dict[str, Any]:
+    notification_config: dict[str, Any] = {}
+    for key in (
+        "TopicConfigurations",
+        "QueueConfigurations",
+        "LambdaFunctionConfigurations",
+    ):
+        values = response.get(key)
+        if values:
+            notification_config[key] = [dict(value) for value in values]
+    if "EventBridgeConfiguration" in response:
+        notification_config["EventBridgeConfiguration"] = dict(
+            response["EventBridgeConfiguration"]
+        )
+    return notification_config
+
+
+def get_bucket_notification_configuration(
+    bucket: str, s3_client: Any = None
+) -> dict[str, Any]:
+    """Return the writable portion of a bucket notification configuration."""
+    if s3_client is None:
+        import boto3
+
+        s3_client = boto3.client("s3")
+    response = s3_client.get_bucket_notification_configuration(Bucket=bucket)
+    return _copy_notification_configuration(response)
+
+
+def _object_event_families(events: Sequence[str]) -> set[str]:
+    families: set[str] = set()
+    for event in events:
+        if event.startswith("s3:ObjectCreated:"):
+            families.add("ObjectCreated")
+        elif event.startswith("s3:ObjectRemoved:"):
+            families.add("ObjectRemoved")
+    return families
+
+
+def _notification_description(kind: str, config: Mapping[str, Any]) -> str:
+    destination = (
+        config.get("TopicArn")
+        or config.get("QueueArn")
+        or config.get("LambdaFunctionArn")
+        or "<unknown destination>"
+    )
+    details = f"{kind} {config.get('Id', '<no id>')!r} ({destination})"
+    if config.get("Filter"):
+        details += f" with filter {config['Filter']!r}"
+    return details
+
+
+def _existing_notification_topic(
+    notification_config: Mapping[str, Any],
+) -> str | None:
+    for config in notification_config.get("TopicConfigurations", []):
+        if config.get("Id") == SNS_TOPIC_CONFIG_ID and config.get("TopicArn"):
+            return str(config["TopicArn"])
+    return None
+
+
+def build_bucket_notification_configuration(
+    existing: Mapping[str, Any], sns_topic_arn: str
+) -> dict[str, Any]:
+    """Build a safe final S3 notification document for Quilt.
+
+    Quilt needs unfiltered create/remove notifications. Any other destination
+    receiving those event families overlaps that unfiltered configuration, which
+    S3 rejects. Such conflicts are reported instead of replacing user config.
+    """
+    notification_config = _copy_notification_configuration(existing)
+    desired_families = {"ObjectCreated", "ObjectRemoved"}
+    selected_topic = False
+
+    configuration_kinds = (
+        ("TopicConfigurations", "SNS topic"),
+        ("QueueConfigurations", "SQS queue"),
+        ("LambdaFunctionConfigurations", "Lambda function"),
+    )
+    for key, kind in configuration_kinds:
+        updated: list[dict[str, Any]] = []
+        for original in notification_config.get(key, []):
+            config = dict(original)
+            families = _object_event_families(config.get("Events", []))
+            same_topic = key == "TopicConfigurations" and (
+                config.get("TopicArn") == sns_topic_arn
+                or config.get("Id") == SNS_TOPIC_CONFIG_ID
+            )
+            if same_topic:
+                if config.get("TopicArn") not in {None, sns_topic_arn}:
+                    raise NotificationConflictError(
+                        f"notification id {SNS_TOPIC_CONFIG_ID!r} already points to "
+                        f"{config.get('TopicArn')}; remove or rename it before preparing"
+                    )
+                if config.get("Filter"):
+                    raise NotificationConflictError(
+                        f"{_notification_description(kind, config)} cannot be reused: "
+                        "Quilt requires unfiltered object-create/delete events; remove "
+                        "or narrow the conflicting notification first"
+                    )
+                config["TopicArn"] = sns_topic_arn
+                config["Events"] = [
+                    event
+                    for event in config.get("Events", [])
+                    if not _object_event_families([event])
+                ] + list(BUCKET_NOTIFICATION_EVENTS)
+                selected_topic = True
+            elif families & desired_families:
+                raise NotificationConflictError(
+                    f"{_notification_description(kind, config)} overlaps Quilt's "
+                    "unfiltered object-create/delete events; remove or narrow the "
+                    "conflicting notification before preparing"
+                )
+            updated.append(config)
+        if updated:
+            notification_config[key] = updated
+
+    if not selected_topic:
+        notification_config.setdefault("TopicConfigurations", []).append(
+            {
+                "Id": SNS_TOPIC_CONFIG_ID,
+                "TopicArn": sns_topic_arn,
+                "Events": list(BUCKET_NOTIFICATION_EVENTS),
+            }
+        )
+    return notification_config
+
+
+def _sns_policy_if_topic_exists(
+    sns_topic_arn: str, sns_client: Any
+) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        return True, get_sns_topic_policy(sns_topic_arn, sns_client=sns_client)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code in {"NotFound", "NotFoundException"}:
+            return False, None
+        raise
+
+
+def _validate_retained_sns_topics(
+    notification_config: Mapping[str, Any],
+    selected_topic_arn: str,
+    sns_client: Any,
+) -> None:
+    """Fail before writes when a preserved SNS notification points nowhere."""
+    for config in notification_config.get("TopicConfigurations", []):
+        topic_arn = config.get("TopicArn")
+        if not topic_arn or topic_arn == selected_topic_arn:
+            continue
+        exists, _policy = _sns_policy_if_topic_exists(str(topic_arn), sns_client)
+        if not exists:
+            raise NotificationConflictError(
+                f"preserved SNS notification {config.get('Id', '<no id>')!r} "
+                f"references missing topic {topic_arn}; remove the stale "
+                "notification or recreate that topic before preparing"
+            )
+
+
+def build_bucket_preparation_plan(
+    bucket: str,
+    region: str,
+    owning_account: str,
+    *,
+    control_account_id: str | None = None,
+    principals: Sequence[str] | None = None,
+    s3_client: Any,
+    sns_client: Any,
+) -> BucketPreparationPlan:
+    """Read AWS state and return the exact idempotent preparation plan."""
+    principal_list = tuple(principals or ())
+    if not principal_list:
+        if not control_account_id:
+            raise ValueError("provide --control-account-id or at least one --principal")
+        principal_list = (f"arn:aws:iam::{control_account_id}:root",)
+
+    existing_bucket_policy = get_bucket_policy(bucket, s3_client=s3_client)
+    bucket_statement = build_quilt_policy_statement(
+        bucket,
+        control_account_id or "",
+        principals=principal_list,
+    )
+    bucket_policy = merge_bucket_policy(existing_bucket_policy, bucket_statement)
+
+    existing_notifications = get_bucket_notification_configuration(
+        bucket, s3_client=s3_client
+    )
+    existing_topic_arn = _existing_notification_topic(existing_notifications)
+    sns_topic_arn = existing_topic_arn or (
+        f"arn:aws:sns:{region}:{owning_account}:{_sns_topic_name(bucket)}"
+    )
+    notification_configuration = build_bucket_notification_configuration(
+        existing_notifications, sns_topic_arn
+    )
+    topic_exists, existing_sns_policy = _sns_policy_if_topic_exists(
+        sns_topic_arn, sns_client
+    )
+    if existing_topic_arn is not None and not topic_exists:
+        raise NotificationConflictError(
+            f"bucket notification {SNS_TOPIC_CONFIG_ID!r} references missing SNS "
+            f"topic {existing_topic_arn}; remove the stale notification or recreate "
+            "that topic before preparing"
+        )
+    _validate_retained_sns_topics(notification_configuration, sns_topic_arn, sns_client)
+    sns_policy = build_sns_topic_policy(
+        existing_sns_policy,
+        bucket,
+        sns_topic_arn,
+        owning_account,
+        principal_list,
+    )
+
+    return BucketPreparationPlan(
+        bucket=bucket,
+        region=region,
+        owning_account=owning_account,
+        principals=principal_list,
+        sns_topic_arn=sns_topic_arn,
+        bucket_policy=bucket_policy,
+        sns_policy=sns_policy,
+        notification_configuration=notification_configuration,
+        topic_exists=topic_exists,
+        bucket_policy_changed=bucket_policy != existing_bucket_policy,
+        sns_policy_changed=sns_policy != existing_sns_policy,
+        notification_configuration_changed=(
+            notification_configuration != existing_notifications
+        ),
+    )
+
+
+def apply_bucket_preparation(
+    plan: BucketPreparationPlan, *, s3_client: Any, sns_client: Any
+) -> None:
+    """Apply a previously built plan, skipping documents already converged."""
+    if not plan.topic_exists:
+        topic_arn = ensure_sns_topic(plan.bucket, plan.region, sns_client=sns_client)
+        if topic_arn != plan.sns_topic_arn:
+            raise ValueError(
+                f"created SNS topic ARN {topic_arn!r} differs from planned "
+                f"ARN {plan.sns_topic_arn!r}"
+            )
+    if plan.sns_policy_changed:
+        apply_sns_topic_policy(
+            plan.sns_topic_arn, plan.sns_policy, sns_client=sns_client
+        )
+    if plan.bucket_policy_changed:
+        apply_bucket_policy(plan.bucket, plan.bucket_policy, s3_client=s3_client)
+    if plan.notification_configuration_changed:
+        s3_client.put_bucket_notification_configuration(
+            Bucket=plan.bucket,
+            NotificationConfiguration=plan.notification_configuration,
+        )
 
 
 def configure_bucket_notifications(
@@ -544,11 +898,24 @@ def _has_object_notification_event(events: list[str]) -> bool:
 
 
 def _sns_topic_name(bucket: str) -> str:
-    topic_name = f"quilt-{bucket}-notifications"
-    if len(topic_name) <= 256:
-        return topic_name
+    prefix = "quilt-"
     suffix = "-notifications"
-    return f"quilt-{bucket[: 256 - len('quilt-') - len(suffix)]}{suffix}"
+    normalized_bucket = "".join(
+        char if char.isascii() and (char.isalnum() or char in "_-") else "-"
+        for char in bucket
+    )
+    topic_name = f"{prefix}{normalized_bucket}{suffix}"
+    if topic_name == f"{prefix}{bucket}{suffix}" and len(topic_name) <= 256:
+        return topic_name
+
+    # S3 bucket names cannot contain underscores, so transformed names occupy a
+    # namespace that no unchanged bucket can produce. The digest also separates
+    # different bucket names that normalize to the same SNS-safe spelling.
+    transformed_prefix = "quilt-x_"
+    digest = hashlib.sha256(bucket.encode()).hexdigest()[:12]
+    unique_suffix = f"-{digest}{suffix}"
+    max_bucket_length = 256 - len(transformed_prefix) - len(unique_suffix)
+    return f"{transformed_prefix}{normalized_bucket[:max_bucket_length]}{unique_suffix}"
 
 
 def _build_sns_topic_publish_policy_statement(

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -460,9 +460,8 @@ def build_bucket_notification_configuration(
         for original in notification_config.get(key, []):
             config = dict(original)
             families = _object_event_families(config.get("Events", []))
-            same_topic = key == "TopicConfigurations" and (
-                config.get("TopicArn") == sns_topic_arn
-                or config.get("Id") == SNS_TOPIC_CONFIG_ID
+            same_topic = (
+                key == "TopicConfigurations" and config.get("Id") == SNS_TOPIC_CONFIG_ID
             )
             if same_topic:
                 if config.get("TopicArn") not in {None, sns_topic_arn}:
@@ -516,12 +515,33 @@ def _sns_policy_if_topic_exists(
         raise
 
 
-def _validate_retained_sns_topics(
+def _sns_policy_has_bucket_marker(
+    policy: Mapping[str, Any] | None,
+    bucket: str,
+    sns_topic_arn: str,
+    owning_account: str,
+) -> bool:
+    """Return whether a topic policy proves Quilt ownership for this bucket."""
+    if policy is None:
+        return False
+    expected = _build_sns_topic_publish_policy_statement(
+        bucket, sns_topic_arn, owning_account
+    )
+    statements = policy.get("Statement", [])
+    if isinstance(statements, Mapping):
+        statements = [statements]
+    return any(statement == expected for statement in statements)
+
+
+def _validate_retained_notification_destinations(
     notification_config: Mapping[str, Any],
     selected_topic_arn: str,
+    *,
     sns_client: Any,
+    sqs_client: Any | None,
+    lambda_client: Any | None,
 ) -> None:
-    """Fail before writes when a preserved SNS notification points nowhere."""
+    """Fail safely when a preserved SNS, SQS, or Lambda destination is stale."""
     for config in notification_config.get("TopicConfigurations", []):
         topic_arn = config.get("TopicArn")
         if not topic_arn or topic_arn == selected_topic_arn:
@@ -534,6 +554,55 @@ def _validate_retained_sns_topics(
                 "notification or recreate that topic before preparing"
             )
 
+    for config in notification_config.get("QueueConfigurations", []):
+        queue_arn = config.get("QueueArn")
+        if not queue_arn:
+            continue
+        if sqs_client is None:
+            raise ValueError("sqs_client is required to validate retained SQS queues")
+        arn_parts = str(queue_arn).split(":", 5)
+        if len(arn_parts) != 6 or arn_parts[2] != "sqs":
+            raise NotificationConflictError(
+                f"preserved SQS notification {config.get('Id', '<no id>')!r} "
+                f"has invalid queue ARN {queue_arn}"
+            )
+        try:
+            sqs_client.get_queue_url(
+                QueueName=arn_parts[5], QueueOwnerAWSAccountId=arn_parts[4]
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code not in {
+                "AWS.SimpleQueueService.NonExistentQueue",
+                "QueueDoesNotExist",
+            }:
+                raise
+            raise NotificationConflictError(
+                f"preserved SQS notification {config.get('Id', '<no id>')!r} "
+                f"references missing queue {queue_arn}; remove the stale "
+                "notification or recreate that queue before preparing"
+            ) from exc
+
+    for config in notification_config.get("LambdaFunctionConfigurations", []):
+        function_arn = config.get("LambdaFunctionArn")
+        if not function_arn:
+            continue
+        if lambda_client is None:
+            raise ValueError(
+                "lambda_client is required to validate retained Lambda functions"
+            )
+        try:
+            lambda_client.get_function_configuration(FunctionName=function_arn)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code")
+            if code != "ResourceNotFoundException":
+                raise
+            raise NotificationConflictError(
+                f"preserved Lambda notification {config.get('Id', '<no id>')!r} "
+                f"references missing function {function_arn}; remove the stale "
+                "notification or recreate that function before preparing"
+            ) from exc
+
 
 def build_bucket_preparation_plan(
     bucket: str,
@@ -544,6 +613,8 @@ def build_bucket_preparation_plan(
     principals: Sequence[str] | None = None,
     s3_client: Any,
     sns_client: Any,
+    sqs_client: Any | None = None,
+    lambda_client: Any | None = None,
 ) -> BucketPreparationPlan:
     """Read AWS state and return the exact idempotent preparation plan."""
     principal_list = tuple(principals or ())
@@ -587,7 +658,24 @@ def build_bucket_preparation_plan(
             f"topic {existing_topic_arn}; remove the stale notification or recreate "
             "that topic before preparing"
         )
-    _validate_retained_sns_topics(notification_configuration, sns_topic_arn, sns_client)
+    if (
+        topic_exists
+        and existing_topic_arn is None
+        and not _sns_policy_has_bucket_marker(
+            existing_sns_policy, bucket, sns_topic_arn, owning_account
+        )
+    ):
+        raise NotificationConflictError(
+            f"existing topic {sns_topic_arn} lacks a bucket-specific Quilt ownership "
+            "marker; rename or remove the colliding topic before preparing"
+        )
+    _validate_retained_notification_destinations(
+        notification_configuration,
+        sns_topic_arn,
+        sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
+    )
     sns_policy = build_sns_topic_policy(
         existing_sns_policy,
         bucket,
@@ -617,10 +705,23 @@ def build_bucket_preparation_plan(
     )
 
 
+def _raise_preparation_drift(*changed: str) -> None:
+    raise PreparationDriftError(
+        "AWS state changed after planning ("
+        + ", ".join(changed)
+        + "); rerun bucket prepare to build a fresh plan"
+    )
+
+
 def _assert_bucket_preparation_is_current(
-    plan: BucketPreparationPlan, *, s3_client: Any, sns_client: Any
+    plan: BucketPreparationPlan,
+    *,
+    s3_client: Any,
+    sns_client: Any,
+    sqs_client: Any | None,
+    lambda_client: Any | None,
 ) -> None:
-    """Optimistically verify every planned document before the first write."""
+    """Verify every baseline and retained destination before the first write."""
     current_bucket_policy = get_bucket_policy(plan.bucket, s3_client=s3_client)
     current_notifications = get_bucket_notification_configuration(
         plan.bucket, s3_client=s3_client
@@ -639,36 +740,79 @@ def _assert_bucket_preparation_is_current(
     elif current_sns_policy != plan.original_sns_policy:
         changed.append("SNS topic policy")
     if changed:
-        raise PreparationDriftError(
-            "AWS state changed after planning ("
-            + ", ".join(changed)
-            + "); rerun bucket prepare to build a fresh plan"
-        )
+        _raise_preparation_drift(*changed)
 
-    _validate_retained_sns_topics(current_notifications, plan.sns_topic_arn, sns_client)
+    _validate_retained_notification_destinations(
+        current_notifications,
+        plan.sns_topic_arn,
+        sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
+    )
 
 
 def apply_bucket_preparation(
-    plan: BucketPreparationPlan, *, s3_client: Any, sns_client: Any
+    plan: BucketPreparationPlan,
+    *,
+    s3_client: Any,
+    sns_client: Any,
+    sqs_client: Any | None = None,
+    lambda_client: Any | None = None,
 ) -> None:
-    """Apply a plan only if all AWS documents still match its baseline."""
+    """Apply a plan with baseline checks before the first and every later write."""
     _assert_bucket_preparation_is_current(
-        plan, s3_client=s3_client, sns_client=sns_client
+        plan,
+        s3_client=s3_client,
+        sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
     )
-    if not plan.topic_exists:
-        topic_arn = ensure_sns_topic(plan.bucket, plan.region, sns_client=sns_client)
-        if topic_arn != plan.sns_topic_arn:
-            raise ValueError(
-                f"created SNS topic ARN {topic_arn!r} differs from planned "
-                f"ARN {plan.sns_topic_arn!r}"
-            )
+
     if plan.sns_policy_changed:
+        expected_sns_policy: dict[str, Any] | None
+        if not plan.topic_exists:
+            topic_arn = ensure_sns_topic(
+                plan.bucket, plan.region, sns_client=sns_client
+            )
+            if topic_arn != plan.sns_topic_arn:
+                raise ValueError(
+                    f"created SNS topic ARN {topic_arn!r} differs from planned "
+                    f"ARN {plan.sns_topic_arn!r}"
+                )
+            expected_sns_policy = _build_default_sns_owner_policy(
+                plan.sns_topic_arn, plan.owning_account
+            )
+        else:
+            expected_sns_policy = plan.original_sns_policy
+
+        current_topic_exists, current_sns_policy = _sns_policy_if_topic_exists(
+            plan.sns_topic_arn, sns_client
+        )
+        if not current_topic_exists or current_sns_policy != expected_sns_policy:
+            _raise_preparation_drift("SNS topic policy")
         apply_sns_topic_policy(
             plan.sns_topic_arn, plan.sns_policy, sns_client=sns_client
         )
+
     if plan.bucket_policy_changed:
+        current_bucket_policy = get_bucket_policy(plan.bucket, s3_client=s3_client)
+        if current_bucket_policy != plan.original_bucket_policy:
+            _raise_preparation_drift("bucket policy")
         apply_bucket_policy(plan.bucket, plan.bucket_policy, s3_client=s3_client)
+
     if plan.notification_configuration_changed:
+        current_notifications = get_bucket_notification_configuration(
+            plan.bucket, s3_client=s3_client
+        )
+        if current_notifications != plan.original_notification_configuration:
+            _raise_preparation_drift("bucket notification configuration")
+        _validate_retained_notification_destinations(
+            current_notifications,
+            plan.sns_topic_arn,
+            sns_client=sns_client,
+            sqs_client=sqs_client,
+            lambda_client=lambda_client,
+        )
         s3_client.put_bucket_notification_configuration(
             Bucket=plan.bucket,
             NotificationConfiguration=plan.notification_configuration,
@@ -678,40 +822,21 @@ def apply_bucket_preparation(
 def configure_bucket_notifications(
     bucket: str, sns_topic_arn: str, s3_client: Any = None
 ) -> None:
-    """Merge a Quilt SNS notification destination into the bucket notification config."""
+    """Converge S3 notifications through the shared safe planner."""
     if s3_client is None:
         import boto3
 
         s3_client = boto3.client("s3")
 
-    response = s3_client.get_bucket_notification_configuration(Bucket=bucket)
-    notification_config: dict[str, Any] = {}
-    for key in (
-        "TopicConfigurations",
-        "QueueConfigurations",
-        "LambdaFunctionConfigurations",
-    ):
-        values = response.get(key)
-        if values:
-            notification_config[key] = [dict(value) for value in values]
-    if "EventBridgeConfiguration" in response:
-        notification_config["EventBridgeConfiguration"] = dict(
-            response["EventBridgeConfiguration"]
+    existing = get_bucket_notification_configuration(bucket, s3_client=s3_client)
+    notification_config = build_bucket_notification_configuration(
+        existing, sns_topic_arn
+    )
+    if notification_config != existing:
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket,
+            NotificationConfiguration=notification_config,
         )
-
-    topic_config = {
-        "Id": SNS_TOPIC_CONFIG_ID,
-        "TopicArn": sns_topic_arn,
-        "Events": list(BUCKET_NOTIFICATION_EVENTS),
-    }
-    notification_config["TopicConfigurations"] = _merge_topic_configurations(
-        notification_config.get("TopicConfigurations", []), topic_config
-    )
-
-    s3_client.put_bucket_notification_configuration(
-        Bucket=bucket,
-        NotificationConfiguration=notification_config,
-    )
 
 
 @dataclass
@@ -815,21 +940,9 @@ def add_bucket(
     control_account_id = str(control_account_id)
 
     principal_list = list(principals) if principals else []
-    sns_principal: str | list[str] = (
-        principal_list if principal_list else f"arn:aws:iam::{control_account_id}:root"
-    )
-
     bucket_title = title or bucket
 
-    # Check if already registered
     existing = stack.admin.buckets.get(bucket)
-    if existing is not None:
-        return AddBucketResult(
-            bucket=bucket,
-            title=getattr(existing, "title", bucket_title),
-            sns_topic_arn=getattr(existing, "sns_notification_arn", "") or "",
-            already_registered=True,
-        )
 
     session = boto3.Session(profile_name=profile)
     s3_client = session.client("s3")
@@ -837,41 +950,33 @@ def add_bucket(
     sns_client = session.client("sns", region_name=bucket_region)
     data_account_id = str(session.client("sts").get_caller_identity()["Account"])
 
-    existing_policy = get_bucket_policy(bucket, s3_client=s3_client)
-    statement = build_quilt_policy_statement(
-        bucket, control_account_id, principals=principal_list or None
-    )
-    merged = merge_bucket_policy(existing_policy, statement)
-    apply_bucket_policy(bucket, merged, s3_client=s3_client)
-
-    # SNS topic
-    sns_topic_arn = get_bucket_notification_sns(bucket, s3_client=s3_client)
-    if sns_topic_arn is None:
-        sns_topic_arn = ensure_sns_topic(bucket, bucket_region, sns_client=sns_client)
-
-    configure_sns_topic_policy(
+    plan = build_bucket_preparation_plan(
         bucket,
-        sns_topic_arn,
+        bucket_region,
         data_account_id,
-        sns_principal,
+        control_account_id=control_account_id,
+        principals=principal_list or None,
+        s3_client=s3_client,
         sns_client=sns_client,
     )
+    apply_bucket_preparation(plan, s3_client=s3_client, sns_client=sns_client)
 
-    # Bucket notifications
-    configure_bucket_notifications(bucket, sns_topic_arn, s3_client=s3_client)
-
-    # Register in Quilt catalog
-    stack.admin.buckets.add(
-        name=bucket,
-        title=bucket_title,
-        sns_notification_arn=sns_topic_arn,
-    )
+    # Register only when the catalog row is absent; preparation always converges.
+    if existing is None:
+        stack.admin.buckets.add(
+            name=bucket,
+            title=bucket_title,
+            sns_notification_arn=plan.sns_topic_arn,
+        )
+        result_title = bucket_title
+    else:
+        result_title = getattr(existing, "title", bucket_title)
 
     return AddBucketResult(
         bucket=bucket,
-        title=bucket_title,
-        sns_topic_arn=sns_topic_arn,
-        already_registered=False,
+        title=result_title,
+        sns_topic_arn=plan.sns_topic_arn,
+        already_registered=existing is not None,
     )
 
 
@@ -1012,18 +1117,3 @@ def _parse_json_document(raw_value: Any) -> dict[str, Any] | None:
     if isinstance(raw_value, Mapping):
         return dict(raw_value)
     return json.loads(str(raw_value))
-
-
-def _merge_topic_configurations(
-    existing_configs: list[dict[str, Any]], topic_config: dict[str, Any]
-) -> list[dict[str, Any]]:
-    merged = [dict(config) for config in existing_configs]
-    for idx, config in enumerate(merged):
-        if (
-            config.get("Id") == topic_config["Id"]
-            or config.get("TopicArn") == topic_config["TopicArn"]
-        ):
-            merged[idx] = dict(topic_config)
-            return merged
-    merged.append(dict(topic_config))
-    return merged

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -125,6 +125,10 @@ class NotificationConflictError(ValueError):
     """Raised when Quilt notifications would overlap an existing destination."""
 
 
+class PreparationDriftError(RuntimeError):
+    """Raised when AWS state changes between preparation planning and apply."""
+
+
 @dataclass(frozen=True)
 class BucketPreparationPlan:
     """Exact AWS documents and secure handoff produced by bucket preparation."""
@@ -137,6 +141,9 @@ class BucketPreparationPlan:
     bucket_policy: dict[str, Any]
     sns_policy: dict[str, Any]
     notification_configuration: dict[str, Any]
+    original_bucket_policy: dict[str, Any] | None
+    original_sns_policy: dict[str, Any] | None
+    original_notification_configuration: dict[str, Any]
     topic_exists: bool
     bucket_policy_changed: bool
     sns_policy_changed: bool
@@ -557,9 +564,17 @@ def build_bucket_preparation_plan(
         bucket, s3_client=s3_client
     )
     existing_topic_arn = _existing_notification_topic(existing_notifications)
-    sns_topic_arn = existing_topic_arn or (
+    canonical_topic_arn = (
         f"arn:aws:sns:{region}:{owning_account}:{_sns_topic_name(bucket)}"
     )
+    if existing_topic_arn is not None and existing_topic_arn != canonical_topic_arn:
+        raise NotificationConflictError(
+            f"bucket notification {SNS_TOPIC_CONFIG_ID!r} points to unverified topic "
+            f"{existing_topic_arn}; expected the bucket-specific Quilt topic "
+            f"{canonical_topic_arn}. Remove or rename the notification before "
+            "preparing"
+        )
+    sns_topic_arn = canonical_topic_arn
     notification_configuration = build_bucket_notification_configuration(
         existing_notifications, sns_topic_arn
     )
@@ -590,6 +605,9 @@ def build_bucket_preparation_plan(
         bucket_policy=bucket_policy,
         sns_policy=sns_policy,
         notification_configuration=notification_configuration,
+        original_bucket_policy=existing_bucket_policy,
+        original_sns_policy=existing_sns_policy,
+        original_notification_configuration=existing_notifications,
         topic_exists=topic_exists,
         bucket_policy_changed=bucket_policy != existing_bucket_policy,
         sns_policy_changed=sns_policy != existing_sns_policy,
@@ -599,10 +617,44 @@ def build_bucket_preparation_plan(
     )
 
 
+def _assert_bucket_preparation_is_current(
+    plan: BucketPreparationPlan, *, s3_client: Any, sns_client: Any
+) -> None:
+    """Optimistically verify every planned document before the first write."""
+    current_bucket_policy = get_bucket_policy(plan.bucket, s3_client=s3_client)
+    current_notifications = get_bucket_notification_configuration(
+        plan.bucket, s3_client=s3_client
+    )
+    current_topic_exists, current_sns_policy = _sns_policy_if_topic_exists(
+        plan.sns_topic_arn, sns_client
+    )
+
+    changed: list[str] = []
+    if current_bucket_policy != plan.original_bucket_policy:
+        changed.append("bucket policy")
+    if current_notifications != plan.original_notification_configuration:
+        changed.append("bucket notification configuration")
+    if current_topic_exists != plan.topic_exists:
+        changed.append("SNS topic existence")
+    elif current_sns_policy != plan.original_sns_policy:
+        changed.append("SNS topic policy")
+    if changed:
+        raise PreparationDriftError(
+            "AWS state changed after planning ("
+            + ", ".join(changed)
+            + "); rerun bucket prepare to build a fresh plan"
+        )
+
+    _validate_retained_sns_topics(current_notifications, plan.sns_topic_arn, sns_client)
+
+
 def apply_bucket_preparation(
     plan: BucketPreparationPlan, *, s3_client: Any, sns_client: Any
 ) -> None:
-    """Apply a previously built plan, skipping documents already converged."""
+    """Apply a plan only if all AWS documents still match its baseline."""
+    _assert_bucket_preparation_is_current(
+        plan, s3_client=s3_client, sns_client=sns_client
+    )
     if not plan.topic_exists:
         topic_arn = ensure_sns_topic(plan.bucket, plan.region, sns_client=sns_client)
         if topic_arn != plan.sns_topic_arn:

--- a/quiltx/quilt3_facade.py
+++ b/quiltx/quilt3_facade.py
@@ -168,3 +168,17 @@ def make_bucket(bucket_uri: str) -> object:
     import quilt3
 
     return quilt3.Bucket(bucket_uri)
+
+
+def catalog_sts_account_id() -> str:
+    """Return the AWS account ID behind the active catalog's minted credentials.
+
+    Uses quilt3's registry-issued temporary credentials — available to any
+    logged-in catalog user, no admin role required — and asks STS which
+    account they belong to: the catalog stack's control account.
+    """
+    import quilt3.session
+
+    botocore_session = quilt3.session.create_botocore_session()
+    sts_client = botocore_session.create_client("sts")
+    return str(sts_client.get_caller_identity()["Account"])

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -419,6 +419,17 @@ def _lightweight_stack_payload(
     )
 
 
+def _print_plan_documents(
+    console: Console, plan: bucket_lib.BucketPreparationPlan
+) -> None:
+    print("\nFinal bucket policy:")
+    _print_json(console, plan.bucket_policy)
+    print("\nFinal SNS topic policy:")
+    _print_json(console, plan.sns_policy)
+    print("\nFinal bucket notification configuration:")
+    _print_json(console, plan.notification_configuration)
+
+
 def _print_bucket_preparation_plan(plan: bucket_lib.BucketPreparationPlan) -> None:
     console = Console(width=120)
     print("Bucket prepare dry-run")
@@ -427,12 +438,7 @@ def _print_bucket_preparation_plan(plan: bucket_lib.BucketPreparationPlan) -> No
     print(f"Owning account: {plan.owning_account}")
     print(f"Effective principals: {', '.join(plan.principals)}")
     print(f"SNS topic: {plan.sns_topic_arn}")
-    print("\nFinal bucket policy:")
-    _print_json(console, plan.bucket_policy)
-    print("\nFinal SNS topic policy:")
-    _print_json(console, plan.sns_policy)
-    print("\nFinal bucket notification configuration:")
-    _print_json(console, plan.notification_configuration)
+    _print_plan_documents(console, plan)
 
 
 def _confirm_bucket_preparation(plan: bucket_lib.BucketPreparationPlan) -> bool:
@@ -482,6 +488,8 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
     if session is None:
         return 1
     sns_client = session.client("sns", region_name=region)
+    sqs_client = session.client("sqs", region_name=region)
+    lambda_client = session.client("lambda", region_name=region)
     owning_account = _get_session_account_id(session)
     plan = bucket_lib.build_bucket_preparation_plan(
         args.bucket_name,
@@ -491,6 +499,8 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
         principals=principals or None,
         s3_client=s3_client,
         sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
     )
 
     if args.dry_run:
@@ -501,7 +511,11 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
         return 1
 
     bucket_lib.apply_bucket_preparation(
-        plan, s3_client=s3_client, sns_client=sns_client
+        plan,
+        s3_client=s3_client,
+        sns_client=sns_client,
+        sqs_client=sqs_client,
+        lambda_client=lambda_client,
     )
     if args.json:
         print(json.dumps(plan.handoff(), indent=2))
@@ -566,6 +580,8 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             return 1
         args.profile = resolved_profile
         sns_client = session.client("sns", region_name=bucket_region)
+        sqs_client = session.client("sqs", region_name=bucket_region)
+        lambda_client = session.client("lambda", region_name=bucket_region)
 
         existing_bucket = stack.admin.buckets.get(args.bucket_name)
         prior_title = (
@@ -573,13 +589,13 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             if existing_bucket is not None
             else None
         )
-        if existing_bucket is not None and args.force:
+        force_reregister = existing_bucket is not None and args.force
+        if force_reregister:
             print(
                 f"Bucket {args.bucket_name}: already registered in Quilt; "
-                "removing and re-adding (--force) so Quilt re-subscribes SQS."
+                "will remove and re-add after AWS preparation (--force) so Quilt "
+                "re-subscribes SQS."
             )
-            stack.admin.buckets.remove(args.bucket_name)
-            existing_bucket = None
         elif existing_bucket is not None:
             print(
                 f"Bucket {args.bucket_name}: already registered in Quilt; "
@@ -588,21 +604,18 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
                 "registration so Quilt re-subscribes SQS."
             )
 
-        bucket_policy = bucket_lib.get_bucket_policy(
-            args.bucket_name, s3_client=s3_client
-        )
-        quilt_statement = bucket_lib.build_quilt_policy_statement(
-            args.bucket_name,
-            control_account_id,
-            principals=principals or None,
-        )
-        merged_policy = bucket_lib.merge_bucket_policy(bucket_policy, quilt_statement)
-
-        sns_topic_arn = bucket_lib.get_bucket_notification_sns(
-            args.bucket_name, s3_client=s3_client
-        )
-
         data_account_id = _get_session_account_id(session)
+        plan = bucket_lib.build_bucket_preparation_plan(
+            args.bucket_name,
+            bucket_region,
+            data_account_id,
+            control_account_id=control_account_id,
+            principals=principals or None,
+            s3_client=s3_client,
+            sns_client=sns_client,
+            sqs_client=sqs_client,
+            lambda_client=lambda_client,
+        )
 
         if args.dry_run:
             _print_dry_run_plan(
@@ -613,12 +626,8 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
                 effective_principals,
                 principal_source,
                 control_region,
-                args.bucket_name,
-                bucket_region,
-                data_account_id,
                 args.profile,
-                merged_policy,
-                sns_topic_arn,
+                plan,
             )
             return 0
 
@@ -630,42 +639,25 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             effective_principals,
             principal_source,
             control_region,
-            args.bucket_name,
-            bucket_region,
-            data_account_id,
             args.profile,
-            sns_topic_arn,
+            plan,
         ):
             print("Aborted.")
             return 1
 
-        if sns_topic_arn is None:
-            sns_topic_arn = bucket_lib.ensure_sns_topic(
-                args.bucket_name,
-                bucket_region,
-                sns_client=sns_client,
-            )
-
-        bucket_lib.configure_sns_topic_policy(
-            args.bucket_name,
-            sns_topic_arn,
-            data_account_id,
-            effective_principals,
+        bucket_lib.apply_bucket_preparation(
+            plan,
+            s3_client=s3_client,
             sns_client=sns_client,
+            sqs_client=sqs_client,
+            lambda_client=lambda_client,
         )
-
-        bucket_lib.apply_bucket_policy(
-            args.bucket_name,
-            merged_policy,
-            s3_client=s3_client,
-        )
-        bucket_lib.configure_bucket_notifications(
-            args.bucket_name,
-            sns_topic_arn,
-            s3_client=s3_client,
-        )
+        sns_topic_arn = plan.sns_topic_arn
 
         bucket_title = args.title or prior_title or args.bucket_name
+        if force_reregister:
+            stack.admin.buckets.remove(args.bucket_name)
+            existing_bucket = None
         if existing_bucket is None:
             stack.admin.buckets.add(
                 name=args.bucket_name,
@@ -990,11 +982,8 @@ def _confirm_bucket_add(
     principals: list[str],
     principal_source: str,
     control_region: str,
-    bucket_name: str,
-    bucket_region: str,
-    data_account_id: str,
     profile: str | None,
-    sns_topic_arn: str | None,
+    plan: bucket_lib.BucketPreparationPlan,
 ) -> bool:
     console = Console(width=120)
     _print_context_table(
@@ -1007,20 +996,16 @@ def _confirm_bucket_add(
         principals,
         principal_source,
         control_region,
-        bucket_name,
-        bucket_region,
-        data_account_id,
+        plan.bucket,
+        plan.region,
+        plan.owning_account,
         profile,
-        sns_topic_arn,
+        plan.sns_topic_arn if plan.topic_exists else None,
     )
-    if sns_topic_arn is None:
-        planned_topic_arn = (
-            f"arn:aws:sns:{bucket_region}:{data_account_id}:"
-            f"{bucket_lib._sns_topic_name(bucket_name)}"
-        )
+    if not plan.topic_exists:
         console.print(
             f"\n[yellow]WARNING:[/yellow] no existing SNS topic found; "
-            f"a new topic will be created: {planned_topic_arn}"
+            f"a new topic will be created: {plan.sns_topic_arn}"
         )
     response = input("Continue? [y/N]: ").strip().lower()
     return response in {"y", "yes"}
@@ -1034,12 +1019,8 @@ def _print_dry_run_plan(
     principals: list[str],
     principal_source: str,
     control_region: str,
-    bucket_name: str,
-    bucket_region: str,
-    data_account_id: str,
     profile: str | None,
-    merged_policy: Mapping[str, Any],
-    sns_topic_arn: str | None,
+    plan: bucket_lib.BucketPreparationPlan,
 ) -> None:
     console = Console(width=120)
     _print_context_table(
@@ -1052,43 +1033,18 @@ def _print_dry_run_plan(
         principals,
         principal_source,
         control_region,
-        bucket_name,
-        bucket_region,
-        data_account_id,
+        plan.bucket,
+        plan.region,
+        plan.owning_account,
         profile,
-        sns_topic_arn,
+        plan.sns_topic_arn if plan.topic_exists else None,
     )
-    print()
-    print("Planned bucket policy:")
-    _print_json(console, merged_policy)
-
-    planned_topic_arn = sns_topic_arn or (
-        f"arn:aws:sns:{bucket_region}:{data_account_id}:"
-        f"{bucket_lib._sns_topic_name(bucket_name)}"
-    )
-    if sns_topic_arn is None:
+    if not plan.topic_exists:
         console.print(
             f"\n[yellow]WARNING:[/yellow] no existing SNS topic found; "
-            f"a new topic will be created: {planned_topic_arn}"
+            f"a new topic will be created: {plan.sns_topic_arn}"
         )
-    print("\nPlanned SNS topic policy statement:")
-    _print_json(
-        console,
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                bucket_lib._build_sns_topic_publish_policy_statement(
-                    bucket_name,
-                    planned_topic_arn,
-                    data_account_id,
-                ),
-                bucket_lib._build_sns_topic_subscribe_policy_statement(
-                    planned_topic_arn,
-                    principals,
-                ),
-            ],
-        },
-    )
+    _print_plan_documents(console, plan)
 
 
 def _print_no_preflight_dry_run(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -120,8 +120,17 @@ def build_parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument(
         "--control-account-id",
         help=(
-            "Quilt control AWS account ID. Required unless --principal is supplied; "
-            "defaults access to that account root."
+            "Quilt control AWS account ID. Required unless --principal or "
+            "--catalog is supplied; defaults access to that account root."
+        ),
+    )
+    prepare_parser.add_argument(
+        "--catalog",
+        help=(
+            "Catalog DNS name used to derive the control account ID when "
+            "--control-account-id and --principal are omitted: reads cached "
+            "stack metadata, else logs in as a regular catalog user (no admin "
+            "required) and asks STS which account minted the credentials."
         ),
     )
     prepare_parser.add_argument(
@@ -441,6 +450,36 @@ def _print_bucket_preparation_plan(plan: bucket_lib.BucketPreparationPlan) -> No
     _print_plan_documents(console, plan)
 
 
+def _control_account_id_from_catalog(catalog_arg: str) -> str:
+    """Derive the Quilt control account ID for a catalog without admin access.
+
+    Cached stack metadata wins (no authentication at all); otherwise log in as
+    a regular catalog user and ask STS which account minted the catalog
+    credentials. Keeps ``bucket prepare`` outside ``catalog_command``: no
+    catalog configuration is loaded and no Quilt admin API is called.
+    """
+    from quiltx import quilt3_facade
+
+    catalog = stack_lib.resolve_catalog_context(catalog_arg)
+    payload = stack_lib.load_stack_payload(catalog.catalog_name)
+    account_id = str((payload or {}).get("account_id") or "")
+    if account_id:
+        print(
+            f"Control account {account_id} from cached stack metadata for "
+            f"{catalog.catalog_name}.",
+            file=sys.stderr,
+        )
+        return account_id
+    catalog.ensure_auth()
+    account_id = quilt3_facade.catalog_sts_account_id()
+    print(
+        f"Control account {account_id} from {catalog.catalog_name} catalog "
+        "credentials.",
+        file=sys.stderr,
+    )
+    return account_id
+
+
 def _confirm_bucket_preparation(plan: bucket_lib.BucketPreparationPlan) -> bool:
     print(f"Prepare s3://{plan.bucket} in {plan.region} for Quilt access.")
     print(f"SNS topic: {plan.sns_topic_arn}")
@@ -460,17 +499,28 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-    if not args.control_account_id and not principals:
-        print(
-            "Error: provide --control-account-id or at least one --principal",
-            file=sys.stderr,
-        )
-        return 1
     if args.control_account_id and (
         len(args.control_account_id) != 12 or not args.control_account_id.isdigit()
     ):
         print(
             "Error: --control-account-id must be a 12-digit AWS account ID",
+            file=sys.stderr,
+        )
+        return 1
+    control_account_id = args.control_account_id
+    if not control_account_id and not principals and args.catalog:
+        try:
+            control_account_id = _control_account_id_from_catalog(args.catalog)
+        except Exception as exc:
+            print(
+                f"Error: cannot derive control account from catalog "
+                f"{args.catalog}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+    if not control_account_id and not principals:
+        print(
+            "Error: provide --control-account-id, --principal, or --catalog",
             file=sys.stderr,
         )
         return 1
@@ -495,7 +545,7 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
         args.bucket_name,
         region,
         owning_account,
-        control_account_id=args.control_account_id,
+        control_account_id=control_account_id,
         principals=principals or None,
         s3_client=s3_client,
         sns_client=sns_client,

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -107,6 +107,51 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    prepare_parser = subparsers.add_parser(
+        "prepare",
+        prog="quiltx bucket prepare",
+        help="Configure bucket access and notifications using AWS credentials only.",
+    )
+    prepare_parser.add_argument("bucket_name", help="S3 bucket name to prepare.")
+    prepare_parser.add_argument(
+        "--profile",
+        help="AWS profile for the data account that owns the bucket.",
+    )
+    prepare_parser.add_argument(
+        "--control-account-id",
+        help=(
+            "Quilt control AWS account ID. Required unless --principal is supplied; "
+            "defaults access to that account root."
+        ),
+    )
+    prepare_parser.add_argument(
+        "--principal",
+        metavar="ARN",
+        action="append",
+        nargs="?",
+        const="",
+        help=(
+            "Explicit Quilt IAM role ARN granted bucket and SNS access. "
+            "Repeatable or comma-separated."
+        ),
+    )
+    output_group = prepare_parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the exact final AWS policy and notification documents.",
+    )
+    output_group.add_argument(
+        "--json",
+        action="store_true",
+        help="Print only the minimal non-secret operator handoff as JSON.",
+    )
+    prepare_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Apply AWS changes without prompting for confirmation.",
+    )
+
     list_parser = subparsers.add_parser(
         "list",
         prog="quiltx bucket list",
@@ -183,6 +228,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.action == "add":
             return _cmd_add(args)
+        if args.action == "prepare":
+            return _cmd_prepare(args)
         if args.action == "remove":
             return _cmd_remove(args)
         if args.action == "list":
@@ -370,6 +417,102 @@ def _lightweight_stack_payload(
         catalog_config=catalog_config,
         region=region,
     )
+
+
+def _print_bucket_preparation_plan(plan: bucket_lib.BucketPreparationPlan) -> None:
+    console = Console(width=120)
+    print("Bucket prepare dry-run")
+    print(f"Bucket: s3://{plan.bucket}")
+    print(f"Region: {plan.region}")
+    print(f"Owning account: {plan.owning_account}")
+    print(f"Effective principals: {', '.join(plan.principals)}")
+    print(f"SNS topic: {plan.sns_topic_arn}")
+    print("\nFinal bucket policy:")
+    _print_json(console, plan.bucket_policy)
+    print("\nFinal SNS topic policy:")
+    _print_json(console, plan.sns_policy)
+    print("\nFinal bucket notification configuration:")
+    _print_json(console, plan.notification_configuration)
+
+
+def _confirm_bucket_preparation(plan: bucket_lib.BucketPreparationPlan) -> bool:
+    print(f"Prepare s3://{plan.bucket} in {plan.region} for Quilt access.")
+    print(f"SNS topic: {plan.sns_topic_arn}")
+    response = input("Apply these AWS changes? [y/N]: ").strip().lower()
+    return response in {"y", "yes"}
+
+
+def _cmd_prepare(args: argparse.Namespace) -> int:
+    principals, show_guidance = _resolve_principals_arg(args.principal)
+    if show_guidance:
+        _print_principal_guidance()
+        return 0
+    for principal in principals:
+        if not principal.startswith("arn:aws:iam::") or ":role/" not in principal:
+            print(
+                f"Error: --principal must be an IAM role ARN, got {principal!r}",
+                file=sys.stderr,
+            )
+            return 1
+    if not args.control_account_id and not principals:
+        print(
+            "Error: provide --control-account-id or at least one --principal",
+            file=sys.stderr,
+        )
+        return 1
+    if args.control_account_id and (
+        len(args.control_account_id) != 12 or not args.control_account_id.isdigit()
+    ):
+        print(
+            "Error: --control-account-id must be a 12-digit AWS account ID",
+            file=sys.stderr,
+        )
+        return 1
+    if args.json and not args.yes:
+        print("Error: --json requires --yes for non-interactive apply", file=sys.stderr)
+        return 1
+
+    session, s3_client, region, _resolved_profile = bucket_lib.resolve_bucket_session(
+        args.bucket_name,
+        args.profile,
+        assume_yes=args.yes,
+        no_prompt=bool(args.json and args.profile),
+        output=sys.stderr,
+    )
+    if session is None:
+        return 1
+    sns_client = session.client("sns", region_name=region)
+    owning_account = _get_session_account_id(session)
+    plan = bucket_lib.build_bucket_preparation_plan(
+        args.bucket_name,
+        region,
+        owning_account,
+        control_account_id=args.control_account_id,
+        principals=principals or None,
+        s3_client=s3_client,
+        sns_client=sns_client,
+    )
+
+    if args.dry_run:
+        _print_bucket_preparation_plan(plan)
+        return 0
+    if not args.yes and not _confirm_bucket_preparation(plan):
+        print("Aborted.")
+        return 1
+
+    bucket_lib.apply_bucket_preparation(
+        plan, s3_client=s3_client, sns_client=sns_client
+    )
+    if args.json:
+        print(json.dumps(plan.handoff(), indent=2))
+    else:
+        print(f"Prepared s3://{plan.bucket} for Quilt access.")
+        print(f"SNS notifications: {plan.sns_topic_arn}")
+        print(
+            "Catalog operator next step: "
+            f"quiltx bucket add {plan.bucket} --no-preflight --catalog <catalog>"
+        )
+    return 0
 
 
 @stack_lib.catalog_command

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1293,7 +1293,13 @@ def test_apply_acl_orders_operations_and_updates_sso_before_role_deletes(
     current.managed_policies[legacy_policy.title] = legacy_policy
     current.all_policies[legacy_policy.title] = legacy_policy
 
-    acl.apply_acl(stack, diff, current)
+    monkeypatch.setattr(
+        "quiltx.bucket.add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: stack.admin.buckets.add(
+            name=bucket, title=title or bucket
+        ),
+    )
+    acl.apply_acl(stack, diff, current, no_preflight=True)
 
     assert calls == [
         ("bucket_add", "bucket-a", "bucket-a"),
@@ -1577,6 +1583,132 @@ def test_apply_acl_detaches_deleted_policies_from_surviving_roles() -> None:
     assert calls == [
         ("role_update", "id-survivor", "survivor", ["id-keep"]),
         ("policy_delete", "id-legacy"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{"region": "us-east-1"}, {"account_id": ""}],
+    ids=["missing-account-id", "empty-account-id"],
+)
+def test_apply_acl_requires_control_account_metadata_for_preflight(
+    monkeypatch, payload
+) -> None:
+    direct_adds: list[str] = []
+    stack = _fake_stack(
+        payload=payload,
+        buckets=SimpleNamespace(
+            add=lambda **kwargs: direct_adds.append(kwargs["name"])
+        ),
+    )
+    monkeypatch.setattr(
+        acl,
+        "_register_bucket_with_retry",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("registration must not run without control-account metadata")
+        ),
+    )
+
+    warnings = acl.apply_acl(
+        stack,
+        acl.AclDiff(buckets_to_add=["bucket-a"]),
+        _empty_current_state(),
+    )
+
+    assert direct_adds == []
+    assert len(warnings) == 1
+    assert "control account metadata is required" in warnings[0]
+    assert "--no-preflight" in warnings[0]
+
+
+def test_register_bucket_with_retry_uses_shared_preparation(monkeypatch) -> None:
+    from quiltx import bucket as bucket_lib
+
+    s3_client = object()
+    sns_client = object()
+    sqs_client = object()
+    lambda_client = object()
+    plan = SimpleNamespace(
+        sns_topic_arn="arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    )
+    calls: list[tuple[Any, ...]] = []
+
+    class Session:
+        def client(self, service: str, region_name: str | None = None):
+            if service == "sns":
+                assert region_name == "us-west-2"
+                return sns_client
+            if service == "sqs":
+                assert region_name == "us-west-2"
+                return sqs_client
+            if service == "lambda":
+                assert region_name == "us-west-2"
+                return lambda_client
+            if service == "sts":
+                return SimpleNamespace(
+                    get_caller_identity=lambda: {"Account": "111122223333"}
+                )
+            raise AssertionError(f"unexpected service {service}")
+
+    def build_plan(*args, **kwargs):
+        calls.append(
+            (
+                "plan",
+                args,
+                kwargs["control_account_id"],
+                kwargs["s3_client"],
+                kwargs["sns_client"],
+                kwargs["sqs_client"],
+                kwargs["lambda_client"],
+            )
+        )
+        return plan
+
+    monkeypatch.setattr(
+        bucket_lib,
+        "resolve_bucket_session",
+        lambda *args, **kwargs: (Session(), s3_client, "us-west-2", "prod"),
+    )
+    monkeypatch.setattr(bucket_lib, "build_bucket_preparation_plan", build_plan)
+    monkeypatch.setattr(
+        bucket_lib,
+        "apply_bucket_preparation",
+        lambda candidate, **kwargs: calls.append(
+            (
+                "apply",
+                candidate,
+                kwargs["s3_client"],
+                kwargs["sns_client"],
+                kwargs["sqs_client"],
+                kwargs["lambda_client"],
+            )
+        ),
+    )
+    stack = _fake_stack(
+        buckets=SimpleNamespace(add=lambda **kwargs: calls.append(("add", kwargs)))
+    )
+
+    acl._register_bucket_with_retry(stack, "bucket-a", "123456789012", assume_yes=True)
+
+    assert calls == [
+        (
+            "plan",
+            ("bucket-a", "us-west-2", "111122223333"),
+            "123456789012",
+            s3_client,
+            sns_client,
+            sqs_client,
+            lambda_client,
+        ),
+        ("apply", plan, s3_client, sns_client, sqs_client, lambda_client),
+        (
+            "add",
+            {
+                "name": "bucket-a",
+                "title": "bucket-a",
+                "sns_notification_arn": plan.sns_topic_arn,
+            },
+        ),
     ]
 
 

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -6,7 +6,7 @@ import contextlib
 import hashlib
 import json
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -328,63 +328,37 @@ def test_configure_sns_topic_policy_creates_or_merges() -> None:
 def test_configure_notifications_merges() -> None:
     client = _client("s3")
     stubber = Stubber(client)
+    existing = {
+        "LambdaFunctionConfigurations": [
+            {
+                "Id": "lambda",
+                "LambdaFunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:f",
+                "Events": ["s3:ReducedRedundancyLostObject"],
+            }
+        ],
+        "QueueConfigurations": [
+            {
+                "Id": "queue",
+                "QueueArn": "arn:aws:sqs:us-east-1:123456789012:q",
+                "Events": ["s3:ObjectRestore:Completed"],
+            }
+        ],
+    }
+    topic_arn = "arn:aws:sns:us-east-1:123456789012:topic"
+    expected = bucket_lib.build_bucket_notification_configuration(existing, topic_arn)
     stubber.add_response(
         "get_bucket_notification_configuration",
-        {
-            "LambdaFunctionConfigurations": [
-                {
-                    "Id": "lambda",
-                    "LambdaFunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:f",
-                    "Events": ["s3:ObjectCreated:*"],
-                }
-            ],
-            "QueueConfigurations": [
-                {
-                    "Id": "queue",
-                    "QueueArn": "arn:aws:sqs:us-east-1:123456789012:q",
-                    "Events": ["s3:ObjectRemoved:*"],
-                }
-            ],
-        },
+        existing,
         {"Bucket": "bucket"},
     )
     stubber.add_response(
         "put_bucket_notification_configuration",
         {},
-        {
-            "Bucket": "bucket",
-            "NotificationConfiguration": {
-                "TopicConfigurations": [
-                    {
-                        "Id": "QuiltBucketNotifications",
-                        "TopicArn": "arn:aws:sns:us-east-1:123456789012:topic",
-                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
-                    }
-                ],
-                "QueueConfigurations": [
-                    {
-                        "Id": "queue",
-                        "QueueArn": "arn:aws:sqs:us-east-1:123456789012:q",
-                        "Events": ["s3:ObjectRemoved:*"],
-                    }
-                ],
-                "LambdaFunctionConfigurations": [
-                    {
-                        "Id": "lambda",
-                        "LambdaFunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:f",
-                        "Events": ["s3:ObjectCreated:*"],
-                    }
-                ],
-            },
-        },
+        {"Bucket": "bucket", "NotificationConfiguration": expected},
     )
     stubber.activate()
 
-    bucket_lib.configure_bucket_notifications(
-        "bucket",
-        "arn:aws:sns:us-east-1:123456789012:topic",
-        s3_client=client,
-    )
+    bucket_lib.configure_bucket_notifications("bucket", topic_arn, s3_client=client)
 
     stubber.deactivate()
 
@@ -719,10 +693,21 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
         {"EventBridgeConfiguration": {}},
         {"Bucket": bucket},
     )
+    # Recheck immediately before each write.
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(existing_bucket_policy)},
+        {"Bucket": bucket},
+    )
     s3_stubber.add_response(
         "put_bucket_policy",
         {},
         {"Bucket": bucket, "Policy": json.dumps(final_bucket_policy)},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {"EventBridgeConfiguration": {}},
+        {"Bucket": bucket},
     )
     s3_stubber.add_response(
         "put_bucket_notification_configuration",
@@ -771,6 +756,20 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
         "create_topic",
         {"TopicArn": topic_arn},
         {"Name": "quilt-bucket-notifications"},
+    )
+    # Recheck the just-created topic still carries only the default owner policy.
+    sns_stubber.add_response(
+        "get_topic_attributes",
+        {
+            "Attributes": {
+                "Policy": json.dumps(
+                    bucket_lib._build_default_sns_owner_policy(
+                        topic_arn, owning_account
+                    )
+                )
+            }
+        },
+        {"TopicArn": topic_arn},
     )
     sns_stubber.add_response(
         "set_topic_attributes",
@@ -906,10 +905,14 @@ class FakeBucket:
 
 
 class FakeSession:
-    def __init__(self, s3_client, sns_client, sts_client) -> None:
+    def __init__(
+        self, s3_client, sns_client, sts_client, sqs_client=None, lambda_client=None
+    ) -> None:
         self._s3_client = s3_client
         self._sns_client = sns_client
         self._sts_client = sts_client
+        self._sqs_client = sqs_client
+        self._lambda_client = lambda_client
         self.profile_name = None
 
     def client(self, service_name: str, region_name: str | None = None):
@@ -918,6 +921,12 @@ class FakeSession:
         if service_name == "sns":
             assert region_name == "us-west-2"
             return self._sns_client
+        if service_name == "sqs":
+            assert region_name == "us-west-2"
+            return self._sqs_client if self._sqs_client is not None else object()
+        if service_name == "lambda":
+            assert region_name == "us-west-2"
+            return self._lambda_client if self._lambda_client is not None else object()
         if service_name == "sts":
             return self._sts_client
         raise AssertionError(f"unexpected service: {service_name}")
@@ -1095,7 +1104,7 @@ def test_prepare_json_default_profile_fallback_keeps_json_stdout(
         def client(self, service: str, region_name: str | None = None):
             if service == "s3":
                 return FakeS3(self.profile_name)
-            if service == "sns":
+            if service in {"sns", "sqs", "lambda"}:
                 assert region_name == "us-west-2"
                 return object()
             raise AssertionError(f"unexpected service {service}")
@@ -1203,6 +1212,15 @@ def test_add_dry_run(monkeypatch, capsys) -> None:
 
     sns_client = _client("sns", region_name="us-west-2")
     sns_stubber = Stubber(sns_client)
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        expected_params={
+            "TopicArn": (
+                "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+            )
+        },
+    )
     sns_stubber.activate()
 
     sts_client = _client("sts", region_name="us-west-2")
@@ -1256,11 +1274,12 @@ def test_add_dry_run(monkeypatch, capsys) -> None:
     assert "us-west-2" in captured.out
     assert "AWS profile <default>" in captured.out
     assert "create SNS topic" in captured.out
-    assert "Planned bucket policy:" in captured.out
+    assert "Final bucket policy:" in captured.out
     assert (
         "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications" in captured.out
     )
-    assert "Planned SNS topic policy statement:" in captured.out
+    assert "Final SNS topic policy:" in captured.out
+    assert "Final bucket notification configuration:" in captured.out
 
     s3_stubber.assert_no_pending_responses()
     sns_stubber.assert_no_pending_responses()
@@ -1268,6 +1287,66 @@ def test_add_dry_run(monkeypatch, capsys) -> None:
     s3_stubber.deactivate()
     sns_stubber.deactivate()
     sts_stubber.deactivate()
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_result"),
+    [(["--dry-run"], 0), ([], 1)],
+    ids=["dry-run", "declined"],
+)
+def test_add_force_does_not_remove_before_execution(
+    monkeypatch, extra_args, expected_result
+) -> None:
+    calls: list[tuple[str, str]] = []
+    buckets = SimpleNamespace(
+        get=lambda name: FakeBucket(name, "Existing Title"),
+        remove=lambda name: calls.append(("remove", name)),
+        add=lambda **kwargs: calls.append(("add", kwargs["name"])),
+    )
+    stack = make_fake_catalog(
+        "demo",
+        payload={"account_id": "123456789012", "region": "us-east-1"},
+        buckets=buckets,
+    )
+    session = SimpleNamespace(client=lambda service, region_name=None: object())
+    plan = _fake_bucket_preparation_plan()
+
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "resolve_catalog_context",
+        lambda _catalog=None, **kwargs: stack,
+    )
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "load_stack_payload",
+        lambda catalog_name: {"account_id": "123456789012", "region": "us-east-1"},
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "resolve_bucket_session",
+        lambda *args, **kwargs: (session, object(), plan.region, None),
+    )
+    monkeypatch.setattr(
+        bucket_tool, "_get_session_account_id", lambda _session: plan.owning_account
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "build_bucket_preparation_plan",
+        lambda *args, **kwargs: plan,
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run or declined confirmation must not apply")
+        ),
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    result = bucket_tool.main(["add", "bucket", "--force", "--no-test", *extra_args])
+
+    assert result == expected_result
+    assert calls == []
 
 
 def test_add_already_registered_reapplies_plumbing(monkeypatch, capsys) -> None:
@@ -1515,77 +1594,50 @@ def test_bucket_add_union_error_messages(typename, message, expected) -> None:
 
 
 def _stub_s3_for_full_add():
-    """S3 stubs covering get_location, policy read/write, notification read/write."""
+    """S3 stubs for planning, revalidation, and applying a registered bucket."""
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    bucket_policy = {"Version": "2012-10-17", "Statement": []}
+    notifications = {
+        "TopicConfigurations": [
+            {
+                "Id": "QuiltBucketNotifications",
+                "TopicArn": topic_arn,
+                "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+            }
+        ]
+    }
+    final_policy = bucket_lib.merge_bucket_policy(
+        bucket_policy,
+        bucket_lib.build_quilt_policy_statement("bucket", "123456789012"),
+    )
     s3_stubber.add_response(
         "get_bucket_location",
         {"LocationConstraint": "us-west-2"},
         {"Bucket": "bucket"},
     )
+    for _ in range(2):
+        s3_stubber.add_response(
+            "get_bucket_policy",
+            {"Policy": json.dumps(bucket_policy)},
+            {"Bucket": "bucket"},
+        )
+        s3_stubber.add_response(
+            "get_bucket_notification_configuration",
+            notifications,
+            {"Bucket": "bucket"},
+        )
+    # Recheck immediately before the bucket-policy write.
     s3_stubber.add_response(
         "get_bucket_policy",
-        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {
-            "TopicConfigurations": [
-                {
-                    "Id": "existing",
-                    "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
-                    "Events": ["s3:ObjectCreated:*"],
-                }
-            ]
-        },
+        {"Policy": json.dumps(bucket_policy)},
         {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
         "put_bucket_policy",
         {},
-        {
-            "Bucket": "bucket",
-            "Policy": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        bucket_lib.build_quilt_policy_statement(
-                            "bucket", "123456789012"
-                        )
-                    ],
-                }
-            ),
-        },
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {
-            "TopicConfigurations": [
-                {
-                    "Id": "existing",
-                    "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
-                    "Events": ["s3:ObjectCreated:*"],
-                }
-            ]
-        },
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "put_bucket_notification_configuration",
-        {},
-        {
-            "Bucket": "bucket",
-            "NotificationConfiguration": {
-                "TopicConfigurations": [
-                    {
-                        "Id": "QuiltBucketNotifications",
-                        "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
-                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
-                    }
-                ]
-            },
-        },
+        {"Bucket": "bucket", "Policy": json.dumps(final_policy)},
     )
     s3_stubber.activate()
     return s3_client, s3_stubber
@@ -1594,46 +1646,27 @@ def _stub_s3_for_full_add():
 def _stub_sns_for_existing_topic():
     sns_client = _client("sns", region_name="us-west-2")
     sns_stubber = Stubber(sns_client)
-    topic_arn = "arn:aws:sns:us-west-2:111122223333:existing"
-    sns_stubber.add_response(
-        "get_topic_attributes",
-        {"Attributes": {}},
-        {"TopicArn": topic_arn},
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    final_policy = bucket_lib.build_sns_topic_policy(
+        None,
+        "bucket",
+        topic_arn,
+        "111122223333",
+        ["arn:aws:iam::123456789012:root"],
     )
+    for _ in range(3):
+        sns_stubber.add_response(
+            "get_topic_attributes",
+            {"Attributes": {}},
+            {"TopicArn": topic_arn},
+        )
     sns_stubber.add_response(
         "set_topic_attributes",
         {},
         {
             "TopicArn": topic_arn,
             "AttributeName": "Policy",
-            "AttributeValue": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "QuiltBucketNotifications",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "s3.amazonaws.com"},
-                            "Action": "sns:Publish",
-                            "Resource": topic_arn,
-                            "Condition": {
-                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
-                                "StringEquals": {"aws:SourceAccount": "111122223333"},
-                            },
-                        },
-                        {
-                            "Sid": "QuiltCrossAccountSNSAccess",
-                            "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-                            "Action": [
-                                "sns:GetTopicAttributes",
-                                "sns:Subscribe",
-                            ],
-                            "Resource": topic_arn,
-                        },
-                    ],
-                }
-            ),
+            "AttributeValue": json.dumps(final_policy),
         },
     )
     sns_stubber.activate()
@@ -1726,7 +1759,7 @@ def test_add_no_stack_cache_auto_discovers(monkeypatch, capsys) -> None:
     assert "Discovering stack" in captured.out
 
 
-def test_add_reuses_existing_sns(monkeypatch) -> None:
+def test_add_rejects_unrelated_existing_sns(monkeypatch, capsys) -> None:
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
     s3_stubber.add_response(
@@ -1752,98 +1785,10 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
         },
         {"Bucket": "bucket"},
     )
-    s3_stubber.add_response(
-        "put_bucket_policy",
-        {},
-        {
-            "Bucket": "bucket",
-            "Policy": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        bucket_lib.build_quilt_policy_statement(
-                            "bucket", "123456789012"
-                        )
-                    ],
-                }
-            ),
-        },
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {
-            "TopicConfigurations": [
-                {
-                    "Id": "existing",
-                    "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
-                    "Events": ["s3:ObjectCreated:*"],
-                }
-            ]
-        },
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "put_bucket_notification_configuration",
-        {},
-        {
-            "Bucket": "bucket",
-            "NotificationConfiguration": {
-                "TopicConfigurations": [
-                    {
-                        "Id": "QuiltBucketNotifications",
-                        "TopicArn": "arn:aws:sns:us-west-2:111122223333:existing",
-                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
-                    }
-                ]
-            },
-        },
-    )
     s3_stubber.activate()
 
     sns_client = _client("sns", region_name="us-west-2")
     sns_stubber = Stubber(sns_client)
-    topic_arn = "arn:aws:sns:us-west-2:111122223333:existing"
-    sns_stubber.add_response(
-        "get_topic_attributes",
-        {"Attributes": {}},
-        {"TopicArn": topic_arn},
-    )
-    sns_stubber.add_response(
-        "set_topic_attributes",
-        {},
-        {
-            "TopicArn": topic_arn,
-            "AttributeName": "Policy",
-            "AttributeValue": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "QuiltBucketNotifications",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "s3.amazonaws.com"},
-                            "Action": "sns:Publish",
-                            "Resource": topic_arn,
-                            "Condition": {
-                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
-                                "StringEquals": {"aws:SourceAccount": "111122223333"},
-                            },
-                        },
-                        {
-                            "Sid": "QuiltCrossAccountSNSAccess",
-                            "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-                            "Action": [
-                                "sns:GetTopicAttributes",
-                                "sns:Subscribe",
-                            ],
-                            "Resource": topic_arn,
-                        },
-                    ],
-                }
-            ),
-        },
-    )
     sns_stubber.activate()
 
     sts_client = _client("sts")
@@ -1881,14 +1826,9 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
         },
     )
 
-    assert bucket_tool.main(["add", "bucket", "--title", "Demo Bucket", "--yes"]) == 0
-    assert add_calls == [
-        {
-            "name": "bucket",
-            "title": "Demo Bucket",
-            "sns_notification_arn": "arn:aws:sns:us-west-2:111122223333:existing",
-        }
-    ]
+    assert bucket_tool.main(["add", "bucket", "--title", "Demo Bucket", "--yes"]) == 1
+    assert "overlaps Quilt's unfiltered" in capsys.readouterr().err
+    assert add_calls == []
 
     s3_stubber.assert_no_pending_responses()
     sns_stubber.assert_no_pending_responses()
@@ -1899,6 +1839,23 @@ def test_add_reuses_existing_sns(monkeypatch) -> None:
 
 
 def test_add_creates_sns(monkeypatch) -> None:
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    bucket_policy = {"Version": "2012-10-17", "Statement": []}
+    final_bucket_policy = bucket_lib.merge_bucket_policy(
+        bucket_policy,
+        bucket_lib.build_quilt_policy_statement("bucket", "123456789012"),
+    )
+    final_notifications = bucket_lib.build_bucket_notification_configuration(
+        {}, topic_arn
+    )
+    final_sns_policy = bucket_lib.build_sns_topic_policy(
+        None,
+        "bucket",
+        topic_arn,
+        "111122223333",
+        ["arn:aws:iam::123456789012:root"],
+    )
+
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
     s3_stubber.add_response(
@@ -1906,67 +1863,61 @@ def test_add_creates_sns(monkeypatch) -> None:
         {"LocationConstraint": "us-west-2"},
         {"Bucket": "bucket"},
     )
+    for _ in range(2):
+        s3_stubber.add_response(
+            "get_bucket_policy",
+            {"Policy": json.dumps(bucket_policy)},
+            {"Bucket": "bucket"},
+        )
+        s3_stubber.add_response(
+            "get_bucket_notification_configuration", {}, {"Bucket": "bucket"}
+        )
+    # Recheck immediately before each write.
     s3_stubber.add_response(
         "get_bucket_policy",
-        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {},
+        {"Policy": json.dumps(bucket_policy)},
         {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
         "put_bucket_policy",
         {},
-        {
-            "Bucket": "bucket",
-            "Policy": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        bucket_lib.build_quilt_policy_statement(
-                            "bucket", "123456789012"
-                        )
-                    ],
-                }
-            ),
-        },
+        {"Bucket": "bucket", "Policy": json.dumps(final_bucket_policy)},
     )
     s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {},
-        {"Bucket": "bucket"},
+        "get_bucket_notification_configuration", {}, {"Bucket": "bucket"}
     )
     s3_stubber.add_response(
         "put_bucket_notification_configuration",
         {},
-        {
-            "Bucket": "bucket",
-            "NotificationConfiguration": {
-                "TopicConfigurations": [
-                    {
-                        "Id": "QuiltBucketNotifications",
-                        "TopicArn": "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications",
-                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
-                    }
-                ]
-            },
-        },
+        {"Bucket": "bucket", "NotificationConfiguration": final_notifications},
     )
     s3_stubber.activate()
 
     sns_client = _client("sns", region_name="us-west-2")
     sns_stubber = Stubber(sns_client)
-    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    for _ in range(2):
+        sns_stubber.add_client_error(
+            "get_topic_attributes",
+            service_error_code="NotFound",
+            expected_params={"TopicArn": topic_arn},
+        )
     sns_stubber.add_response(
         "create_topic",
         {"TopicArn": topic_arn},
         {"Name": "quilt-bucket-notifications"},
     )
+    # Recheck the just-created topic still carries only the default owner policy.
     sns_stubber.add_response(
         "get_topic_attributes",
-        {"Attributes": {}},
+        {
+            "Attributes": {
+                "Policy": json.dumps(
+                    bucket_lib._build_default_sns_owner_policy(
+                        topic_arn, "111122223333"
+                    )
+                )
+            }
+        },
         {"TopicArn": topic_arn},
     )
     sns_stubber.add_response(
@@ -1975,34 +1926,7 @@ def test_add_creates_sns(monkeypatch) -> None:
         {
             "TopicArn": topic_arn,
             "AttributeName": "Policy",
-            "AttributeValue": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "QuiltBucketNotifications",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "s3.amazonaws.com"},
-                            "Action": "sns:Publish",
-                            "Resource": topic_arn,
-                            "Condition": {
-                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
-                                "StringEquals": {"aws:SourceAccount": "111122223333"},
-                            },
-                        },
-                        {
-                            "Sid": "QuiltCrossAccountSNSAccess",
-                            "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-                            "Action": [
-                                "sns:GetTopicAttributes",
-                                "sns:Subscribe",
-                            ],
-                            "Resource": topic_arn,
-                        },
-                    ],
-                }
-            ),
+            "AttributeValue": json.dumps(final_sns_policy),
         },
     )
     sns_stubber.activate()
@@ -2112,8 +2036,9 @@ def test_build_parser_uses_bucket_prog() -> None:
         parser.parse_args(["add", "--help"])
 
 
-def test_confirm_bucket_add_renders_context_table(monkeypatch, capsys) -> None:
+def test_confirm_bucket_add_renders_existing_topic_context(monkeypatch, capsys) -> None:
     monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+    plan = replace(_fake_bucket_preparation_plan(), topic_exists=True)
 
     assert bucket_tool._confirm_bucket_add(
         "demo",
@@ -2123,11 +2048,8 @@ def test_confirm_bucket_add_renders_context_table(monkeypatch, capsys) -> None:
         ["arn:aws:iam::123456789012:role/quilt-registry"],
         "--principal",
         "us-east-1",
-        "bucket",
-        "us-west-2",
-        "111122223333",
         "open",
-        "arn:aws:sns:us-west-2:111122223333:existing",
+        plan,
     )
 
     captured = capsys.readouterr()
@@ -2135,8 +2057,31 @@ def test_confirm_bucket_add_renders_context_table(monkeypatch, capsys) -> None:
     assert "arn:aws:iam::123456789012:role/quilt-registry" in captured.out
     assert "--principal" in captured.out
     assert "s3://bucket" in captured.out
-    assert "reuse existing SNS topic" in captured.out
+    assert "reuse quiltx SNS topic" in captured.out
+    assert "quilt-bucket-notifications" in captured.out
     assert "AWS profile open" in captured.out
+
+
+def test_confirm_bucket_add_renders_planned_topic_creation(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    plan = _fake_bucket_preparation_plan()
+
+    assert not bucket_tool._confirm_bucket_add(
+        "demo",
+        "https://demo.example.com",
+        None,
+        "123456789012",
+        list(plan.principals),
+        "account root (default)",
+        "us-east-1",
+        None,
+        plan,
+    )
+
+    output = capsys.readouterr().out
+    assert "create SNS topic" in output
+    assert plan.sns_topic_arn in output
+    assert "reuse existing SNS topic" not in output
 
 
 def test_sns_topic_source_labels_known_topic_names() -> None:
@@ -2202,20 +2147,75 @@ def _stack_for_add_bucket(
     return stack
 
 
-def test_add_bucket_already_registered(monkeypatch) -> None:
+def _install_add_bucket_preparation_fakes(
+    monkeypatch, plan: bucket_lib.BucketPreparationPlan
+) -> list[bucket_lib.BucketPreparationPlan]:
+    s3_client = object()
+    sns_client = object()
+    sts_client = SimpleNamespace(
+        get_caller_identity=lambda: {"Account": plan.owning_account}
+    )
+    session = FakeSession(s3_client, sns_client, sts_client)
+    applied: list[bucket_lib.BucketPreparationPlan] = []
+
+    monkeypatch.setattr(boto3, "Session", lambda profile_name=None: session)
+    monkeypatch.setattr(
+        bucket_lib, "get_bucket_region", lambda bucket, *, s3_client: plan.region
+    )
+    monkeypatch.setattr(
+        bucket_lib,
+        "build_bucket_preparation_plan",
+        lambda *args, **kwargs: plan,
+    )
+    monkeypatch.setattr(
+        bucket_lib,
+        "apply_bucket_preparation",
+        lambda candidate, **kwargs: applied.append(candidate),
+    )
+    return applied
+
+
+def test_add_bucket_already_registered_still_prepares(monkeypatch) -> None:
+    plan = _fake_bucket_preparation_plan()
+    applied = _install_add_bucket_preparation_fakes(monkeypatch, plan)
     stack = _stack_for_add_bucket(monkeypatch)
-    _install_fake_quilt3(monkeypatch, get_result=FakeBucket("bucket", "My Bucket"))
+    add_calls: list[dict[str, str]] = []
+    _install_fake_quilt3(
+        monkeypatch,
+        get_result=FakeBucket("bucket", "My Bucket"),
+        add_calls=add_calls,
+    )
 
     result = add_bucket(stack, "bucket")
+
     assert result == AddBucketResult(
         bucket="bucket",
         title="My Bucket",
-        sns_topic_arn="",
+        sns_topic_arn=plan.sns_topic_arn,
         already_registered=True,
     )
+    assert applied == [plan]
+    assert add_calls == []
 
 
 def test_add_bucket_creates_new(monkeypatch) -> None:
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    bucket_policy = {"Version": "2012-10-17", "Statement": []}
+    final_bucket_policy = bucket_lib.merge_bucket_policy(
+        bucket_policy,
+        bucket_lib.build_quilt_policy_statement("bucket", "123456789012"),
+    )
+    final_notifications = bucket_lib.build_bucket_notification_configuration(
+        {}, topic_arn
+    )
+    final_sns_policy = bucket_lib.build_sns_topic_policy(
+        None,
+        "bucket",
+        topic_arn,
+        "111122223333",
+        ["arn:aws:iam::123456789012:root"],
+    )
+
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
     s3_stubber.add_response(
@@ -2223,67 +2223,61 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
         {"LocationConstraint": "us-west-2"},
         {"Bucket": "bucket"},
     )
+    for _ in range(2):
+        s3_stubber.add_response(
+            "get_bucket_policy",
+            {"Policy": json.dumps(bucket_policy)},
+            {"Bucket": "bucket"},
+        )
+        s3_stubber.add_response(
+            "get_bucket_notification_configuration", {}, {"Bucket": "bucket"}
+        )
+    # Recheck immediately before each write.
     s3_stubber.add_response(
         "get_bucket_policy",
-        {"Policy": json.dumps({"Version": "2012-10-17", "Statement": []})},
+        {"Policy": json.dumps(bucket_policy)},
         {"Bucket": "bucket"},
     )
     s3_stubber.add_response(
         "put_bucket_policy",
         {},
-        {
-            "Bucket": "bucket",
-            "Policy": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        bucket_lib.build_quilt_policy_statement(
-                            "bucket", "123456789012"
-                        )
-                    ],
-                }
-            ),
-        },
+        {"Bucket": "bucket", "Policy": json.dumps(final_bucket_policy)},
     )
     s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {},
-        {"Bucket": "bucket"},
-    )
-    s3_stubber.add_response(
-        "get_bucket_notification_configuration",
-        {},
-        {"Bucket": "bucket"},
+        "get_bucket_notification_configuration", {}, {"Bucket": "bucket"}
     )
     s3_stubber.add_response(
         "put_bucket_notification_configuration",
         {},
-        {
-            "Bucket": "bucket",
-            "NotificationConfiguration": {
-                "TopicConfigurations": [
-                    {
-                        "Id": "QuiltBucketNotifications",
-                        "TopicArn": "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications",
-                        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
-                    }
-                ]
-            },
-        },
+        {"Bucket": "bucket", "NotificationConfiguration": final_notifications},
     )
     s3_stubber.activate()
 
     sns_client = _client("sns", region_name="us-west-2")
     sns_stubber = Stubber(sns_client)
-    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    for _ in range(2):
+        sns_stubber.add_client_error(
+            "get_topic_attributes",
+            service_error_code="NotFound",
+            expected_params={"TopicArn": topic_arn},
+        )
     sns_stubber.add_response(
         "create_topic",
         {"TopicArn": topic_arn},
         {"Name": "quilt-bucket-notifications"},
     )
+    # Recheck the just-created topic still carries only the default owner policy.
     sns_stubber.add_response(
         "get_topic_attributes",
-        {"Attributes": {}},
+        {
+            "Attributes": {
+                "Policy": json.dumps(
+                    bucket_lib._build_default_sns_owner_policy(
+                        topic_arn, "111122223333"
+                    )
+                )
+            }
+        },
         {"TopicArn": topic_arn},
     )
     sns_stubber.add_response(
@@ -2292,34 +2286,7 @@ def test_add_bucket_creates_new(monkeypatch) -> None:
         {
             "TopicArn": topic_arn,
             "AttributeName": "Policy",
-            "AttributeValue": json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Sid": "QuiltBucketNotifications",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "s3.amazonaws.com"},
-                            "Action": "sns:Publish",
-                            "Resource": topic_arn,
-                            "Condition": {
-                                "ArnEquals": {"aws:SourceArn": "arn:aws:s3:::bucket"},
-                                "StringEquals": {"aws:SourceAccount": "111122223333"},
-                            },
-                        },
-                        {
-                            "Sid": "QuiltCrossAccountSNSAccess",
-                            "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
-                            "Action": [
-                                "sns:GetTopicAttributes",
-                                "sns:Subscribe",
-                            ],
-                            "Resource": topic_arn,
-                        },
-                    ],
-                }
-            ),
+            "AttributeValue": json.dumps(final_sns_policy),
         },
     )
     sns_stubber.activate()
@@ -2382,12 +2349,24 @@ def test_add_bucket_no_stack_payload(monkeypatch) -> None:
 
 
 def test_add_bucket_defaults_title_to_bucket_name(monkeypatch) -> None:
+    plan = replace(_fake_bucket_preparation_plan(), bucket="my-data")
+    applied = _install_add_bucket_preparation_fakes(monkeypatch, plan)
     stack = _stack_for_add_bucket(monkeypatch)
-    _install_fake_quilt3(monkeypatch, get_result=FakeBucket("my-data", "my-data"))
+    add_calls: list[dict[str, str]] = []
+    _install_fake_quilt3(monkeypatch, add_calls=add_calls)
 
     result = add_bucket(stack, "my-data")
+
     assert result.title == "my-data"
-    assert result.already_registered is True
+    assert result.already_registered is False
+    assert applied == [plan]
+    assert add_calls == [
+        {
+            "name": "my-data",
+            "title": "my-data",
+            "sns_notification_arn": plan.sns_topic_arn,
+        }
+    ]
 
 
 # -- Tests for --principal --

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import contextlib
+import hashlib
+import json
 import sys
 from dataclasses import dataclass
 from types import ModuleType, SimpleNamespace
@@ -216,6 +217,52 @@ def test_ensure_sns_topic_fails_hard() -> None:
         stubber.deactivate()
 
 
+def test_sns_topic_name_normalizes_dotted_bucket_with_collision_hash() -> None:
+    dotted_bucket = "example.data.bucket"
+    first = bucket_lib._sns_topic_name(dotted_bucket)
+    digest = hashlib.sha256(dotted_bucket.encode()).hexdigest()[:12]
+    adversarial = bucket_lib._sns_topic_name(f"example-data-bucket-{digest}")
+
+    assert "." not in first
+    assert first.startswith("quilt-x_example-data-bucket-")
+    assert first.endswith("-notifications")
+    assert len(first) <= 256
+    assert first != adversarial
+
+
+def test_build_sns_topic_policy_preserves_owner_access() -> None:
+    topic_arn = "arn:aws:sns:us-east-1:111122223333:topic"
+
+    policy = bucket_lib.build_sns_topic_policy(
+        None,
+        "bucket",
+        topic_arn,
+        "111122223333",
+        ["arn:aws:iam::123456789012:root"],
+    )
+
+    owner_statement = policy["Statement"][0]
+    assert owner_statement["Sid"] == "__default_statement_ID"
+    assert owner_statement["Action"] == [
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission",
+        "SNS:DeleteTopic",
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic",
+        "SNS:Publish",
+    ]
+    assert owner_statement["Condition"] == {
+        "StringEquals": {"AWS:SourceOwner": "111122223333"}
+    }
+    assert [statement["Sid"] for statement in policy["Statement"]] == [
+        "__default_statement_ID",
+        "QuiltBucketNotifications",
+        "QuiltCrossAccountSNSAccess",
+    ]
+
+
 def test_configure_sns_topic_policy_creates_or_merges() -> None:
     client = _client("sns")
     stubber = Stubber(client)
@@ -342,6 +389,371 @@ def test_configure_notifications_merges() -> None:
     stubber.deactivate()
 
 
+def test_build_prepare_notifications_preserves_compatible_destinations() -> None:
+    existing = {
+        "TopicConfigurations": [
+            {
+                "Id": "archive-topic",
+                "TopicArn": "arn:aws:sns:us-east-1:111122223333:archive",
+                "Events": ["s3:ObjectRestore:Completed"],
+            }
+        ],
+        "QueueConfigurations": [
+            {
+                "Id": "archive-queue",
+                "QueueArn": "arn:aws:sqs:us-east-1:111122223333:archive",
+                "Events": ["s3:ObjectRestore:Delete"],
+            }
+        ],
+        "LambdaFunctionConfigurations": [
+            {
+                "Id": "archive-lambda",
+                "LambdaFunctionArn": (
+                    "arn:aws:lambda:us-east-1:111122223333:function:archive"
+                ),
+                "Events": ["s3:ReducedRedundancyLostObject"],
+            }
+        ],
+        "EventBridgeConfiguration": {},
+    }
+    topic_arn = "arn:aws:sns:us-east-1:111122223333:quilt-bucket-notifications"
+
+    result = bucket_lib.build_bucket_notification_configuration(existing, topic_arn)
+
+    assert result["TopicConfigurations"][:-1] == existing["TopicConfigurations"]
+    assert result["TopicConfigurations"][-1] == {
+        "Id": "QuiltBucketNotifications",
+        "TopicArn": topic_arn,
+        "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+    }
+    assert result["QueueConfigurations"] == existing["QueueConfigurations"]
+    assert (
+        result["LambdaFunctionConfigurations"]
+        == existing["LambdaFunctionConfigurations"]
+    )
+    assert result["EventBridgeConfiguration"] == {}
+
+
+@pytest.mark.parametrize(
+    ("key", "arn_key", "arn"),
+    [
+        (
+            "TopicConfigurations",
+            "TopicArn",
+            "arn:aws:sns:us-east-1:111122223333:other",
+        ),
+        (
+            "QueueConfigurations",
+            "QueueArn",
+            "arn:aws:sqs:us-east-1:111122223333:queue",
+        ),
+        (
+            "LambdaFunctionConfigurations",
+            "LambdaFunctionArn",
+            "arn:aws:lambda:us-east-1:111122223333:function:handler",
+        ),
+    ],
+)
+def test_build_prepare_notifications_rejects_object_event_overlap(
+    key: str, arn_key: str, arn: str
+) -> None:
+    existing = {
+        key: [
+            {
+                "Id": "existing",
+                arn_key: arn,
+                "Events": ["s3:ObjectCreated:Put"],
+                "Filter": {
+                    "Key": {"FilterRules": [{"Name": "prefix", "Value": "uploads/"}]}
+                },
+            }
+        ]
+    }
+
+    with pytest.raises(bucket_lib.NotificationConflictError) as exc_info:
+        bucket_lib.build_bucket_notification_configuration(
+            existing,
+            "arn:aws:sns:us-east-1:111122223333:quilt-bucket-notifications",
+        )
+
+    message = str(exc_info.value)
+    assert "overlaps" in message
+    assert "remove or narrow" in message
+    assert "uploads/" in message
+
+
+def test_prepare_plan_rejects_unrelated_object_topic_instead_of_adopting() -> None:
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_client_error(
+        "get_bucket_policy",
+        service_error_code="NoSuchBucketPolicy",
+        expected_params={"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {
+            "TopicConfigurations": [
+                {
+                    "Id": "audit",
+                    "TopicArn": "arn:aws:sns:us-west-2:111122223333:audit",
+                    "Events": ["s3:ObjectCreated:Put"],
+                }
+            ]
+        },
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.activate()
+
+    with pytest.raises(bucket_lib.NotificationConflictError, match="audit"):
+        bucket_lib.build_bucket_preparation_plan(
+            "bucket",
+            "us-west-2",
+            "111122223333",
+            control_account_id="123456789012",
+            s3_client=s3_client,
+            sns_client=sns_client,
+        )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
+def test_prepare_plan_rejects_stale_quilt_topic_before_writes() -> None:
+    stale_topic = "arn:aws:sns:us-west-2:111122223333:deleted-topic"
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_client_error(
+        "get_bucket_policy",
+        service_error_code="NoSuchBucketPolicy",
+        expected_params={"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {
+            "TopicConfigurations": [
+                {
+                    "Id": "QuiltBucketNotifications",
+                    "TopicArn": stale_topic,
+                    "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+                }
+            ]
+        },
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        expected_params={"TopicArn": stale_topic},
+    )
+    sns_stubber.activate()
+
+    with pytest.raises(bucket_lib.NotificationConflictError, match="missing SNS topic"):
+        bucket_lib.build_bucket_preparation_plan(
+            "bucket",
+            "us-west-2",
+            "111122223333",
+            control_account_id="123456789012",
+            s3_client=s3_client,
+            sns_client=sns_client,
+        )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
+def test_prepare_plan_rejects_stale_preserved_topic_before_writes() -> None:
+    archive_topic = "arn:aws:sns:us-west-2:111122223333:archive"
+    planned_topic = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_client_error(
+        "get_bucket_policy",
+        service_error_code="NoSuchBucketPolicy",
+        expected_params={"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {
+            "TopicConfigurations": [
+                {
+                    "Id": "archive",
+                    "TopicArn": archive_topic,
+                    "Events": ["s3:ObjectRestore:Completed"],
+                }
+            ]
+        },
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        expected_params={"TopicArn": planned_topic},
+    )
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        expected_params={"TopicArn": archive_topic},
+    )
+    sns_stubber.activate()
+
+    with pytest.raises(bucket_lib.NotificationConflictError, match="archive"):
+        bucket_lib.build_bucket_preparation_plan(
+            "bucket",
+            "us-west-2",
+            "111122223333",
+            control_account_id="123456789012",
+            s3_client=s3_client,
+            sns_client=sns_client,
+        )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
+def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> None:
+    bucket = "bucket"
+    region = "us-west-2"
+    owning_account = "111122223333"
+    control_account = "123456789012"
+    principal = f"arn:aws:iam::{control_account}:root"
+    topic_arn = f"arn:aws:sns:{region}:{owning_account}:quilt-bucket-notifications"
+    existing_bucket_policy = {
+        "Version": "2012-10-17",
+        "Statement": [{"Sid": "Existing", "Effect": "Allow"}],
+    }
+    final_bucket_policy = bucket_lib.merge_bucket_policy(
+        existing_bucket_policy,
+        bucket_lib.build_quilt_policy_statement(
+            bucket, control_account, principals=[principal]
+        ),
+    )
+    final_sns_policy = bucket_lib.build_sns_topic_policy(
+        None, bucket, topic_arn, owning_account, [principal]
+    )
+    final_notifications = bucket_lib.build_bucket_notification_configuration(
+        {"EventBridgeConfiguration": {}}, topic_arn
+    )
+
+    s3_client = _client("s3", region_name=region)
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(existing_bucket_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {"EventBridgeConfiguration": {}},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "put_bucket_policy",
+        {},
+        {"Bucket": bucket, "Policy": json.dumps(final_bucket_policy)},
+    )
+    s3_stubber.add_response(
+        "put_bucket_notification_configuration",
+        {},
+        {"Bucket": bucket, "NotificationConfiguration": final_notifications},
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(final_bucket_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        final_notifications,
+        {"Bucket": bucket},
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name=region)
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        service_message="topic does not exist",
+        expected_params={"TopicArn": topic_arn},
+    )
+    sns_stubber.add_response(
+        "create_topic",
+        {"TopicArn": topic_arn},
+        {"Name": "quilt-bucket-notifications"},
+    )
+    sns_stubber.add_response(
+        "set_topic_attributes",
+        {},
+        {
+            "TopicArn": topic_arn,
+            "AttributeName": "Policy",
+            "AttributeValue": json.dumps(final_sns_policy),
+        },
+    )
+    sns_stubber.add_response(
+        "get_topic_attributes",
+        {"Attributes": {"Policy": json.dumps(final_sns_policy)}},
+        {"TopicArn": topic_arn},
+    )
+    sns_stubber.activate()
+
+    first = bucket_lib.build_bucket_preparation_plan(
+        bucket,
+        region,
+        owning_account,
+        control_account_id=control_account,
+        s3_client=s3_client,
+        sns_client=sns_client,
+    )
+    assert first.topic_exists is False
+    bucket_lib.apply_bucket_preparation(
+        first, s3_client=s3_client, sns_client=sns_client
+    )
+
+    second = bucket_lib.build_bucket_preparation_plan(
+        bucket,
+        region,
+        owning_account,
+        control_account_id=control_account,
+        s3_client=s3_client,
+        sns_client=sns_client,
+    )
+    assert second.topic_exists is True
+    assert second.bucket_policy_changed is False
+    assert second.sns_policy_changed is False
+    assert second.notification_configuration_changed is False
+    assert second.bucket_policy == first.bucket_policy
+    assert second.sns_policy == first.sns_policy
+    assert second.notification_configuration == first.notification_configuration
+    bucket_lib.apply_bucket_preparation(
+        second, s3_client=s3_client, sns_client=sns_client
+    )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
 @dataclass
 class FakeBucket:
     name: str
@@ -366,6 +778,217 @@ class FakeSession:
         if service_name == "sts":
             return self._sts_client
         raise AssertionError(f"unexpected service: {service_name}")
+
+
+def _fake_bucket_preparation_plan() -> bucket_lib.BucketPreparationPlan:
+    return bucket_lib.BucketPreparationPlan(
+        bucket="bucket",
+        region="us-west-2",
+        owning_account="111122223333",
+        principals=("arn:aws:iam::123456789012:root",),
+        sns_topic_arn=("arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"),
+        bucket_policy={"Version": "2012-10-17", "Statement": [{"Sid": "bucket"}]},
+        sns_policy={"Version": "2012-10-17", "Statement": [{"Sid": "sns"}]},
+        notification_configuration={"TopicConfigurations": [{"Id": "notification"}]},
+        topic_exists=False,
+        bucket_policy_changed=True,
+        sns_policy_changed=True,
+        notification_configuration_changed=True,
+    )
+
+
+def _install_prepare_fakes(monkeypatch, plan: bucket_lib.BucketPreparationPlan) -> None:
+    session = SimpleNamespace(client=lambda service_name, region_name=None: object())
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "resolve_bucket_session",
+        lambda *args, **kwargs: (session, object(), "us-west-2", None),
+    )
+    monkeypatch.setattr(
+        bucket_tool, "_get_session_account_id", lambda _session: "111122223333"
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "build_bucket_preparation_plan",
+        lambda *args, **kwargs: plan,
+    )
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "resolve_catalog_context",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("prepare must not resolve or authenticate a catalog")
+        ),
+    )
+
+
+def test_prepare_dry_run_prints_exact_documents_without_writes(
+    monkeypatch, capsys
+) -> None:
+    plan = _fake_bucket_preparation_plan()
+    _install_prepare_fakes(monkeypatch, plan)
+    documents: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        bucket_tool,
+        "_print_json",
+        lambda _console, document: documents.append(dict(document)),
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run must not write AWS state")
+        ),
+    )
+
+    result = bucket_tool.main(
+        ["prepare", "bucket", "--control-account-id", "123456789012", "--dry-run"]
+    )
+
+    assert result == 0
+    output = capsys.readouterr().out
+    assert "Final bucket policy:" in output
+    assert "Final SNS topic policy:" in output
+    assert "Final bucket notification configuration:" in output
+    assert documents == [
+        plan.bucket_policy,
+        plan.sns_policy,
+        plan.notification_configuration,
+    ]
+
+
+def test_prepare_json_is_minimal_and_uses_no_catalog(monkeypatch, capsys) -> None:
+    plan = _fake_bucket_preparation_plan()
+    _install_prepare_fakes(monkeypatch, plan)
+    applied: list[bucket_lib.BucketPreparationPlan] = []
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda candidate, **kwargs: applied.append(candidate),
+    )
+
+    result = bucket_tool.main(
+        ["prepare", "bucket", "--control-account-id", "123456789012", "--json", "--yes"]
+    )
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "bucket": "bucket",
+        "region": "us-west-2",
+        "owning_account": "111122223333",
+        "principals": ["arn:aws:iam::123456789012:root"],
+        "sns_topic_arn": (
+            "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+        ),
+    }
+    assert applied == [plan]
+
+
+def test_prepare_json_profile_failure_keeps_stdout_clean(monkeypatch, capsys) -> None:
+    seen: dict[str, Any] = {}
+
+    def fail_resolve(*args, **kwargs):
+        seen.update(kwargs)
+        print("profile cannot access bucket", file=kwargs["output"])
+        return None, None, "", "requested"
+
+    monkeypatch.setattr(bucket_tool.bucket_lib, "resolve_bucket_session", fail_resolve)
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "resolve_catalog_context",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("prepare must not resolve a catalog")
+        ),
+    )
+
+    result = bucket_tool.main(
+        [
+            "prepare",
+            "bucket",
+            "--profile",
+            "requested",
+            "--control-account-id",
+            "123456789012",
+            "--json",
+            "--yes",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert "profile cannot access bucket" in captured.err
+    assert seen["no_prompt"] is True
+    assert seen["output"] is sys.stderr
+
+
+def test_prepare_json_default_profile_fallback_keeps_json_stdout(
+    monkeypatch, capsys
+) -> None:
+    from botocore.exceptions import ClientError
+
+    plan = _fake_bucket_preparation_plan()
+
+    class FakeS3:
+        def __init__(self, profile: str) -> None:
+            self.profile = profile
+
+        def get_bucket_location(self, Bucket: str) -> dict[str, Any]:
+            if self.profile == "prod":
+                return {"LocationConstraint": "us-west-2"}
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetBucketLocation",
+            )
+
+    class FallbackSession:
+        available_profiles = ["prod"]
+
+        def __init__(self, profile_name: str | None = None) -> None:
+            self.profile_name = profile_name or ""
+
+        def client(self, service: str, region_name: str | None = None):
+            if service == "s3":
+                return FakeS3(self.profile_name)
+            if service == "sns":
+                assert region_name == "us-west-2"
+                return object()
+            raise AssertionError(f"unexpected service {service}")
+
+    monkeypatch.setattr(bucket_tool.boto3, "Session", FallbackSession)
+    monkeypatch.setattr(
+        bucket_tool, "_get_session_account_id", lambda _session: "111122223333"
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "build_bucket_preparation_plan",
+        lambda *args, **kwargs: plan,
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib, "apply_bucket_preparation", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "resolve_catalog_context",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("prepare must not resolve a catalog")
+        ),
+    )
+
+    result = bucket_tool.main(
+        [
+            "prepare",
+            "bucket",
+            "--control-account-id",
+            "123456789012",
+            "--json",
+            "--yes",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == plan.handoff()
+    assert "Retrying with profile prod." in captured.err
 
 
 class FakeQuiltBucket:
@@ -1807,6 +2430,9 @@ def test_resolve_bucket_session_switches_on_access_denied(monkeypatch, capsys) -
     assert region == "us-east-1"
     assert isinstance(session, FakeSession)
     assert session.profile_name == "prod"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Retrying with profile prod." in captured.err
 
 
 def test_resolve_bucket_session_aborts_when_user_declines(monkeypatch, capsys) -> None:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1146,6 +1146,119 @@ def test_prepare_json_default_profile_fallback_keeps_json_stdout(
     assert "Retrying with profile prod." in captured.err
 
 
+def test_prepare_requires_control_account_principal_or_catalog(capsys) -> None:
+    assert bucket_tool.main(["prepare", "bucket"]) == 1
+    assert (
+        "provide --control-account-id, --principal, or --catalog"
+        in capsys.readouterr().err
+    )
+
+
+def _install_prepare_catalog_fakes(
+    monkeypatch,
+    plan: bucket_lib.BucketPreparationPlan,
+    *,
+    payload: dict[str, Any] | None,
+    allow_auth: bool,
+) -> tuple[list[str], list[str], list[str]]:
+    """Wire prepare fakes plus a fake catalog; return (plan ids, auths, resolved)."""
+    _install_prepare_fakes(monkeypatch, plan)
+    control_ids: list[str] = []
+    auth_calls: list[str] = []
+    resolved: list[str] = []
+
+    def build_plan(*args, **kwargs):
+        control_ids.append(kwargs["control_account_id"])
+        return plan
+
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib, "build_bucket_preparation_plan", build_plan
+    )
+
+    def ensure_auth(*args, **kwargs):
+        if not allow_auth:
+            raise AssertionError("cached stack metadata must not authenticate")
+        auth_calls.append("auth")
+
+    catalog = SimpleNamespace(
+        catalog_name="open.quiltdata.com", ensure_auth=ensure_auth
+    )
+
+    def resolve_catalog_context(catalog_arg, **kwargs):
+        resolved.append(catalog_arg)
+        return catalog
+
+    monkeypatch.setattr(
+        bucket_tool.stack_lib, "resolve_catalog_context", resolve_catalog_context
+    )
+    monkeypatch.setattr(
+        bucket_tool.stack_lib,
+        "load_stack_payload",
+        lambda catalog_name: payload,
+    )
+    return control_ids, auth_calls, resolved
+
+
+def test_prepare_catalog_uses_cached_stack_metadata(monkeypatch, capsys) -> None:
+    plan = _fake_bucket_preparation_plan()
+    control_ids, _auth_calls, resolved = _install_prepare_catalog_fakes(
+        monkeypatch,
+        plan,
+        payload={"account_id": "123456789012"},
+        allow_auth=False,
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("dry-run must not write AWS state")
+        ),
+    )
+
+    result = bucket_tool.main(
+        ["prepare", "bucket", "--catalog", "open.quiltdata.com", "--dry-run"]
+    )
+
+    assert result == 0
+    assert resolved == ["open.quiltdata.com"]
+    assert control_ids == ["123456789012"]
+    assert (
+        "Control account 123456789012 from cached stack metadata"
+        in capsys.readouterr().err
+    )
+
+
+def test_prepare_catalog_falls_back_to_catalog_credentials(monkeypatch, capsys) -> None:
+    plan = _fake_bucket_preparation_plan()
+    control_ids, auth_calls, _resolved = _install_prepare_catalog_fakes(
+        monkeypatch, plan, payload=None, allow_auth=True
+    )
+    monkeypatch.setattr(
+        "quiltx.quilt3_facade.catalog_sts_account_id", lambda: "123456789012"
+    )
+    applied: list[bucket_lib.BucketPreparationPlan] = []
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda candidate, **kwargs: applied.append(candidate),
+    )
+
+    result = bucket_tool.main(
+        ["prepare", "bucket", "--catalog", "open.quiltdata.com", "--json", "--yes"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert auth_calls == ["auth"]
+    assert control_ids == ["123456789012"]
+    assert applied == [plan]
+    assert json.loads(captured.out) == plan.handoff()
+    assert (
+        "Control account 123456789012 from open.quiltdata.com catalog credentials"
+        in captured.err
+    )
+
+
 class FakeQuiltBucket:
     def __init__(self, uri: str) -> None:
         self.uri = uri

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -525,8 +525,51 @@ def test_prepare_plan_rejects_unrelated_object_topic_instead_of_adopting() -> No
     sns_stubber.deactivate()
 
 
+def test_prepare_plan_rejects_unverified_quilt_notification_topic() -> None:
+    unverified_topic = "arn:aws:sns:us-west-2:111122223333:unrelated"
+    s3_client = _client("s3", region_name="us-west-2")
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_client_error(
+        "get_bucket_policy",
+        service_error_code="NoSuchBucketPolicy",
+        expected_params={"Bucket": "bucket"},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {
+            "TopicConfigurations": [
+                {
+                    "Id": "QuiltBucketNotifications",
+                    "TopicArn": unverified_topic,
+                    "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+                }
+            ]
+        },
+        {"Bucket": "bucket"},
+    )
+    s3_stubber.activate()
+    sns_client = _client("sns", region_name="us-west-2")
+    sns_stubber = Stubber(sns_client)
+    sns_stubber.activate()
+
+    with pytest.raises(bucket_lib.NotificationConflictError, match="unverified topic"):
+        bucket_lib.build_bucket_preparation_plan(
+            "bucket",
+            "us-west-2",
+            "111122223333",
+            control_account_id="123456789012",
+            s3_client=s3_client,
+            sns_client=sns_client,
+        )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
 def test_prepare_plan_rejects_stale_quilt_topic_before_writes() -> None:
-    stale_topic = "arn:aws:sns:us-west-2:111122223333:deleted-topic"
+    stale_topic = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
     s3_client = _client("s3", region_name="us-west-2")
     s3_stubber = Stubber(s3_client)
     s3_stubber.add_client_error(
@@ -665,6 +708,17 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
         {"EventBridgeConfiguration": {}},
         {"Bucket": bucket},
     )
+    # Revalidation immediately before the first apply.
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(existing_bucket_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        {"EventBridgeConfiguration": {}},
+        {"Bucket": bucket},
+    )
     s3_stubber.add_response(
         "put_bucket_policy",
         {},
@@ -685,10 +739,28 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
         final_notifications,
         {"Bucket": bucket},
     )
+    # Revalidation before the converged no-op apply.
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(final_bucket_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration",
+        final_notifications,
+        {"Bucket": bucket},
+    )
     s3_stubber.activate()
 
     sns_client = _client("sns", region_name=region)
     sns_stubber = Stubber(sns_client)
+    sns_stubber.add_client_error(
+        "get_topic_attributes",
+        service_error_code="NotFound",
+        service_message="topic does not exist",
+        expected_params={"TopicArn": topic_arn},
+    )
+    # Revalidation confirms the planned topic is still absent.
     sns_stubber.add_client_error(
         "get_topic_attributes",
         service_error_code="NotFound",
@@ -709,6 +781,12 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
             "AttributeValue": json.dumps(final_sns_policy),
         },
     )
+    sns_stubber.add_response(
+        "get_topic_attributes",
+        {"Attributes": {"Policy": json.dumps(final_sns_policy)}},
+        {"TopicArn": topic_arn},
+    )
+    # Revalidation before the converged no-op apply.
     sns_stubber.add_response(
         "get_topic_attributes",
         {"Attributes": {"Policy": json.dumps(final_sns_policy)}},
@@ -754,6 +832,71 @@ def test_bucket_preparation_is_idempotent_across_new_and_existing_topic() -> Non
     sns_stubber.deactivate()
 
 
+def test_bucket_preparation_rejects_drift_before_any_write() -> None:
+    bucket = "bucket"
+    region = "us-west-2"
+    topic_arn = "arn:aws:sns:us-west-2:111122223333:quilt-bucket-notifications"
+    baseline_policy = {
+        "Version": "2012-10-17",
+        "Statement": [{"Sid": "Existing", "Effect": "Allow"}],
+    }
+    changed_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {"Sid": "Existing", "Effect": "Allow"},
+            {"Sid": "ConcurrentWriter", "Effect": "Deny"},
+        ],
+    }
+
+    s3_client = _client("s3", region_name=region)
+    s3_stubber = Stubber(s3_client)
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(baseline_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration", {}, {"Bucket": bucket}
+    )
+    s3_stubber.add_response(
+        "get_bucket_policy",
+        {"Policy": json.dumps(changed_policy)},
+        {"Bucket": bucket},
+    )
+    s3_stubber.add_response(
+        "get_bucket_notification_configuration", {}, {"Bucket": bucket}
+    )
+    s3_stubber.activate()
+
+    sns_client = _client("sns", region_name=region)
+    sns_stubber = Stubber(sns_client)
+    for _ in range(2):
+        sns_stubber.add_client_error(
+            "get_topic_attributes",
+            service_error_code="NotFound",
+            expected_params={"TopicArn": topic_arn},
+        )
+    sns_stubber.activate()
+
+    plan = bucket_lib.build_bucket_preparation_plan(
+        bucket,
+        region,
+        "111122223333",
+        control_account_id="123456789012",
+        s3_client=s3_client,
+        sns_client=sns_client,
+    )
+    with pytest.raises(bucket_lib.PreparationDriftError, match="bucket policy"):
+        bucket_lib.apply_bucket_preparation(
+            plan, s3_client=s3_client, sns_client=sns_client
+        )
+
+    s3_stubber.assert_no_pending_responses()
+    sns_stubber.assert_no_pending_responses()
+    s3_stubber.deactivate()
+    sns_stubber.deactivate()
+
+
 @dataclass
 class FakeBucket:
     name: str
@@ -790,6 +933,9 @@ def _fake_bucket_preparation_plan() -> bucket_lib.BucketPreparationPlan:
         bucket_policy={"Version": "2012-10-17", "Statement": [{"Sid": "bucket"}]},
         sns_policy={"Version": "2012-10-17", "Statement": [{"Sid": "sns"}]},
         notification_configuration={"TopicConfigurations": [{"Id": "notification"}]},
+        original_bucket_policy=None,
+        original_sns_policy=None,
+        original_notification_configuration={},
         topic_exists=False,
         bucket_policy_changed=True,
         sns_policy_changed=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.17.3"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- add `quiltx bucket prepare` as an AWS-only path with no catalog configuration, authentication, or admin calls
- plan and idempotently apply the final bucket policy, SNS policy, and S3 notification document
- unify `quiltx bucket add` and ACL bucket reconciliation on the same preparation planner/applicator
- preserve unrelated policies, SNS owner access, EventBridge, and compatible Topic/Queue/Lambda notifications
- reject overlapping or stale notification destinations (SNS, SQS, and Lambda) before making writes
- support control-account root or repeatable explicit role principals
- provide exact no-write `--dry-run` documents and a minimal non-secret `--json --yes` operator handoff
- document the bucket-owner prepare → catalog-operator `--no-preflight` workflow
- bump the release to 0.18.0 with dated Added/Changed changelog entries

## Safety and idempotence
- existing Quilt notifications are adopted only by the stable Quilt configuration ID
- adopting an existing topic at the canonical ARN requires a bucket-specific Quilt ownership marker in its policy
- each AWS document is re-read and compared against its plan baseline immediately before its own write; concurrent drift raises `PreparationDriftError` with zero further writes
- a just-created topic's policy is re-read before being set, so a concurrently created topic is never overwritten
- `--force` re-registration removes the catalog row only after AWS preparation succeeds
- new topics retain the canonical SNS owner-access policy
- generated SNS names are valid and collision-safe for dotted or long bucket names
- repeated preparation converges without duplicate statements/configurations or additional writes
- machine JSON remains clean during AWS profile fallback

## Validation
- `./poe lint-check`
- `./poe test` (395 passed, 1 skipped)
- pre-commit and pre-push hooks
- `uv run quiltx bucket prepare --help`

Closes #84
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an AWS-only `quiltx bucket prepare` workflow that plans and applies S3, SNS, and notification configuration before handing registration to a catalog operator.
- Adds preparation planning, policy merging, notification conflict detection, and idempotent application.
- Adds dry-run and minimal JSON handoff modes without catalog authentication.
- Documents the split bucket-owner/catalog-operator workflow and releases version 0.18.0.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until unrelated SNS topics cannot be adopted by ID and apply-time writes preserve state changed after planning.

The new preparation path can grant subscription access on an unverified existing topic and can overwrite concurrent policy or notification updates using stale full-document snapshots.

**Files Needing Attention:** quiltx/bucket.py and quiltx/tools/bucket.py

<details open><summary><h3>Security Review</h3></summary>

The preparation path can adopt an unrelated SNS topic based solely on a reused notification ID and grant the requested control principals subscription access to that topic.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/bucket.py | Adds the preparation planner and apply path, but topic adoption lacks ownership validation and stale full-document writes can overwrite concurrent changes. |
| quiltx/tools/bucket.py | Adds the AWS-only CLI, validation, dry-run, confirmation, and JSON handoff; its plan-before-prompt flow exposes the stale-plan window. |
| tests/test_bucket.py | Adds broad happy-path, conflict, idempotency, and output coverage but does not cover unrelated stable-ID topics or state changes between planning and applying. |
| README.md | Documents the credential-isolated bucket-owner and catalog-operator workflow. |
| README_DEV.md | Records the three bucket-registration paths and preparation safety expectations. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  actor Owner as Bucket owner
  participant CLI as quiltx bucket prepare
  participant S3
  participant SNS
  actor Catalog as Catalog operator
  Owner->>CLI: prepare bucket and principals
  CLI->>S3: Read bucket policy and notifications
  CLI->>SNS: Read selected topic policy
  CLI-->>Owner: Show plan or request confirmation
  CLI->>SNS: Create topic and apply policy
  CLI->>S3: Apply bucket policy
  CLI->>S3: Replace notification configuration
  CLI-->>Owner: Emit minimal handoff
  Owner-->>Catalog: Transfer handoff
  Catalog->>Catalog: bucket add --no-preflight
```

<sub>Reviews (1): Last reviewed commit: ["Add AWS-only bucket preparation"](https://github.com/quiltdata/quiltx/commit/811f1adbca2ba9e0c5db8b6aacfb531e24230991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52797014)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
