### PR TITLE
Fix control-account derivation and out-of-region bucket probes (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-08-17
+
+### Fixed
+
+- `quiltx bucket prepare --catalog DNS` no longer reports the ambient AWS
+  account as the Quilt control account ([#91](https://github.com/quiltdata/quiltx/issues/91)).
+  Without cached stack metadata, the account is now derived from credentials
+  minted by the catalog's own registry; if the catalog will not mint them,
+  the command fails and asks for an explicit `--control-account-id` or
+  `--principal` instead of emitting a plausible wrong principal. The message
+  names the credential source it actually used.
+- Bucket access probes resolve the bucket's region before testing access, so a
+  bucket outside the profile's default region is no longer reported as
+  unreachable (`GetBucketLocation` answers `AccessDenied` across regions).
+  `bucket prepare`, `bucket add`, and `catalog acl` can now preflight
+  out-of-region buckets.
+
 ## [0.18.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ uvx quiltx bucket prepare my-bucket \
 Use repeatable `--principal arn:aws:iam::123456789012:role/...` options to grant
 specific Quilt roles instead of the control-account root. If you don't know the
 control account ID, pass `--catalog example.quiltdata.com` instead: any
-logged-in catalog user (no admin role needed) can derive it from the catalog's
-minted credentials. `--dry-run` prints the
+logged-in catalog user (no admin role needed) can derive it from cached stack
+metadata or from credentials the catalog's own registry mints. If the catalog
+will not mint credentials, the command fails and asks for an explicit
+`--control-account-id` or `--principal` rather than guessing from your local AWS
+profile. `--dry-run` prints the
 exact final S3 policy, SNS policy, and notification configuration without any
 writes. Preparation preserves unrelated policies and compatible notifications,
 and stops with actionable details when an object-event notification overlaps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.18.0"
+version = "0.18.1"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -13,15 +13,86 @@ from quiltx import stack as stack_lib
 from quiltx.utils import get_bucket_region
 
 
+def _reported_bucket_region(payload: Any) -> str | None:
+    """Extract the bucket region S3 reports in a response or error payload.
+
+    HeadBucket answers ``x-amz-bucket-region`` (surfaced as ``BucketRegion``)
+    even when the call itself fails, which is how an out-of-region bucket can
+    be told apart from one the caller cannot read at all.
+    """
+    if not isinstance(payload, Mapping):
+        return None
+    region = payload.get("BucketRegion")
+    if region:
+        return str(region)
+    error = payload.get("Error")
+    if isinstance(error, Mapping):
+        region = error.get("BucketRegion") or error.get("Region")
+        if region:
+            return str(region)
+    metadata = payload.get("ResponseMetadata")
+    headers = metadata.get("HTTPHeaders") if isinstance(metadata, Mapping) else None
+    if isinstance(headers, Mapping):
+        region = headers.get("x-amz-bucket-region")
+        if region:
+            return str(region)
+    return None
+
+
+def head_bucket_region(s3_client: Any, bucket: str) -> str | None:
+    """Return the region HeadBucket reports for *bucket*, or None if unknown.
+
+    Best-effort probe: any failure to learn the region (including clients that
+    do not implement HeadBucket) yields None so callers keep their original
+    error.
+    """
+    try:
+        response = s3_client.head_bucket(Bucket=bucket)
+    except Exception as exc:  # region hint only; never mask the caller's error
+        return _reported_bucket_region(getattr(exc, "response", None))
+    return _reported_bucket_region(response)
+
+
+def open_bucket_client(bucket: str, session: Any) -> tuple[Any, str]:
+    """Return an S3 client bound to *bucket*'s region plus that region.
+
+    Probes with the session's default region first, then retries against the
+    region HeadBucket reports. Without the retry, a bucket outside the
+    profile's default region answers ``AccessDenied`` on GetBucketLocation and
+    looks unreachable even with a full cross-account grant (issue #91).
+
+    Raises the underlying ``ClientError``/``BotoCoreError`` when the session
+    genuinely cannot read the bucket.
+    """
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    s3_client = session.client("s3")
+    try:
+        return s3_client, get_bucket_region(bucket, s3_client=s3_client)
+    except (ClientError, BotoCoreError):
+        region = head_bucket_region(s3_client, bucket)
+        probed_region = getattr(getattr(s3_client, "meta", None), "region_name", None)
+        if region is None or region == probed_region:
+            raise
+
+    regional_client = session.client("s3", region_name=region)
+    try:
+        return regional_client, get_bucket_region(bucket, s3_client=regional_client)
+    except (ClientError, BotoCoreError):
+        # HeadBucket named the region, so treat it as authoritative only when
+        # an in-region HeadBucket also proves access.
+        regional_client.head_bucket(Bucket=bucket)
+        return regional_client, region
+
+
 def find_profile_for_bucket(bucket: str, profiles: Sequence[str]) -> str | None:
-    """Return the first profile whose GetBucketLocation succeeds for *bucket*."""
+    """Return the first profile that can read *bucket* in the bucket's region."""
     import boto3
     from botocore.exceptions import BotoCoreError, ClientError
 
     for name in profiles:
         try:
-            session = boto3.Session(profile_name=name)
-            session.client("s3").get_bucket_location(Bucket=bucket)
+            open_bucket_client(bucket, boto3.Session(profile_name=name))
         except (ClientError, BotoCoreError):
             continue
         return name
@@ -54,9 +125,8 @@ def resolve_bucket_session(
     ask = prompt if prompt is not None else input
 
     session = boto3.Session(profile_name=profile)
-    s3_client = session.client("s3")
     try:
-        region = get_bucket_region(bucket, s3_client=s3_client)
+        s3_client, region = open_bucket_client(bucket, session)
         return session, s3_client, region, profile
     except (ClientError, BotoCoreError) as exc:
         print(
@@ -88,8 +158,7 @@ def resolve_bucket_session(
             return None, None, "", profile
 
     new_session = boto3.Session(profile_name=match)
-    new_s3 = new_session.client("s3")
-    region = get_bucket_region(bucket, s3_client=new_s3)
+    new_s3, region = open_bucket_client(bucket, new_session)
     return new_session, new_s3, region, match
 
 

--- a/quiltx/quilt3_facade.py
+++ b/quiltx/quilt3_facade.py
@@ -23,7 +23,7 @@ import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Iterator, Mapping
+from typing import Any, Iterator, Mapping
 
 # Lock held during the bind-and-call sequence in Catalog.ensure_auth / admin.
 # See §4.4 in the spec.
@@ -170,15 +170,88 @@ def make_bucket(bucket_uri: str) -> object:
     return quilt3.Bucket(bucket_uri)
 
 
+class CatalogCredentialsError(RuntimeError):
+    """Raised when registry-issued credentials for the active catalog are absent.
+
+    Never fall back to the ambient AWS credential chain in this case: the
+    resulting account ID would describe whatever profile happens to be
+    configured locally, not the catalog's control account (issue #91).
+    """
+
+
+# botocore method name reported by quilt3.session.QuiltProvider.
+QUILT_CREDENTIALS_METHOD = "quilt-registry"
+
+
+def _mint_registry_credentials() -> dict[str, str]:
+    """Fetch fresh STS credentials from the active catalog's registry.
+
+    Uses quilt3's authenticated HTTP session (the API key bound by
+    ``Catalog.ensure_auth``) against ``get_registry_url()``, which quiltx
+    rebinds to the active catalog. Nothing is written to disk, and no cached
+    or ambient credential source can substitute for this call.
+    """
+    import quilt3.session
+
+    registry_url = quilt3.session.get_registry_url()
+    if not registry_url:
+        raise CatalogCredentialsError("no active catalog registry URL")
+    session = quilt3.session.get_session()
+    response = session.get(f"{registry_url.rstrip('/')}/api/auth/get_credentials")
+    payload = response.json()
+    try:
+        return {
+            "access_key": payload["AccessKeyId"],
+            "secret_key": payload["SecretAccessKey"],
+            "token": payload["SessionToken"],
+            "expiry_time": payload["Expiration"],
+        }
+    except (KeyError, TypeError) as exc:
+        raise CatalogCredentialsError(
+            f"registry {registry_url} returned no usable credentials"
+        ) from exc
+
+
+def catalog_botocore_session() -> Any:
+    """Return a botocore session backed only by registry-issued credentials.
+
+    Raises ``CatalogCredentialsError`` when the active catalog will not mint
+    credentials, or when the resolved credentials did not come from quilt3's
+    ``QuiltProvider``.
+    """
+    import quilt3.session
+
+    try:
+        credentials = _mint_registry_credentials()
+    except CatalogCredentialsError:
+        raise
+    except Exception as exc:  # transport, auth, or quilt3 failure
+        raise CatalogCredentialsError(
+            f"catalog registry did not issue credentials: {exc}"
+        ) from exc
+
+    botocore_session = quilt3.session.create_botocore_session(credentials=credentials)
+    resolved = botocore_session.get_credentials()
+    method = getattr(resolved, "method", None)
+    if resolved is None or method != QUILT_CREDENTIALS_METHOD:
+        raise CatalogCredentialsError(
+            "refusing to use credentials from "
+            f"{method or 'the ambient AWS credential chain'}: expected "
+            f"quilt3's {QUILT_CREDENTIALS_METHOD} provider"
+        )
+    return botocore_session
+
+
 def catalog_sts_account_id() -> str:
     """Return the AWS account ID behind the active catalog's minted credentials.
 
     Uses quilt3's registry-issued temporary credentials — available to any
     logged-in catalog user, no admin role required — and asks STS which
     account they belong to: the catalog stack's control account.
-    """
-    import quilt3.session
 
-    botocore_session = quilt3.session.create_botocore_session()
+    Raises ``CatalogCredentialsError`` rather than answering for the local
+    AWS profile when the catalog does not mint credentials.
+    """
+    botocore_session = catalog_botocore_session()
     sts_client = botocore_session.create_client("sts")
     return str(sts_client.get_caller_identity()["Account"])

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -130,7 +130,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Catalog DNS name used to derive the control account ID when "
             "--control-account-id and --principal are omitted: reads cached "
             "stack metadata, else logs in as a regular catalog user (no admin "
-            "required) and asks STS which account minted the credentials."
+            "required) and asks STS which account minted the catalog's own "
+            "credentials; never falls back to ambient AWS credentials."
         ),
     )
     prepare_parser.add_argument(
@@ -457,6 +458,10 @@ def _control_account_id_from_catalog(catalog_arg: str) -> str:
     a regular catalog user and ask STS which account minted the catalog
     credentials. Keeps ``bucket prepare`` outside ``catalog_command``: no
     catalog configuration is loaded and no Quilt admin API is called.
+
+    Never falls back to the ambient AWS credential chain: an account ID that
+    tracks ``AWS_PROFILE`` would silently produce a bucket policy granting an
+    unrelated account (issue #91).
     """
     from quiltx import quilt3_facade
 
@@ -471,10 +476,17 @@ def _control_account_id_from_catalog(catalog_arg: str) -> str:
         )
         return account_id
     catalog.ensure_auth()
-    account_id = quilt3_facade.catalog_sts_account_id()
+    try:
+        account_id = quilt3_facade.catalog_sts_account_id()
+    except quilt3_facade.CatalogCredentialsError as exc:
+        raise RuntimeError(
+            f"{exc}. Pass --control-account-id or --principal explicitly, or "
+            f"refresh the stack cache with: quiltx catalog stack "
+            f"--catalog {catalog.catalog_name}"
+        ) from exc
     print(
-        f"Control account {account_id} from {catalog.catalog_name} catalog "
-        "credentials.",
+        f"Control account {account_id} from registry-issued credentials for "
+        f"{catalog.catalog_name}.",
         file=sys.stderr,
     )
     return account_id

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -12,9 +12,11 @@ from typing import Any
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
 from quiltx import bucket as bucket_lib
+from quiltx import quilt3_facade
 from quiltx.bucket import AddBucketResult, add_bucket
 from quiltx.tools import bucket as bucket_tool
 
@@ -1254,9 +1256,42 @@ def test_prepare_catalog_falls_back_to_catalog_credentials(monkeypatch, capsys) 
     assert applied == [plan]
     assert json.loads(captured.out) == plan.handoff()
     assert (
-        "Control account 123456789012 from open.quiltdata.com catalog credentials"
-        in captured.err
+        "Control account 123456789012 from registry-issued credentials for "
+        "open.quiltdata.com" in captured.err
     )
+
+
+def test_prepare_catalog_refuses_ambient_credentials(monkeypatch, capsys) -> None:
+    """Issue #91: never fall back to the local AWS profile's account ID."""
+    plan = _fake_bucket_preparation_plan()
+    _control_ids, auth_calls, _resolved = _install_prepare_catalog_fakes(
+        monkeypatch, plan, payload=None, allow_auth=True
+    )
+
+    def refuse() -> str:
+        raise quilt3_facade.CatalogCredentialsError(
+            "refusing to use credentials from the ambient AWS credential chain"
+        )
+
+    monkeypatch.setattr("quiltx.quilt3_facade.catalog_sts_account_id", refuse)
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "apply_bucket_preparation",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not write AWS state without a control account")
+        ),
+    )
+
+    result = bucket_tool.main(
+        ["prepare", "bucket", "--catalog", "open.quiltdata.com", "--json", "--yes"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert auth_calls == ["auth"]
+    assert "ambient AWS credential chain" in captured.err
+    assert "--control-account-id" in captured.err
+    assert "Control account" not in captured.err
 
 
 class FakeQuiltBucket:
@@ -2633,6 +2668,144 @@ def test_cmd_profile_finds_profile_for_bucket(monkeypatch, capsys) -> None:
     assert bucket_tool.main(["profile", "quilt-example"]) == 0
     assert capsys.readouterr().out.strip() == "prod"
     assert calls == ["sales", "open", "prod"]
+
+
+class _CrossRegionS3:
+    """S3 double where GetBucketLocation only answers in the bucket's region."""
+
+    denied = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+        "GetBucketLocation",
+    )
+
+    def __init__(self, region: str, bucket_region: str = "us-west-2") -> None:
+        self.meta = SimpleNamespace(region_name=region)
+        self.bucket_region = bucket_region
+        self.location_calls = 0
+        self.head_calls = 0
+
+    def get_bucket_location(self, Bucket: str) -> dict[str, Any]:
+        self.location_calls += 1
+        if self.meta.region_name != self.bucket_region:
+            raise self.denied
+        return {"LocationConstraint": self.bucket_region}
+
+    def head_bucket(self, Bucket: str) -> dict[str, Any]:
+        self.head_calls += 1
+        return {"BucketRegion": self.bucket_region}
+
+
+class _CrossRegionSession:
+    """Session double handing out region-pinned :class:`_CrossRegionS3` clients."""
+
+    available_profiles = ["default"]
+
+    def __init__(self, profile_name: str | None = None) -> None:
+        self.profile_name = profile_name or "default"
+        self.clients: list[_CrossRegionS3] = []
+
+    def client(self, service: str, region_name: str | None = None) -> _CrossRegionS3:
+        assert service == "s3"
+        created = _CrossRegionS3(region_name or "us-east-1")
+        self.clients.append(created)
+        return created
+
+
+def test_open_bucket_client_retries_in_the_buckets_region() -> None:
+    """Issue #91: an out-of-region bucket is not mistaken for an unreadable one."""
+    session = _CrossRegionSession()
+
+    s3_client, region = bucket_lib.open_bucket_client("quilt-example", session)
+
+    assert region == "us-west-2"
+    assert s3_client.meta.region_name == "us-west-2"
+    assert [client.meta.region_name for client in session.clients] == [
+        "us-east-1",
+        "us-west-2",
+    ]
+
+
+def test_open_bucket_client_accepts_head_only_access() -> None:
+    """HeadBucket in the right region proves access even if GetBucketLocation fails."""
+
+    class HeadOnlyS3(_CrossRegionS3):
+        def get_bucket_location(self, Bucket: str) -> dict[str, Any]:
+            self.location_calls += 1
+            raise self.denied
+
+    class HeadOnlySession(_CrossRegionSession):
+        def client(self, service: str, region_name: str | None = None) -> HeadOnlyS3:
+            created = HeadOnlyS3(region_name or "us-east-1")
+            self.clients.append(created)
+            return created
+
+    s3_client, region = bucket_lib.open_bucket_client(
+        "quilt-example", HeadOnlySession()
+    )
+
+    assert region == "us-west-2"
+    assert s3_client.meta.region_name == "us-west-2"
+
+
+def test_open_bucket_client_raises_on_same_region_denial() -> None:
+    """A denial in the bucket's own region stays a denial."""
+
+    class DeniedS3(_CrossRegionS3):
+        def get_bucket_location(self, Bucket: str) -> dict[str, Any]:
+            self.location_calls += 1
+            raise self.denied
+
+    class DeniedSession(_CrossRegionSession):
+        def client(self, service: str, region_name: str | None = None) -> DeniedS3:
+            created = DeniedS3(region_name or "us-west-2")
+            self.clients.append(created)
+            return created
+
+    session = DeniedSession()
+    with pytest.raises(ClientError):
+        bucket_lib.open_bucket_client("quilt-example", session)
+    assert len(session.clients) == 1
+
+
+def test_resolve_bucket_session_keeps_out_of_region_profile(monkeypatch) -> None:
+    """The first profile is kept when only the probe region was wrong."""
+    monkeypatch.setattr(boto3, "Session", _CrossRegionSession)
+
+    session, s3_client, region, profile = bucket_lib.resolve_bucket_session(
+        "quilt-example", "default", assume_yes=False
+    )
+
+    assert profile == "default"
+    assert region == "us-west-2"
+    assert s3_client.meta.region_name == "us-west-2"
+    assert isinstance(session, _CrossRegionSession)
+
+
+def test_head_bucket_region_reads_error_header() -> None:
+    class RedirectS3:
+        def head_bucket(self, Bucket: str) -> dict[str, Any]:
+            raise ClientError(
+                {
+                    "Error": {"Code": "301", "Message": "Moved Permanently"},
+                    "ResponseMetadata": {
+                        "HTTPHeaders": {"x-amz-bucket-region": "eu-central-1"}
+                    },
+                },
+                "HeadBucket",
+            )
+
+    assert bucket_lib.head_bucket_region(RedirectS3(), "b") == "eu-central-1"
+
+
+def test_head_bucket_region_is_none_without_a_hint() -> None:
+    class OpaqueS3:
+        def head_bucket(self, Bucket: str) -> dict[str, Any]:
+            raise ClientError(
+                {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadBucket"
+            )
+
+    assert bucket_lib.head_bucket_region(OpaqueS3(), "b") is None
+    assert bucket_lib.head_bucket_region(object(), "b") is None
 
 
 def test_resolve_bucket_session_switches_on_access_denied(monkeypatch, capsys) -> None:

--- a/tests/test_quilt3_facade.py
+++ b/tests/test_quilt3_facade.py
@@ -44,3 +44,150 @@ def test_login_with_api_key_propagates_quilt3_errors(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="invalid api key prefix"):
         quilt3_facade.login_with_api_key("not-a-real-key")
+
+
+class _FakeCredentials:
+    def __init__(self, method: str) -> None:
+        self.method = method
+
+
+class _FakeBotocoreSession:
+    def __init__(self, credentials: _FakeCredentials | None, account: str) -> None:
+        self._credentials = credentials
+        self._account = account
+
+    def get_credentials(self) -> _FakeCredentials | None:
+        return self._credentials
+
+    def create_client(self, service: str) -> object:
+        assert service == "sts"
+        account = self._account
+
+        class _Sts:
+            def get_caller_identity(self) -> dict[str, str]:
+                return {"Account": account}
+
+        return _Sts()
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload: dict[str, str]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, str]:
+        return self._payload
+
+
+def _install_fake_quilt3_session(
+    monkeypatch,
+    *,
+    credentials_payload: dict[str, str] | None,
+    resolved_method: str | None,
+    registry_url: str = "https://registry.example.com",
+    account: str = "123456789012",
+) -> dict[str, object]:
+    """Install a fake quilt3.session; return a dict recording facade calls."""
+    calls: dict[str, object] = {}
+
+    fake_session = ModuleType("quilt3.session")
+
+    def get_registry_url() -> str:
+        return registry_url
+
+    def get_session() -> object:
+        class _Http:
+            def get(self, url: str) -> _FakeHttpResponse:
+                calls["url"] = url
+                if credentials_payload is None:
+                    raise RuntimeError("Authentication failed")
+                return _FakeHttpResponse(credentials_payload)
+
+        return _Http()
+
+    def create_botocore_session(*, credentials=None):
+        calls["credentials"] = credentials
+        resolved = (
+            _FakeCredentials(resolved_method) if resolved_method is not None else None
+        )
+        return _FakeBotocoreSession(resolved, account)
+
+    fake_session.get_registry_url = get_registry_url  # type: ignore[attr-defined]
+    fake_session.get_session = get_session  # type: ignore[attr-defined]
+    fake_session.create_botocore_session = create_botocore_session  # type: ignore[attr-defined]
+
+    fake_quilt3 = ModuleType("quilt3")
+    fake_quilt3.session = fake_session  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quilt3", fake_quilt3)
+    monkeypatch.setitem(sys.modules, "quilt3.session", fake_session)
+    return calls
+
+
+_STS_PAYLOAD = {
+    "AccessKeyId": "ASIA",
+    "SecretAccessKey": "secret",
+    "SessionToken": "token",
+    "Expiration": "2030-01-01T00:00:00Z",
+}
+
+
+def test_catalog_sts_account_id_uses_registry_issued_credentials(monkeypatch) -> None:
+    calls = _install_fake_quilt3_session(
+        monkeypatch,
+        credentials_payload=_STS_PAYLOAD,
+        resolved_method=quilt3_facade.QUILT_CREDENTIALS_METHOD,
+    )
+
+    assert quilt3_facade.catalog_sts_account_id() == "123456789012"
+    assert calls["url"] == "https://registry.example.com/api/auth/get_credentials"
+    assert calls["credentials"] == {
+        "access_key": "ASIA",
+        "secret_key": "secret",
+        "token": "token",
+        "expiry_time": "2030-01-01T00:00:00Z",
+    }
+
+
+def test_catalog_sts_account_id_rejects_ambient_credentials(monkeypatch) -> None:
+    """Issue #91: ambient AWS credentials must not be reported as the catalog's."""
+    import pytest
+
+    _install_fake_quilt3_session(
+        monkeypatch,
+        credentials_payload=_STS_PAYLOAD,
+        resolved_method="shared-credentials-file",
+    )
+
+    with pytest.raises(
+        quilt3_facade.CatalogCredentialsError, match="shared-credentials-file"
+    ):
+        quilt3_facade.catalog_sts_account_id()
+
+
+def test_catalog_sts_account_id_fails_when_registry_mints_nothing(monkeypatch) -> None:
+    import pytest
+
+    _install_fake_quilt3_session(
+        monkeypatch,
+        credentials_payload=None,
+        resolved_method=quilt3_facade.QUILT_CREDENTIALS_METHOD,
+    )
+
+    with pytest.raises(
+        quilt3_facade.CatalogCredentialsError, match="did not issue credentials"
+    ):
+        quilt3_facade.catalog_sts_account_id()
+
+
+def test_catalog_sts_account_id_fails_on_incomplete_credentials(monkeypatch) -> None:
+    import pytest
+
+    _install_fake_quilt3_session(
+        monkeypatch,
+        credentials_payload={"AccessKeyId": "ASIA"},
+        resolved_method=quilt3_facade.QUILT_CREDENTIALS_METHOD,
+    )
+
+    with pytest.raises(
+        quilt3_facade.CatalogCredentialsError, match="no usable credentials"
+    ):
+        quilt3_facade.catalog_sts_account_id()

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
Fixes #91.

## Problem

`quiltx bucket prepare --catalog CATALOG` printed "Control account <id> from
CATALOG catalog credentials" while actually reporting the account of whatever
local AWS profile was active. Since that ID becomes the bucket-policy principal
(`arn:aws:iam::<id>:root`), the handoff JSON produced a policy granting an
unrelated account — surfacing much later as an opaque `AccessDenied` during
`bucket add` / `catalog acl`.

Root cause: `quilt3.session.create_botocore_session()` installs `QuiltProvider`
only when quilt3 has stored credentials. quiltx authenticates through its own
keyring/API key, so quilt3 usually has none and the session falls through to
the standard AWS chain.

The second bug (from the issue comment): access probes built S3 clients with no
region, so `GetBucketLocation` on an out-of-region bucket answered
`AccessDenied` and a fully entitled profile was reported as having no access.

## Changes

- `quilt3_facade.catalog_sts_account_id()` mints credentials from the active
  catalog's own registry (`/api/auth/get_credentials` via quilt3's
  API-key-bound session, nothing written to disk), then asserts the resolved
  botocore provider is quilt3's `quilt-registry` provider. Anything else raises
  the new `CatalogCredentialsError` — no ambient fallback.
- `bucket prepare` turns that error into an actionable message asking for
  `--control-account-id` / `--principal` (or a stack-cache refresh), and only
  claims "registry-issued credentials for CATALOG" when that is the source it
  used. Cached stack metadata still wins and still authenticates nothing.
- New `bucket.open_bucket_client()` probes with the session default region,
  then retries against the region HeadBucket reports (`x-amz-bucket-region`,
  which S3 returns even on failures). A same-region denial stays a denial.
  `find_profile_for_bucket` and `resolve_bucket_session` both use it, so
  `bucket prepare`, `bucket add`, and `catalog acl` can preflight
  out-of-region buckets.
- Version bumped to 0.18.1, CHANGELOG and README updated.

Not changed: `stack.lightweight_stack_payload()` still uses the ambient chain
to identify the control account, which is documented and intended for
control-account operators.

## Testing

`./poe test-all` — 410 passed, black + mypy clean. New tests cover:
registry-minted credential use, rejection of ambient/incomplete credentials,
the CLI refusing to proceed without a verified control account, cross-region
retry, head-only access, same-region denial, and region-hint extraction from
redirect/opaque error payloads.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents ambient AWS credentials from being mistaken for catalog-issued credentials and adds regional S3 probing for bucket preparation, registration, and ACL preflight.

- Mints temporary credentials directly from the authenticated catalog registry and verifies their botocore provider.
- Retries bucket access using the region reported by HeadBucket.
- Adds failure guidance, regression coverage, documentation, and a patch-version release update.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified in the corrected credential or regional bucket-probing paths.

The affected CLI and ACL workflows use the new regional S3 client, while catalog account derivation rejects ambient credentials and provides an explicit failure path when registry credentials are unavailable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/bucket.py | Adds region-hint extraction and regional S3-client retry logic used by the affected CLI and ACL preflight paths. |
| quiltx/quilt3_facade.py | Mints catalog registry credentials explicitly, rejects ambient provider fallback, and derives the control account through STS. |
| quiltx/tools/bucket.py | Converts catalog credential failures into actionable CLI guidance and accurately reports the selected credential source. |
| tests/test_bucket.py | Adds coverage for cross-region, HeadBucket-only, same-region denial, profile fallback, and control-account failure behavior. |
| tests/test_quilt3_facade.py | Covers registry credential normalization, provider verification, and malformed or unavailable credential responses. |
| pyproject.toml | Bumps the package version to 0.18.1 without changing dependency constraints. |
| uv.lock | Updates only the local quiltx package version in the resolved lockfile. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bucket prepare/add or catalog ACL] --> B[Resolve local AWS session]
    B --> C[Probe GetBucketLocation in default region]
    C -->|Success| D[Use returned regional S3 client]
    C -->|Denied or redirected| E[HeadBucket extracts bucket region]
    E --> F[Create regional S3 client]
    F --> D
    A --> G{Explicit or cached control account?}
    G -->|Yes| H[Use supplied or cached account]
    G -->|No| I[Authenticate to catalog registry]
    I --> J[Mint temporary registry credentials]
    J --> K{Provider is quilt-registry?}
    K -->|Yes| L[Call STS and derive control account]
    K -->|No| M[Fail with explicit-account guidance]
```

<sub>Reviews (1): Last reviewed commit: ["Derive control account from the catalog,..."](https://github.com/quiltdata/quiltx/commit/ad5f943110afbfa8ed08362c6b1c297ed67bb3f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54054464)</sub>

<!-- /greptile_comment -->