### PR TITLE
Verify live bucket access server-side; run it on the no-preflight path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,20 @@ registers through GraphQL only, letting the catalog stack probe with its own
 IAM. The same mode is available for ACL reconciliation with
 `quiltx catalog acl --no-preflight` or `QUILTX_NO_PREFLIGHT=1`.
 
+Post-add verification runs on both add paths (`--no-test` opts out) and reports
+registration, live access, and index wiring separately:
+
+- Live access is a server-side probe: `quiltx.bucket.probe_bucket_access` reads
+  the bucket's full catalog configuration and resubmits it unchanged, so the
+  registry re-validates S3/SNS with the stack's own identity. Configuration is
+  never rewritten; a catalog that cannot answer yields `status "unavailable"`
+  and callers fall back to the index probe.
+- Index wiring is a warning once live access is verified (indexing lags, and
+  empty buckets never index); `--require-index` makes it fatal.
+- `quiltx bucket test BUCKET --pre-registration [--profile P]` checks a
+  cross-account grant before registration using control-account credentials and
+  reports the probing principal.
+
 ### ECS Tool (`quiltx ecs`)
 
 Provides catalog ECS operations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   granting `Subscribe`/`GetTopicAttributes`. It runs from the control account
   (`--profile`), reports the principal used, and fails when that principal is
   not in the catalog's control account, so a wrong-account grant surfaces at
-  handoff instead of as an opaque `AccessDenied` inside `catalog acl`.
+  handoff instead of as an opaque `AccessDenied` inside `catalog acl`. Topic
+  policies are read conservatively: an explicit `Deny` overrides an allow, and a
+  condition-bearing allow is reported as conditional rather than granted.
 - `quiltx bucket test --require-index` and `quiltx bucket add --require-index`
   treat an empty search index as a failure. By default an empty index is a
   warning once live access is verified, since indexing lags registration and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-08-17
+
+### Added
+
+- `quiltx bucket test` and post-add verification now run a server-side live
+  access probe ([#87](https://github.com/quiltdata/quiltx/issues/87)). The
+  catalog re-validates the bucket with the stack's own service identity, so a
+  valid empty bucket passes, revoked access fails even when stale search-index
+  entries remain, and failures name the failed capability (bucket metadata,
+  S3 read, notification configuration, or SNS topic) plus the control account
+  and stack principal. Registration, live access, and index wiring are reported
+  as three separate checks. A catalog that cannot answer the probe is reported
+  as skipped, and verification falls back to the index probe. The probe
+  resubmits the bucket's existing catalog configuration unchanged to trigger
+  re-validation; `QUILTX_NO_LIVE_PROBE=1` skips it.
+- `quiltx bucket test --pre-registration` checks a cross-account grant before
+  any catalog registration exists ([#92](https://github.com/quiltdata/quiltx/issues/92)):
+  bucket reachable, `GetBucketNotification` readable, and the SNS topic policy
+  granting `Subscribe`/`GetTopicAttributes`. It runs from the control account
+  (`--profile`), reports the principal used, and fails when that principal is
+  not in the catalog's control account, so a wrong-account grant surfaces at
+  handoff instead of as an opaque `AccessDenied` inside `catalog acl`.
+- `quiltx bucket test --require-index` and `quiltx bucket add --require-index`
+  treat an empty search index as a failure. By default an empty index is a
+  warning once live access is verified, since indexing lags registration and
+  empty buckets never index.
+
+### Fixed
+
+- `quiltx bucket add --no-preflight` now verifies after registering
+  ([#92](https://github.com/quiltdata/quiltx/issues/92)). The documented
+  cross-account flow previously exited 0 without any check, reporting success
+  for a bucket that was registered but unreadable and unindexed. `--no-test` is
+  now the opt-out on that path too, instead of being silently a no-op, and an
+  already-registered bucket is verified rather than skipped.
+- `quiltx bucket test` reports the Quilt control account and stack principal on
+  failure instead of `unknown`, which is precisely the diagnostic needed when a
+  grant was issued to the wrong account
+  ([#92](https://github.com/quiltdata/quiltx/issues/92)).
+
 ## [0.18.1] - 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -108,8 +108,42 @@ uvx quiltx catalog acl acl.yml --catalog example.quiltdata.com --no-preflight --
 ```
 
 `--no-preflight` submits the GraphQL registration directly, lets the stack probe
-with its IAM, skips local S3/SNS setup, and implies `--no-test`. Set
-`QUILTX_NO_PREFLIGHT=1` to use the same mode for scripted runs.
+with its IAM, and skips local S3/SNS setup. It still verifies afterwards — the
+cross-account path is the one most likely to be misconfigured — so pass
+`--no-test` to opt out. Set `QUILTX_NO_PREFLIGHT=1` to use the same mode for
+scripted runs.
+
+### Verifying access
+
+`quiltx bucket test BUCKET` reports three independent checks:
+
+1. **Registration** — the bucket has a catalog row.
+2. **Live access** — the catalog re-validates the bucket server-side with the
+   stack's own service identity, so an empty bucket passes and revoked access
+   fails even when stale search-index entries remain. Failures name the failed
+   capability, the Quilt control account, and the stack principal. The probe
+   resubmits the bucket's existing catalog configuration unchanged to trigger
+   that re-validation; set `QUILTX_NO_LIVE_PROBE=1` to skip it where no bucket
+   mutation is acceptable.
+3. **Index wiring** — the search index has entries, which proves SNS to SQS
+   delivery is live. Once live access is verified, an empty index is a warning
+   rather than a failure, since indexing lags registration and empty buckets
+   never index. Pass `--require-index` to make it fatal.
+
+Before a bucket is registered, check a cross-account grant straight from the
+handoff with control-account credentials:
+
+```bash
+uvx quiltx bucket test my-bucket --catalog example.quiltdata.com \
+  --pre-registration --profile control-account
+```
+
+That mode treats "not registered" as expected and checks what is checkable:
+the bucket is reachable, `GetBucketNotification` is readable, and the SNS topic
+policy grants `Subscribe`/`GetTopicAttributes`. It reports the principal that
+ran the checks and fails loudly when that principal is not in the catalog's
+control account — which is how a grant issued to the wrong account surfaces at
+handoff time instead of as an opaque `AccessDenied` later.
 
 ### Persistent install (optional)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ uvx quiltx bucket test my-bucket --catalog example.quiltdata.com \
 
 That mode treats "not registered" as expected and checks what is checkable:
 the bucket is reachable, `GetBucketNotification` is readable, and the SNS topic
-policy grants `Subscribe`/`GetTopicAttributes`. It reports the principal that
+policy grants `Subscribe`/`GetTopicAttributes`. Topic policies are read
+conservatively — an explicit `Deny` counts, and a condition-bearing `Allow` is
+reported as conditional rather than assumed to apply. It reports the principal that
 ran the checks and fails loudly when that principal is not in the catalog's
 control account — which is how a grant issued to the wrong account surfaces at
 handoff time instead of as an opaque `AccessDenied` later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.18.1"
+version = "0.18.2"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -1292,14 +1292,22 @@ def _aws_error_detail(exc: BaseException) -> str:
 
 
 def _normalized_principal(principal: str | None) -> str | None:
-    """Map an assumed-role session ARN back to the role ARN policies name."""
+    """Map an assumed-role session ARN back to the role ARN policies name.
+
+    ``sts:GetCallerIdentity`` answers
+    ``arn:aws:sts::123:assumed-role/Role/session`` while policies name
+    ``arn:aws:iam::123:role/Role``. Any ARN shape that does not parse cleanly is
+    returned unchanged rather than rewritten into a guess.
+    """
     if not principal:
         return None
     parts = principal.split(":")
-    if len(parts) == 6 and parts[2] == "sts" and parts[5].startswith("assumed-role/"):
-        role_name = parts[5].split("/")[1]
-        return f"arn:aws:iam::{parts[4]}:role/{role_name}"
-    return principal
+    if len(parts) != 6 or parts[2] != "sts":
+        return principal
+    resource = parts[5].split("/")
+    if len(resource) < 2 or resource[0] != "assumed-role" or not resource[1]:
+        return principal
+    return f"arn:aws:iam::{parts[4]}:role/{resource[1]}"
 
 
 def _statement_principals(statement: Mapping[str, Any]) -> list[str]:
@@ -1396,8 +1404,10 @@ def evaluate_sns_policy(
     for statement in statements:
         if not isinstance(statement, Mapping):
             continue
-        effect = str(statement.get("Effect", "Allow"))
-        if effect not in {"Allow", "Deny"}:
+        # Casefold the effect so an oddly-spelled Deny is still honored rather
+        # than silently skipped, which would over-report access.
+        effect = str(statement.get("Effect", "Allow")).strip().lower()
+        if effect not in {"allow", "deny"}:
             continue
         resources = statement.get("Resource")
         if isinstance(resources, str):
@@ -1409,7 +1419,7 @@ def evaluate_sns_policy(
         covered = _statement_covers_actions(statement, actions)
         if not covered:
             continue
-        if effect == "Deny":
+        if effect == "deny":
             # A conditional deny may not apply, but treating it as binding is
             # the safe reading: the probe under-reports access rather than
             # promising a grant AWS refuses.

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -1049,6 +1049,523 @@ def add_bucket(
     )
 
 
+# --- Live access verification -------------------------------------------------
+#
+# Registration and search-index state do not prove that the catalog stack can
+# read a bucket right now (issue #87): a stale index entry outlives revoked
+# access, and an empty or freshly registered bucket has nothing to index. The
+# probes below separate the three questions -- is the bucket registered, can the
+# catalog stack read it live, and is notification/index wiring delivering.
+
+# Mirrors BucketUpdateInput in the catalog's GraphQL schema. Every field is read
+# back from BucketConfig and resubmitted unchanged, so re-validation cannot
+# rewrite the bucket's configuration.
+BUCKET_UPDATE_INPUT_FIELDS = (
+    "title",
+    "iconUrl",
+    "description",
+    "linkedData",
+    "overviewUrl",
+    "tags",
+    "relevanceScore",
+    "snsNotificationArn",
+    "scannerParallelShardsDepth",
+    "skipMetaDataIndexing",
+    "fileExtensionsToIndex",
+    "indexContentBytes",
+    "browsable",
+    "prefixes",
+)
+
+BUCKET_CONFIG_QUERY = """
+query quiltxBucketConfig($name: String!) {
+  bucketConfig(name: $name) {
+    name
+    lastIndexed
+    %s
+  }
+}
+""" % ("\n    ".join(BUCKET_UPDATE_INPUT_FIELDS))
+
+BUCKET_REVALIDATE_MUTATION = """
+mutation quiltxBucketRevalidate($name: String!, $input: BucketUpdateInput!) {
+  bucketUpdate(name: $name, input: $input) {
+    __typename
+    ... on BucketUpdateSuccess {
+      bucketConfig {
+        name
+      }
+    }
+    ... on InsufficientPermissions {
+      message
+    }
+  }
+}
+"""
+
+# Which capability the registry's answer implicates, for error output.
+ACCESS_PROBE_CAPABILITIES = {
+    "BucketUpdateSuccess": "bucket metadata, listing, and object read",
+    "InsufficientPermissions": "S3 read access (ListBucket / GetObject)",
+    "NotificationConfigurationError": "bucket notification configuration",
+    "NotificationTopicNotFound": "SNS notification topic",
+    "SnsInvalid": "SNS notification topic",
+    "BucketNotFound": "catalog registration",
+}
+
+LIVE_ACCESS_CAPABILITY = "live S3 access"
+
+
+@dataclass(frozen=True)
+class BucketAccessProbe:
+    """Result of asking the catalog stack to re-verify live bucket access.
+
+    The catalog re-validates the bucket with the stack's own service identity,
+    so the answer describes current S3 access rather than local credentials or
+    search-index state.
+    """
+
+    bucket: str
+    status: str  # "ok" | "failed" | "unavailable"
+    capability: str
+    detail: str
+    principal: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "failed"
+
+    @property
+    def unavailable(self) -> bool:
+        return self.status == "unavailable"
+
+
+def _admin_graphql(query: str, variables: Mapping[str, Any]) -> Mapping[str, Any]:
+    from quiltx import quilt3_facade
+
+    return quilt3_facade.admin_graphql(query, variables)
+
+
+def read_bucket_config(bucket: str, *, graphql: Any = None) -> dict[str, Any] | None:
+    """Return the catalog's full configuration for *bucket*, or None if absent."""
+    run = graphql or _admin_graphql
+    data = run(BUCKET_CONFIG_QUERY, {"name": bucket})
+    config = (data or {}).get("bucketConfig")
+    return dict(config) if config else None
+
+
+def probe_bucket_access(
+    stack: stack_lib.Catalog,
+    bucket: str,
+    *,
+    principal: str | None = None,
+    graphql: Any = None,
+) -> BucketAccessProbe:
+    """Ask the catalog stack to re-verify live access to *bucket*.
+
+    Reads the bucket's complete catalog configuration and resubmits it
+    unchanged. The registry validates S3 and SNS access with the stack's own
+    identity while handling that mutation, which makes its answer a live
+    access probe: an empty bucket passes, and revoked access fails even when
+    stale search-index entries remain.
+
+    A catalog that cannot answer either operation yields ``status
+    "unavailable"`` so callers can fall back instead of reporting a failure.
+    """
+    stack.ensure_auth()
+    run = graphql or _admin_graphql
+
+    try:
+        config = read_bucket_config(bucket, graphql=run)
+    except Exception as exc:
+        if stack_lib.is_auth_error(exc):
+            raise
+        return BucketAccessProbe(
+            bucket=bucket,
+            status="unavailable",
+            capability=LIVE_ACCESS_CAPABILITY,
+            detail=f"catalog did not answer the bucketConfig query: {exc}",
+            principal=principal,
+        )
+
+    if config is None:
+        return BucketAccessProbe(
+            bucket=bucket,
+            status="failed",
+            capability="catalog registration",
+            detail=f"{bucket} is not registered in Quilt",
+            principal=principal,
+        )
+
+    payload = {field: config.get(field) for field in BUCKET_UPDATE_INPUT_FIELDS}
+    try:
+        data = run(BUCKET_REVALIDATE_MUTATION, {"name": bucket, "input": payload})
+    except Exception as exc:
+        if stack_lib.is_auth_error(exc):
+            raise
+        return BucketAccessProbe(
+            bucket=bucket,
+            status="unavailable",
+            capability=LIVE_ACCESS_CAPABILITY,
+            detail=f"catalog did not re-validate the bucket: {exc}",
+            principal=principal,
+        )
+
+    result = (data or {}).get("bucketUpdate") or {}
+    typename = str(result.get("__typename") or "")
+    capability = ACCESS_PROBE_CAPABILITIES.get(typename, LIVE_ACCESS_CAPABILITY)
+    if typename == "BucketUpdateSuccess":
+        return BucketAccessProbe(
+            bucket=bucket,
+            status="ok",
+            capability=capability,
+            detail="catalog stack re-validated the bucket with its own identity",
+            principal=principal,
+        )
+
+    message = str(result.get("message") or "").strip()
+    if message:
+        detail = f"{typename}: {message}"
+    elif typename:
+        detail = typename
+    else:
+        detail = f"unexpected bucketUpdate response {result!r}"
+    return BucketAccessProbe(
+        bucket=bucket,
+        status="failed",
+        capability=capability,
+        detail=detail,
+        principal=principal,
+    )
+
+
+# --- Pre-registration grant checks -------------------------------------------
+#
+# A cross-account grant handed back by ``bucket prepare`` is fully checkable
+# before the catalog row exists (issue #92). These checks run from the control
+# account so a wrong-account grant surfaces at handoff time instead of as an
+# opaque AccessDenied inside ``catalog acl``.
+
+GRANT_SNS_ACTIONS = ("sns:GetTopicAttributes", "sns:Subscribe")
+
+
+@dataclass(frozen=True)
+class GrantCheck:
+    """One capability checked against a bucket from the control account."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class BucketGrantReport:
+    """Control-account view of a bucket grant, with the principal that probed it."""
+
+    bucket: str
+    principal: str | None
+    account_id: str | None
+    region: str | None
+    checks: tuple[GrantCheck, ...]
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.checks) and all(check.ok for check in self.checks)
+
+
+def _aws_error_detail(exc: BaseException) -> str:
+    response = getattr(exc, "response", None)
+    if isinstance(response, Mapping):
+        error = response.get("Error")
+        if isinstance(error, Mapping):
+            code = str(error.get("Code") or "").strip()
+            message = str(error.get("Message") or "").strip()
+            if code and message:
+                return f"{code}: {message}"
+            if code:
+                return code
+    return str(exc)
+
+
+def _normalized_principal(principal: str | None) -> str | None:
+    """Map an assumed-role session ARN back to the role ARN policies name."""
+    if not principal:
+        return None
+    parts = principal.split(":")
+    if len(parts) == 6 and parts[2] == "sts" and parts[5].startswith("assumed-role/"):
+        role_name = parts[5].split("/")[1]
+        return f"arn:aws:iam::{parts[4]}:role/{role_name}"
+    return principal
+
+
+def _statement_principals(statement: Mapping[str, Any]) -> list[str]:
+    principal = statement.get("Principal")
+    if principal is None:
+        return []
+    if isinstance(principal, Mapping):
+        aws = principal.get("AWS")
+    else:
+        aws = principal
+    if aws is None:
+        return []
+    if isinstance(aws, str):
+        return [aws]
+    return [str(item) for item in aws]
+
+
+def _statement_matches_principal(
+    statement: Mapping[str, Any], principal: str | None, account_id: str | None
+) -> bool:
+    candidates = {value for value in (_normalized_principal(principal),) if value}
+    if account_id:
+        candidates.add(account_id)
+        candidates.add(f"arn:aws:iam::{account_id}:root")
+    for value in _statement_principals(statement):
+        if value == "*" or value in candidates:
+            return True
+    return False
+
+
+def _statement_actions(statement: Mapping[str, Any]) -> set[str]:
+    actions = statement.get("Action")
+    if actions is None:
+        return set()
+    if isinstance(actions, str):
+        actions = [actions]
+    return {str(action).lower() for action in actions}
+
+
+def sns_policy_granted_actions(
+    policy: Mapping[str, Any] | None,
+    actions: Sequence[str],
+    *,
+    principal: str | None,
+    account_id: str | None,
+    topic_arn: str,
+) -> set[str]:
+    """Return which *actions* an SNS topic policy allows for this principal."""
+    if not policy:
+        return set()
+    statements = policy.get("Statement") or []
+    if isinstance(statements, Mapping):
+        statements = [statements]
+
+    granted: set[str] = set()
+    for statement in statements:
+        if not isinstance(statement, Mapping):
+            continue
+        if str(statement.get("Effect", "Allow")) != "Allow":
+            continue
+        resources = statement.get("Resource")
+        if isinstance(resources, str):
+            resources = [resources]
+        if resources and topic_arn not in resources and "*" not in resources:
+            continue
+        if not _statement_matches_principal(statement, principal, account_id):
+            continue
+        allowed = _statement_actions(statement)
+        for action in actions:
+            lowered = action.lower()
+            service = lowered.split(":", 1)[0]
+            if allowed & {"*", f"{service}:*", lowered}:
+                granted.add(action)
+    return granted
+
+
+def _first_notification_topic(notification_config: Mapping[str, Any]) -> str | None:
+    for config in notification_config.get("TopicConfigurations", []):
+        topic_arn = config.get("TopicArn")
+        if topic_arn and _has_object_notification_event(config.get("Events") or []):
+            return str(topic_arn)
+    return None
+
+
+def _arn_region(arn: str) -> str | None:
+    parts = arn.split(":")
+    return parts[3] if len(parts) > 5 and parts[3] else None
+
+
+def probe_bucket_grant(
+    bucket: str,
+    *,
+    session: Any,
+    expected_account_id: str | None = None,
+) -> BucketGrantReport:
+    """Check a bucket grant from the control account, before registration.
+
+    Reports the principal that ran the checks so a grant issued to the wrong
+    account is identified at the handoff instead of surfacing later as an
+    opaque ``AccessDenied``.
+    """
+    from botocore.exceptions import BotoCoreError
+
+    checks: list[GrantCheck] = []
+    principal: str | None = None
+    account_id: str | None = None
+    region: str | None = None
+
+    try:
+        identity = session.client("sts").get_caller_identity()
+        principal = str(identity.get("Arn") or "") or None
+        account_id = str(identity.get("Account") or "") or None
+        checks.append(
+            GrantCheck(
+                "probing principal (sts:GetCallerIdentity)",
+                True,
+                principal or f"account {account_id}",
+            )
+        )
+    except (ClientError, BotoCoreError) as exc:
+        checks.append(
+            GrantCheck(
+                "probing principal (sts:GetCallerIdentity)",
+                False,
+                _aws_error_detail(exc),
+            )
+        )
+
+    if expected_account_id:
+        matched = account_id == expected_account_id
+        checks.append(
+            GrantCheck(
+                "control account match",
+                matched,
+                (
+                    f"probing in the Quilt control account {expected_account_id}"
+                    if matched
+                    else (
+                        f"probe ran in account {account_id or 'unknown'}, but the "
+                        f"catalog's control account is {expected_account_id}"
+                    )
+                ),
+            )
+        )
+
+    s3_client: Any = None
+    try:
+        s3_client, region = open_bucket_client(bucket, session)
+        checks.append(
+            GrantCheck(
+                "bucket reachable (s3:GetBucketLocation)", True, f"region {region}"
+            )
+        )
+    except (ClientError, BotoCoreError) as exc:
+        checks.append(
+            GrantCheck(
+                "bucket reachable (s3:GetBucketLocation)",
+                False,
+                _aws_error_detail(exc),
+            )
+        )
+
+    topic_arn: str | None = None
+    if s3_client is not None:
+        try:
+            listing = s3_client.list_objects_v2(Bucket=bucket, MaxKeys=1)
+            empty = not int(listing.get("KeyCount") or 0)
+            checks.append(
+                GrantCheck(
+                    "list bucket (s3:ListBucket)",
+                    True,
+                    (
+                        "bucket is empty; access is still valid"
+                        if empty
+                        else "listing returned an object"
+                    ),
+                )
+            )
+        except (ClientError, BotoCoreError) as exc:
+            checks.append(
+                GrantCheck("list bucket (s3:ListBucket)", False, _aws_error_detail(exc))
+            )
+
+        try:
+            notifications = get_bucket_notification_configuration(
+                bucket, s3_client=s3_client
+            )
+            topic_arn = _existing_notification_topic(
+                notifications
+            ) or _first_notification_topic(notifications)
+            checks.append(
+                GrantCheck(
+                    "read notifications (s3:GetBucketNotification)",
+                    bool(topic_arn),
+                    (
+                        f"object notifications publish to {topic_arn}"
+                        if topic_arn
+                        else (
+                            "no SNS topic receives object-create/remove events; run "
+                            "`quiltx bucket prepare` in the data account first"
+                        )
+                    ),
+                )
+            )
+        except (ClientError, BotoCoreError) as exc:
+            checks.append(
+                GrantCheck(
+                    "read notifications (s3:GetBucketNotification)",
+                    False,
+                    _aws_error_detail(exc),
+                )
+            )
+
+    if topic_arn:
+        try:
+            sns_client = session.client(
+                "sns", region_name=_arn_region(topic_arn) or region
+            )
+            attributes = sns_client.get_topic_attributes(TopicArn=topic_arn).get(
+                "Attributes", {}
+            )
+            checks.append(
+                GrantCheck(
+                    "read SNS topic (sns:GetTopicAttributes)", True, str(topic_arn)
+                )
+            )
+            granted = sns_policy_granted_actions(
+                _parse_json_document(attributes.get("Policy")),
+                GRANT_SNS_ACTIONS,
+                principal=principal,
+                account_id=account_id,
+                topic_arn=topic_arn,
+            )
+            missing = [action for action in GRANT_SNS_ACTIONS if action not in granted]
+            checks.append(
+                GrantCheck(
+                    "SNS topic policy grants subscribe",
+                    not missing,
+                    (
+                        "topic policy allows " + ", ".join(GRANT_SNS_ACTIONS)
+                        if not missing
+                        else (
+                            f"topic policy does not allow {', '.join(missing)} for "
+                            f"{principal or account_id or 'this principal'}"
+                        )
+                    ),
+                )
+            )
+        except (ClientError, BotoCoreError) as exc:
+            checks.append(
+                GrantCheck(
+                    "read SNS topic (sns:GetTopicAttributes)",
+                    False,
+                    _aws_error_detail(exc),
+                )
+            )
+
+    return BucketGrantReport(
+        bucket=bucket,
+        principal=principal,
+        account_id=account_id,
+        region=region,
+        checks=tuple(checks),
+    )
+
+
 def _bucket_add_typename(result: Any) -> str:
     if isinstance(result, Mapping):
         value = result.get("__typename") or result.get("typename__")

--- a/quiltx/bucket.py
+++ b/quiltx/bucket.py
@@ -1339,26 +1339,65 @@ def _statement_actions(statement: Mapping[str, Any]) -> set[str]:
     return {str(action).lower() for action in actions}
 
 
-def sns_policy_granted_actions(
+@dataclass(frozen=True)
+class SnsPolicyEvaluation:
+    """Static reading of an SNS topic policy for one principal.
+
+    ``conditional`` holds actions that only a condition-bearing statement
+    allows. Conditions are not evaluated, so those actions are reported apart
+    from ``granted`` rather than assumed to apply -- the canonical SNS owner
+    statement, for instance, allows Subscribe only to the topic owner.
+    """
+
+    granted: frozenset[str]
+    denied: frozenset[str]
+    conditional: frozenset[str]
+
+    def missing(self, actions: Sequence[str]) -> list[str]:
+        return [action for action in actions if action not in self.granted]
+
+
+def _statement_covers_actions(
+    statement: Mapping[str, Any], actions: Sequence[str]
+) -> set[str]:
+    listed = _statement_actions(statement)
+    covered: set[str] = set()
+    for action in actions:
+        lowered = action.lower()
+        service = lowered.split(":", 1)[0]
+        if listed & {"*", f"{service}:*", lowered}:
+            covered.add(action)
+    return covered
+
+
+def evaluate_sns_policy(
     policy: Mapping[str, Any] | None,
     actions: Sequence[str],
     *,
     principal: str | None,
     account_id: str | None,
     topic_arn: str,
-) -> set[str]:
-    """Return which *actions* an SNS topic policy allows for this principal."""
+) -> SnsPolicyEvaluation:
+    """Read which *actions* an SNS topic policy allows for this principal.
+
+    An explicit ``Deny`` overrides any allow, matching IAM evaluation. Only
+    unconditional allows count as granted; ``NotPrincipal`` and ``NotAction``
+    are not interpreted, so a policy using them is read conservatively.
+    """
     if not policy:
-        return set()
+        return SnsPolicyEvaluation(frozenset(), frozenset(), frozenset())
     statements = policy.get("Statement") or []
     if isinstance(statements, Mapping):
         statements = [statements]
 
     granted: set[str] = set()
+    denied: set[str] = set()
+    conditional: set[str] = set()
     for statement in statements:
         if not isinstance(statement, Mapping):
             continue
-        if str(statement.get("Effect", "Allow")) != "Allow":
+        effect = str(statement.get("Effect", "Allow"))
+        if effect not in {"Allow", "Deny"}:
             continue
         resources = statement.get("Resource")
         if isinstance(resources, str):
@@ -1367,13 +1406,56 @@ def sns_policy_granted_actions(
             continue
         if not _statement_matches_principal(statement, principal, account_id):
             continue
-        allowed = _statement_actions(statement)
-        for action in actions:
-            lowered = action.lower()
-            service = lowered.split(":", 1)[0]
-            if allowed & {"*", f"{service}:*", lowered}:
-                granted.add(action)
-    return granted
+        covered = _statement_covers_actions(statement, actions)
+        if not covered:
+            continue
+        if effect == "Deny":
+            # A conditional deny may not apply, but treating it as binding is
+            # the safe reading: the probe under-reports access rather than
+            # promising a grant AWS refuses.
+            denied |= covered
+        elif statement.get("Condition"):
+            conditional |= covered
+        else:
+            granted |= covered
+
+    return SnsPolicyEvaluation(
+        granted=frozenset(granted - denied),
+        denied=frozenset(denied),
+        conditional=frozenset(conditional - denied),
+    )
+
+
+def _sns_grant_detail(
+    evaluation: SnsPolicyEvaluation,
+    *,
+    principal: str | None,
+    account_id: str | None,
+) -> str:
+    """Explain an SNS policy reading in terms an operator can act on."""
+    who = principal or account_id or "this principal"
+    missing = evaluation.missing(GRANT_SNS_ACTIONS)
+    if not missing:
+        return f"topic policy allows {', '.join(GRANT_SNS_ACTIONS)} for {who}"
+
+    reasons: list[str] = []
+    denied = [action for action in missing if action in evaluation.denied]
+    if denied:
+        reasons.append(f"explicitly denied: {', '.join(denied)}")
+    conditional = [action for action in missing if action in evaluation.conditional]
+    if conditional:
+        reasons.append(
+            f"allowed only under conditions quiltx does not evaluate: "
+            f"{', '.join(conditional)}"
+        )
+    absent = [
+        action
+        for action in missing
+        if action not in evaluation.denied and action not in evaluation.conditional
+    ]
+    if absent:
+        reasons.append(f"not allowed: {', '.join(absent)}")
+    return f"topic policy for {who}: " + "; ".join(reasons)
 
 
 def _first_notification_topic(notification_config: Mapping[str, Any]) -> str | None:
@@ -1526,25 +1608,19 @@ def probe_bucket_grant(
                     "read SNS topic (sns:GetTopicAttributes)", True, str(topic_arn)
                 )
             )
-            granted = sns_policy_granted_actions(
+            evaluation = evaluate_sns_policy(
                 _parse_json_document(attributes.get("Policy")),
                 GRANT_SNS_ACTIONS,
                 principal=principal,
                 account_id=account_id,
                 topic_arn=topic_arn,
             )
-            missing = [action for action in GRANT_SNS_ACTIONS if action not in granted]
             checks.append(
                 GrantCheck(
                     "SNS topic policy grants subscribe",
-                    not missing,
-                    (
-                        "topic policy allows " + ", ".join(GRANT_SNS_ACTIONS)
-                        if not missing
-                        else (
-                            f"topic policy does not allow {', '.join(missing)} for "
-                            f"{principal or account_id or 'this principal'}"
-                        )
+                    not evaluation.missing(GRANT_SNS_ACTIONS),
+                    _sns_grant_detail(
+                        evaluation, principal=principal, account_id=account_id
                     ),
                 )
             )

--- a/quiltx/quilt3_facade.py
+++ b/quiltx/quilt3_facade.py
@@ -163,6 +163,26 @@ def admin_modules() -> AdminClients:
     )
 
 
+def admin_graphql_client() -> Any:
+    """Return quilt3's authenticated admin GraphQL client for the active catalog."""
+    from quilt3.admin import util
+
+    return util.get_client()
+
+
+def admin_graphql(query: str, variables: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Execute a raw admin GraphQL document and return its ``data`` payload.
+
+    Used for operations quilt3 does not generate a typed method for — notably
+    reading and re-submitting a bucket's complete configuration, which is how
+    the catalog stack is asked to re-verify live bucket access with its own
+    identity.
+    """
+    client = admin_graphql_client()
+    response = client.execute(query=query, variables=dict(variables))
+    return client.get_data(response)
+
+
 def make_bucket(bucket_uri: str) -> object:
     """Return a quilt3.Bucket instance for the given s3:// URI."""
     import quilt3

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -61,7 +61,19 @@ def build_parser() -> argparse.ArgumentParser:
     add_parser.add_argument(
         "--no-test",
         action="store_true",
-        help="Skip the post-add registration/read verification.",
+        help=(
+            "Skip the post-add verification (registration, live access, "
+            "index wiring). Applies to --no-preflight too."
+        ),
+    )
+    add_parser.add_argument(
+        "--require-index",
+        action="store_true",
+        help=(
+            "Fail when the search index has no entries yet. By default an "
+            "empty index is a warning once live access is verified, since "
+            "indexing lags registration and empty buckets never index."
+        ),
     )
     add_parser.add_argument(
         "--no-preflight",
@@ -69,7 +81,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Skip local AWS preflight/setup and submit bucketAdd directly, "
             "letting the catalog stack probe the bucket. Never prompts for "
-            "confirmation (--yes is not required)."
+            "confirmation (--yes is not required). Post-add verification "
+            "still runs; use --no-test to skip it."
         ),
     )
     add_parser.add_argument(
@@ -185,10 +198,38 @@ def build_parser() -> argparse.ArgumentParser:
     test_parser = subparsers.add_parser(
         "test",
         prog="quiltx bucket test",
-        help="Verify the control account can read the bucket (tests cross-account policy).",
+        help=(
+            "Verify registration, live catalog-stack access, and index wiring "
+            "for a bucket (or a grant, with --pre-registration)."
+        ),
     )
     add_catalog_args(test_parser, auth_required=True)
     test_parser.add_argument("bucket_name", help="S3 bucket name to test.")
+    test_parser.add_argument(
+        "--require-index",
+        action="store_true",
+        help=(
+            "Fail when the search index has no entries yet, instead of warning "
+            "once live access is verified."
+        ),
+    )
+    test_parser.add_argument(
+        "--pre-registration",
+        action="store_true",
+        help=(
+            "Check a cross-account grant before the bucket is registered: "
+            "bucket reachable, notifications readable, SNS topic subscribable. "
+            "Runs from the control account and reports the principal used; "
+            "'not registered' is an expected state in this mode."
+        ),
+    )
+    test_parser.add_argument(
+        "--profile",
+        help=(
+            "AWS profile for the Quilt control account, used only by "
+            "--pre-registration."
+        ),
+    )
 
     reindex_parser = subparsers.add_parser(
         "reindex",
@@ -743,6 +784,8 @@ def _cmd_add(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
             stack,
             args.bucket_name,
             control_account_id=control_account_id,
+            principal=_stack_output_value(stack_payload, "RegistryRoleARN"),
+            require_index=bool(getattr(args, "require_index", False)),
         )
     except Exception as exc:
         if stack_lib.is_auth_error(exc):
@@ -767,37 +810,51 @@ def _cmd_add_no_preflight(stack: stack_lib.Catalog, args: argparse.Namespace) ->
             "removing and re-adding (--force) via GraphQL only."
         )
         stack.admin.buckets.remove(args.bucket_name)
-    elif existing_bucket is not None:
-        print(
-            f"Bucket {args.bucket_name}: already registered in Quilt; "
-            "local preflight/setup skipped."
-        )
-        return 0
+        existing_bucket = None
 
-    try:
-        result = bucket_lib.add_bucket_without_preflight(
-            stack,
-            args.bucket_name,
-            title=bucket_title,
-        )
-    except bucket_lib.BucketAddError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
-
-    if result.already_registered:
+    if existing_bucket is not None:
         print(
             f"Bucket {args.bucket_name}: already registered in Quilt; "
             "local preflight/setup skipped."
         )
     else:
+        try:
+            result = bucket_lib.add_bucket_without_preflight(
+                stack,
+                args.bucket_name,
+                title=bucket_title,
+            )
+        except bucket_lib.BucketAddError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+        if result.already_registered:
+            print(
+                f"Bucket {args.bucket_name}: already registered in Quilt; "
+                "local preflight/setup skipped."
+            )
+        else:
+            print(
+                f"Registered bucket {result.bucket} as {result.title} "
+                "via GraphQL only; local AWS preflight/setup skipped."
+            )
+
+    if args.no_test:
         print(
-            f"Registered bucket {result.bucket} as {result.title} "
-            "via GraphQL only; local AWS preflight/setup skipped."
+            f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
         )
-    print(
-        f"Run `quiltx bucket test {args.bucket_name}` to verify registration and access."
+        return 0
+
+    # --no-preflight is the cross-account flow, spanning two accounts and often
+    # two organizations: the configuration most likely to be wrong. Verification
+    # is catalog-side work and needs no data-account credentials, so it runs
+    # here too (issue #92).
+    print()
+    return _verify_bucket_registration_and_access(
+        stack,
+        args.bucket_name,
+        require_index=bool(getattr(args, "require_index", False)),
     )
-    return 0
 
 
 @stack_lib.catalog_command
@@ -884,17 +941,97 @@ def _cmd_profile(args: argparse.Namespace) -> int:
 
 @stack_lib.catalog_command
 def _cmd_test(stack: stack_lib.Catalog, args: argparse.Namespace) -> int:
-    return _verify_bucket_registration_and_access(stack, args.bucket_name)
+    if getattr(args, "pre_registration", False):
+        control_account_id, _principal = _control_context(stack)
+        return _cmd_test_pre_registration(stack, args, control_account_id)
+    # control_account_id / principal are resolved lazily, only when a failure
+    # needs them, so the standalone path reports them instead of "unknown"
+    # (issue #92) without paying for stack discovery on the happy path.
+    return _verify_bucket_registration_and_access(
+        stack,
+        args.bucket_name,
+        require_index=bool(getattr(args, "require_index", False)),
+    )
+
+
+def _cmd_test_pre_registration(
+    stack: stack_lib.Catalog,
+    args: argparse.Namespace,
+    control_account_id: str | None,
+) -> int:
+    """Check a cross-account grant before any catalog registration exists."""
+    bucket_name = args.bucket_name
+    print(f"Pre-registration grant check for s3://{bucket_name}:")
+    if stack.admin.buckets.get(bucket_name) is not None:
+        print(
+            "  registered in Quilt: yes; --pre-registration only checks the "
+            "control-account grant"
+        )
+    else:
+        print("  registered in Quilt: no (expected with --pre-registration)")
+
+    session = boto3.Session(profile_name=args.profile)
+    report = bucket_lib.probe_bucket_grant(
+        bucket_name,
+        session=session,
+        expected_account_id=control_account_id,
+    )
+    for check in report.checks:
+        status = "OK" if check.ok else "FAILED"
+        print(f"  {status}: {check.name}: {check.detail}")
+
+    if report.ok:
+        print(
+            f"OK: the grant on s3://{bucket_name} is usable from "
+            f"{report.principal or 'this principal'}."
+        )
+        print(
+            f"Next step: quiltx bucket add {bucket_name} --no-preflight "
+            "--catalog <catalog>"
+        )
+        return 0
+
+    print(
+        f"FAILED: the grant on s3://{bucket_name} is not usable yet.",
+        file=sys.stderr,
+    )
+    print(
+        f"  - probing principal: {report.principal or 'unknown'}",
+        file=sys.stderr,
+    )
+    print(
+        f"  - Quilt control account: {control_account_id or 'unknown'}",
+        file=sys.stderr,
+    )
+    print(
+        "  - note: checks reflect the probing principal; a grant narrowed to "
+        "specific stack roles may still differ from what the stack sees",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def _verify_bucket_registration_and_access(
-    stack: stack_lib.Catalog, bucket_name: str, *, control_account_id: str | None = None
+    stack: stack_lib.Catalog,
+    bucket_name: str,
+    *,
+    control_account_id: str | None = None,
+    principal: str | None = None,
+    require_index: bool = False,
 ) -> int:
-    from quiltx.quilt3_facade import make_bucket
+    """Report registration, live catalog-stack access, and index wiring.
 
-    bucket_uri = f"s3://{bucket_name}"
-    registered = None
-    stage = "registration lookup"
+    The three checks answer different questions and are reported separately
+    (issue #87): registration is a catalog lookup, live access is re-validated
+    server-side with the stack's own identity, and index wiring depends on
+    SNS -> SQS delivery plus an initial scan that legitimately lags.
+
+    ``control_account_id`` and ``principal`` name the Quilt side of a
+    cross-account grant. When omitted they are derived from stack metadata at
+    the moment a failure is reported, so the diagnostic lines are populated
+    even in the standalone ``bucket test`` path (issue #92).
+    """
+    context = _ControlContext(stack, control_account_id, principal)
     try:
         registered = next(
             (
@@ -904,64 +1041,223 @@ def _verify_bucket_registration_and_access(
             ),
             None,
         )
-        if registered is None:
-            raise ValueError(f"{bucket_name} is not registered in Quilt")
-
-        # Direct S3 access check (b.ls()) intentionally skipped: it ran with
-        # the user's locally-cached Quilt STS credentials, which may be stale
-        # or scoped by a role that doesn't grant access to this bucket. That
-        # produced false-negative AccessDenied errors after legitimate
-        # bucket-add operations. See issue tracker for "stale credentials
-        # prevent direct verification".
-
-        stage = "search index probe"
-        # Confirm the catalog's search index actually has entries for this
-        # bucket — proves the SNS -> SQS subscription wiring is live.
-        # Retry briefly since the initial scan can lag a freshly added bucket.
-        import time as _time
-
-        b: Any = make_bucket(bucket_uri)
-        results: list[Any] = []
-        for attempt in range(6):
-            results = b.search("*", limit=1)
-            if results:
-                break
-            if attempt < 5:
-                _time.sleep(10)
-        if not results:
-            raise RuntimeError(
-                "search index returned 0 results after ~60s; SNS "
-                "subscription or initial scan has not indexed this bucket yet"
-            )
-
-        print(f"OK: {bucket_name} is registered in Quilt as {registered.title}")
-        print(f"OK: search index is populated ({len(results)}+ result[s])")
-        return 0
     except Exception as exc:
         if stack_lib.is_auth_error(exc):
             raise
-        control_line = (
-            f"  - Quilt control account: {control_account_id}"
-            if control_account_id
-            else "  - Quilt control account: unknown"
+        return _print_verification_failure(
+            bucket_name,
+            stage="registration lookup",
+            registered=False,
+            context=context,
+            capability="catalog registration",
+            error=str(exc),
+            cause="registration lookup failed",
         )
-        registered_tag = "yes" if registered is not None else "no"
-        if stage == "search index probe":
-            cause = (
-                "  - likely cause: bucket's SNS topic is not subscribed to "
-                "this stack's SQS queues, or initial scan has not completed"
-            )
-        else:
-            cause = "  - likely cause: registration lookup failed"
-        lines = [
-            f"FAILED: bucket {bucket_name} verification failed at {stage}.",
-            f"  - registered in Quilt: {registered_tag}",
-            control_line,
-            f"  - error: {exc}",
-            cause,
-        ]
-        print("\n".join(lines), file=sys.stderr)
-        return 1
+
+    if registered is None:
+        return _print_verification_failure(
+            bucket_name,
+            stage="registration lookup",
+            registered=False,
+            context=context,
+            capability="catalog registration",
+            error=f"{bucket_name} is not registered in Quilt",
+            cause="the bucket has no catalog row",
+            hint=(
+                f"to check the grant before registering, run: "
+                f"quiltx bucket test {bucket_name} --pre-registration"
+            ),
+        )
+    print(f"OK: {bucket_name} is registered in Quilt as {registered.title}")
+
+    # Live access: the catalog re-validates the bucket with the stack's own
+    # identity, so an empty bucket passes and revoked access fails even when a
+    # stale search-index entry survives. Re-validation resubmits the bucket's
+    # existing configuration unchanged; QUILTX_NO_LIVE_PROBE=1 opts out for
+    # catalogs where no bucket mutation is acceptable.
+    probe = _live_access_probe(stack, bucket_name)
+    if probe.failed:
+        return _print_verification_failure(
+            bucket_name,
+            stage="live access probe",
+            registered=True,
+            context=context,
+            capability=probe.capability,
+            error=probe.detail,
+            cause=(
+                "the catalog stack's identity cannot read this bucket; check "
+                "the bucket policy grant for the principal above"
+            ),
+        )
+    if probe.unavailable:
+        print(f"SKIPPED: live access probe unavailable ({probe.detail})")
+    else:
+        print(f"OK: catalog stack has live access ({probe.capability})")
+
+    indexed, index_error = _probe_search_index(bucket_name)
+    if indexed is not None:
+        print(f"OK: search index is populated ({indexed}+ result[s])")
+        return 0
+
+    index_failure_is_fatal = require_index or not probe.ok
+    if index_failure_is_fatal:
+        return _print_verification_failure(
+            bucket_name,
+            stage="search index probe",
+            registered=True,
+            context=context,
+            capability="notification/index wiring",
+            error=index_error or "search index returned 0 results",
+            cause=(
+                "bucket's SNS topic is not subscribed to this stack's SQS "
+                "queues, or the initial scan has not completed"
+            ),
+        )
+
+    print(
+        f"WARNING: search index has no entries for {bucket_name} yet "
+        f"({index_error}).",
+        file=sys.stderr,
+    )
+    print(
+        "  - live access is verified, so this is indexing lag, an empty "
+        "bucket, or disabled indexing",
+        file=sys.stderr,
+    )
+    print(
+        f"  - to treat this as a failure, re-run: quiltx bucket test "
+        f"{bucket_name} --require-index",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _live_access_probe(
+    stack: stack_lib.Catalog, bucket_name: str
+) -> bucket_lib.BucketAccessProbe:
+    if _env_flag("QUILTX_NO_LIVE_PROBE"):
+        return bucket_lib.BucketAccessProbe(
+            bucket=bucket_name,
+            status="unavailable",
+            capability=bucket_lib.LIVE_ACCESS_CAPABILITY,
+            detail="disabled by QUILTX_NO_LIVE_PROBE",
+        )
+    return bucket_lib.probe_bucket_access(stack, bucket_name)
+
+
+def _probe_search_index(
+    bucket_name: str, *, attempts: int = 6, delay: float = 10.0
+) -> tuple[int | None, str | None]:
+    """Return (result count, None) once the index answers, else (None, reason).
+
+    Confirms the catalog's search index has entries for this bucket, which
+    proves the SNS -> SQS subscription wiring is live. Retries because the
+    initial scan lags a freshly added bucket.
+    """
+    import time as _time
+
+    from quiltx.quilt3_facade import make_bucket
+
+    try:
+        b: Any = make_bucket(f"s3://{bucket_name}")
+        for attempt in range(attempts):
+            results = b.search("*", limit=1)
+            if results:
+                return len(results), None
+            if attempt < attempts - 1:
+                _time.sleep(delay)
+    except Exception as exc:
+        if stack_lib.is_auth_error(exc):
+            raise
+        return None, f"search failed: {exc}"
+    return None, f"search index returned 0 results after ~{int(attempts * delay)}s"
+
+
+def _print_verification_failure(
+    bucket_name: str,
+    *,
+    stage: str,
+    registered: bool,
+    context: "_ControlContext",
+    capability: str,
+    error: str,
+    cause: str,
+    hint: str | None = None,
+) -> int:
+    control_account_id, principal = context.resolve()
+    lines = [
+        f"FAILED: bucket {bucket_name} verification failed at {stage}.",
+        f"  - registered in Quilt: {'yes' if registered else 'no'}",
+        f"  - Quilt control account: {control_account_id or 'unknown'}",
+        f"  - Quilt stack principal: {principal or 'unknown'}",
+        f"  - failed capability: {capability}",
+        f"  - error: {error}",
+        f"  - likely cause: {cause}",
+    ]
+    if hint:
+        lines.append(f"  - {hint}")
+    print("\n".join(lines), file=sys.stderr)
+    return 1
+
+
+class _ControlContext:
+    """The Quilt-side identity of a grant, resolved only when it is needed.
+
+    Stack discovery is not free, and the control account and stack principal
+    only matter when something failed — but then they are the answer, so they
+    must never be blank (issue #92).
+    """
+
+    def __init__(
+        self,
+        stack: stack_lib.Catalog,
+        control_account_id: str | None = None,
+        principal: str | None = None,
+    ) -> None:
+        self._stack = stack
+        self._control_account_id = control_account_id
+        self._principal = principal
+        self._resolved = control_account_id is not None or principal is not None
+
+    def resolve(self) -> tuple[str | None, str | None]:
+        if not self._resolved:
+            self._control_account_id, self._principal = _control_context(self._stack)
+            self._resolved = True
+        return self._control_account_id, self._principal
+
+
+def _control_context(stack: stack_lib.Catalog) -> tuple[str | None, str | None]:
+    """Return (control account id, stack principal ARN), best effort.
+
+    Both are diagnostic: when a grant was issued to the wrong account, these
+    two lines are the answer, so they must not be blank in the standalone
+    ``bucket test`` path (issue #92).
+    """
+    try:
+        payload = _ensure_stack_payload(stack)
+    except Exception as exc:
+        if stack_lib.is_auth_error(exc):
+            raise
+        print(f"Note: Quilt control account unknown: {exc}", file=sys.stderr)
+        return None, None
+
+    try:
+        control_account_id: str | None = _load_control_account_id(payload)
+    except ValueError as exc:
+        print(f"Note: {exc}", file=sys.stderr)
+        control_account_id = None
+    return control_account_id, _stack_output_value(payload, "RegistryRoleARN")
+
+
+def _stack_output_value(
+    stack_payload: Mapping[str, Any] | None, key: str
+) -> str | None:
+    for output in (stack_payload or {}).get("outputs") or []:
+        if not isinstance(output, Mapping):
+            continue
+        if str(output.get("OutputKey", "")) == key and output.get("OutputValue"):
+            return str(output["OutputValue"])
+    return None
 
 
 def _load_control_account_id(stack_payload: Mapping[str, Any] | None) -> str:
@@ -1132,9 +1428,13 @@ def _print_no_preflight_dry_run(
         "GetBucketPolicy / PutBucketPolicy",
         "SNS topic creation and policy configuration",
         "bucket-notification configuration",
-        "post-add verification (--no-preflight implies --no-test)",
     ):
         print(f"  - {item}")
+    print()
+    print(
+        "Post-add verification (registration, live catalog-stack access, index "
+        "wiring) still runs; pass --no-test to skip it."
+    )
 
 
 def _print_context_table(

--- a/quiltx/tools/bucket.py
+++ b/quiltx/tools/bucket.py
@@ -1206,6 +1206,11 @@ class _ControlContext:
     Stack discovery is not free, and the control account and stack principal
     only matter when something failed — but then they are the answer, so they
     must never be blank (issue #92).
+
+    Callers either supply both values or neither: both come from the same stack
+    payload, so a caller that already loaded it passes what that payload holds
+    (``principal`` is None when the stack has no ``RegistryRoleARN`` output) and
+    re-deriving would repeat the work for the same answer.
     """
 
     def __init__(

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -3765,33 +3765,84 @@ def test_probe_bucket_grant_flags_missing_notification_topic() -> None:
     assert _checks(report)["read notifications (s3:GetBucketNotification)"] is False
 
 
-def test_sns_policy_granted_actions_matches_assumed_role_sessions() -> None:
+def _evaluate(policy, *, principal="arn:aws:iam::123456789012:role/operator"):
+    return bucket_lib.evaluate_sns_policy(
+        policy,
+        ("sns:Subscribe",),
+        principal=principal,
+        account_id="123456789012",
+        topic_arn=TOPIC_ARN,
+    )
+
+
+def test_evaluate_sns_policy_matches_assumed_role_sessions() -> None:
     policy = _grant_sns_policy(
         "sns:Subscribe",
         principal="arn:aws:iam::123456789012:role/operator",
     )
-    granted = bucket_lib.sns_policy_granted_actions(
-        policy,
-        ("sns:Subscribe",),
-        principal="arn:aws:sts::123456789012:assumed-role/operator/session",
-        account_id="123456789012",
-        topic_arn=TOPIC_ARN,
+    evaluation = _evaluate(
+        policy, principal="arn:aws:sts::123456789012:assumed-role/operator/session"
     )
-    assert granted == {"sns:Subscribe"}
+    assert evaluation.granted == {"sns:Subscribe"}
+    assert evaluation.missing(("sns:Subscribe",)) == []
 
 
-def test_sns_policy_granted_actions_ignores_other_principals() -> None:
+def test_evaluate_sns_policy_ignores_other_principals() -> None:
     policy = _grant_sns_policy(
         "sns:Subscribe", principal="arn:aws:iam::999988887777:root"
     )
-    granted = bucket_lib.sns_policy_granted_actions(
-        policy,
-        ("sns:Subscribe",),
-        principal="arn:aws:iam::123456789012:role/operator",
-        account_id="123456789012",
-        topic_arn=TOPIC_ARN,
+    assert _evaluate(policy).granted == frozenset()
+
+
+def test_evaluate_sns_policy_honors_explicit_deny() -> None:
+    policy = _grant_sns_policy("sns:Subscribe")
+    policy["Statement"].append(
+        {
+            "Sid": "BlockSubscribe",
+            "Effect": "Deny",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": "sns:Subscribe",
+            "Resource": TOPIC_ARN,
+        }
     )
-    assert granted == set()
+    evaluation = _evaluate(policy)
+    assert evaluation.granted == frozenset()
+    assert evaluation.denied == {"sns:Subscribe"}
+    assert evaluation.missing(("sns:Subscribe",)) == ["sns:Subscribe"]
+
+
+def test_evaluate_sns_policy_does_not_assume_conditional_allows() -> None:
+    """The canonical owner statement allows Subscribe only to the topic owner."""
+    policy = bucket_lib._build_default_sns_owner_policy(TOPIC_ARN, "111122223333")
+    evaluation = _evaluate(policy)
+    assert evaluation.granted == frozenset()
+    assert evaluation.conditional == {"sns:Subscribe"}
+
+
+def test_probe_bucket_grant_flags_denied_subscribe(capsys) -> None:
+    policy = _grant_sns_policy("sns:GetTopicAttributes", "sns:Subscribe")
+    policy["Statement"].append(
+        {
+            "Sid": "BlockSubscribe",
+            "Effect": "Deny",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": "sns:Subscribe",
+            "Resource": TOPIC_ARN,
+        }
+    )
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(sns=_GrantSns(policy)),
+        expected_account_id="123456789012",
+    )
+
+    assert not report.ok
+    detail = next(
+        check.detail
+        for check in report.checks
+        if check.name == "SNS topic policy grants subscribe"
+    )
+    assert "explicitly denied: sns:Subscribe" in detail
 
 
 def test_test_pre_registration_passes_before_registration(monkeypatch, capsys) -> None:

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -3811,6 +3811,77 @@ def test_evaluate_sns_policy_honors_explicit_deny() -> None:
     assert evaluation.missing(("sns:Subscribe",)) == ["sns:Subscribe"]
 
 
+def test_evaluate_sns_policy_honors_oddly_spelled_deny() -> None:
+    """A Deny must never be skipped for spelling: that would over-report access."""
+    policy = _grant_sns_policy("sns:Subscribe")
+    policy["Statement"].append(
+        {
+            "Effect": "deny",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+            "Action": "sns:Subscribe",
+            "Resource": TOPIC_ARN,
+        }
+    )
+    evaluation = _evaluate(policy)
+    assert evaluation.granted == frozenset()
+    assert evaluation.denied == {"sns:Subscribe"}
+
+
+@pytest.mark.parametrize(
+    "principal",
+    [
+        "arn:aws:sts::123456789012:assumed-role",
+        "arn:aws:sts::123456789012:assumed-role/",
+        "arn:aws:sts::123456789012:federated-user/someone",
+        "not-an-arn",
+    ],
+)
+def test_normalized_principal_leaves_unparseable_arns_alone(principal) -> None:
+    assert bucket_lib._normalized_principal(principal) == principal
+
+
+def test_normalized_principal_maps_assumed_role_to_role_arn() -> None:
+    assert (
+        bucket_lib._normalized_principal(
+            "arn:aws:sts::123456789012:assumed-role/operator/session-name"
+        )
+        == "arn:aws:iam::123456789012:role/operator"
+    )
+
+
+def test_control_context_uses_supplied_values_without_rediscovery(monkeypatch) -> None:
+    """A caller that already loaded the stack payload is not made to reload it."""
+    monkeypatch.setattr(
+        bucket_tool,
+        "_control_context",
+        lambda stack: (_ for _ in ()).throw(
+            AssertionError("supplied context must not trigger stack discovery")
+        ),
+    )
+    context = bucket_tool._ControlContext(
+        make_fake_catalog(), "123456789012", principal=None
+    )
+    assert context.resolve() == ("123456789012", None)
+
+
+def test_control_context_derives_when_nothing_is_supplied(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_context(stack):
+        calls.append("resolved")
+        return "123456789012", "arn:aws:iam::123456789012:role/quilt-registry"
+
+    monkeypatch.setattr(bucket_tool, "_control_context", fake_context)
+    context = bucket_tool._ControlContext(make_fake_catalog())
+
+    assert context.resolve() == (
+        "123456789012",
+        "arn:aws:iam::123456789012:role/quilt-registry",
+    )
+    assert context.resolve()[0] == "123456789012"
+    assert calls == ["resolved"]
+
+
 def test_evaluate_sns_policy_does_not_assume_conditional_allows() -> None:
     """The canonical owner statement allows Subscribe only to the topic owner."""
     policy = bucket_lib._build_default_sns_owner_policy(TOPIC_ARN, "111122223333")

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1305,7 +1305,72 @@ class FakeQuiltBucket:
         return [{"_source": {"key": "file.txt"}}]
 
 
-def _install_fake_quilt3(monkeypatch, *, get_result=None, listed=None, add_calls=None):
+def _fake_bucket_config(name: str) -> dict[str, Any]:
+    """A BucketConfig payload covering every BucketUpdateInput field."""
+    config: dict[str, Any] = {
+        field: None for field in bucket_lib.BUCKET_UPDATE_INPUT_FIELDS
+    }
+    config.update(
+        {
+            "name": name,
+            "lastIndexed": None,
+            "title": name,
+            "browsable": True,
+            "relevanceScore": 0,
+            "prefixes": [],
+        }
+    )
+    return config
+
+
+def _install_fake_graphql(
+    monkeypatch,
+    *,
+    typename: str = "BucketUpdateSuccess",
+    message: str | None = None,
+    registered: bool = True,
+    calls: list[tuple[str, dict[str, Any]]] | None = None,
+    error: BaseException | None = None,
+):
+    """Stub the admin GraphQL transport used by the live-access probe."""
+
+    def fake_graphql(query: str, variables):
+        if calls is not None:
+            calls.append((query, dict(variables)))
+        if error is not None:
+            raise error
+        if "quiltxBucketConfig" in query:
+            if not registered:
+                return {"bucketConfig": None}
+            return {"bucketConfig": _fake_bucket_config(str(variables["name"]))}
+        payload: dict[str, Any] = {"__typename": typename}
+        if message is not None:
+            payload["message"] = message
+        return {"bucketUpdate": payload}
+
+    monkeypatch.setattr(bucket_lib, "_admin_graphql", fake_graphql)
+    return fake_graphql
+
+
+def _stub_verification(monkeypatch, result: int = 0) -> list[str]:
+    """Record post-add verification calls instead of running them."""
+    calls: list[str] = []
+
+    def fake_verify(stack, bucket, **kwargs):
+        calls.append(bucket)
+        return result
+
+    monkeypatch.setattr(
+        bucket_tool, "_verify_bucket_registration_and_access", fake_verify
+    )
+    return calls
+
+
+def _install_fake_quilt3(
+    monkeypatch, *, get_result=None, listed=None, add_calls=None, graphql=True
+):
+    if graphql:
+        _install_fake_graphql(monkeypatch)
     bucket_list = list(listed or [])
     if get_result is not None and listed is None:
         bucket_list.append(get_result)
@@ -1602,6 +1667,7 @@ def test_add_already_registered_skips_post_test_when_no_test_flag(monkeypatch) -
 
 def test_add_no_preflight_registers_without_boto3(monkeypatch, capsys) -> None:
     add_calls: list[tuple[str, str | None]] = []
+    verify_calls: list[str] = []
     _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
     _install_stack_context(monkeypatch)
     monkeypatch.setattr(
@@ -1611,12 +1677,13 @@ def test_add_no_preflight_registers_without_boto3(monkeypatch, capsys) -> None:
             AssertionError("boto3 should not be used")
         ),
     )
+
+    def fake_verify(stack, bucket, **kwargs):
+        verify_calls.append(bucket)
+        return 0
+
     monkeypatch.setattr(
-        bucket_tool,
-        "_verify_bucket_registration_and_access",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            AssertionError("post-add test should not run")
-        ),
+        bucket_tool, "_verify_bucket_registration_and_access", fake_verify
     )
 
     def fake_add_without_preflight(stack, bucket, *, title=None):
@@ -1634,12 +1701,15 @@ def test_add_no_preflight_registers_without_boto3(monkeypatch, capsys) -> None:
     assert "via GraphQL only" in captured.out
     assert "local AWS preflight/setup skipped" in captured.out
     assert add_calls == [("bucket", "bucket")]
+    # Issue #92: the cross-account path verifies, it does not just suggest it.
+    assert verify_calls == ["bucket"]
 
 
 def test_add_no_preflight_env_var(monkeypatch) -> None:
     add_calls: list[str] = []
     _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
     _install_stack_context(monkeypatch)
+    _stub_verification(monkeypatch)
     monkeypatch.setenv("QUILTX_NO_PREFLIGHT", "1")
     monkeypatch.setattr(
         bucket_tool.boto3,
@@ -1666,6 +1736,7 @@ def test_add_no_preflight_env_var(monkeypatch) -> None:
 def test_add_no_preflight_no_prompt_does_not_require_yes(monkeypatch) -> None:
     _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
     _install_stack_context(monkeypatch)
+    _stub_verification(monkeypatch)
     monkeypatch.setattr(
         bucket_tool.bucket_lib,
         "add_bucket_without_preflight",
@@ -1680,6 +1751,7 @@ def test_add_no_preflight_no_prompt_does_not_require_yes(monkeypatch) -> None:
 def test_add_no_preflight_force_removes_then_adds(monkeypatch) -> None:
     calls: list[tuple[str, str]] = []
     _install_stack_context(monkeypatch)
+    _stub_verification(monkeypatch)
 
     buckets = SimpleNamespace()
     buckets.get = lambda name: FakeBucket(name, "Existing")
@@ -2161,16 +2233,297 @@ def test_test_checks_registration_and_read_access(monkeypatch, capsys) -> None:
     assert bucket_tool.main(["test", "bucket-a"]) == 0
     captured = capsys.readouterr()
     assert "OK: bucket-a is registered in Quilt as Bucket A" in captured.out
+    assert "OK: catalog stack has live access" in captured.out
     assert "OK: search index is populated" in captured.out
 
 
 def test_test_fails_when_bucket_not_registered(monkeypatch, capsys) -> None:
     _install_stack_context(monkeypatch)
     _install_fake_quilt3(monkeypatch, listed=[FakeBucket("other", "Other")])
+    monkeypatch.setattr(bucket_tool, "_control_context", lambda stack: (None, None))
 
     assert bucket_tool.main(["test", "bucket-a"]) == 1
     captured = capsys.readouterr()
     assert "bucket-a is not registered in Quilt" in captured.err
+    assert "--pre-registration" in captured.err
+
+
+# ------------------------------------------------------------------------
+# Live access verification (issue #87) and where it is wired (issue #92)
+# ------------------------------------------------------------------------
+
+
+def _install_index_probe(monkeypatch, *, results: int | None, error: str | None = None):
+    monkeypatch.setattr(
+        bucket_tool,
+        "_probe_search_index",
+        lambda bucket_name, **kwargs: (results, error),
+    )
+
+
+def test_probe_bucket_access_resubmits_the_current_config_unchanged(
+    monkeypatch,
+) -> None:
+    """The live probe must not rewrite configuration while re-validating."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+    _install_fake_graphql(monkeypatch, calls=calls)
+
+    probe = bucket_lib.probe_bucket_access(make_fake_catalog(), "bucket-a")
+
+    assert probe.ok
+    assert probe.capability == "bucket metadata, listing, and object read"
+    query, variables = calls[-1]
+    assert "bucketUpdate" in query
+    expected = _fake_bucket_config("bucket-a")
+    assert variables["input"] == {
+        field: expected[field] for field in bucket_lib.BUCKET_UPDATE_INPUT_FIELDS
+    }
+
+
+@pytest.mark.parametrize(
+    ("typename", "message", "capability"),
+    [
+        (
+            "InsufficientPermissions",
+            "s3:ListBucket denied for arn:aws:iam::123456789012:role/registry",
+            "S3 read access (ListBucket / GetObject)",
+        ),
+        (
+            "NotificationConfigurationError",
+            None,
+            "bucket notification configuration",
+        ),
+        ("NotificationTopicNotFound", None, "SNS notification topic"),
+    ],
+)
+def test_probe_bucket_access_reports_the_failed_capability(
+    monkeypatch, typename, message, capability
+) -> None:
+    _install_fake_graphql(monkeypatch, typename=typename, message=message)
+
+    probe = bucket_lib.probe_bucket_access(make_fake_catalog(), "bucket-a")
+
+    assert probe.failed
+    assert probe.capability == capability
+    assert typename in probe.detail
+    if message:
+        assert message in probe.detail
+
+
+def test_probe_bucket_access_unavailable_when_catalog_cannot_answer(
+    monkeypatch,
+) -> None:
+    _install_fake_graphql(monkeypatch, error=RuntimeError("Cannot query field"))
+
+    probe = bucket_lib.probe_bucket_access(make_fake_catalog(), "bucket-a")
+
+    assert probe.unavailable
+    assert "Cannot query field" in probe.detail
+
+
+def test_probe_bucket_access_reports_unregistered_bucket(monkeypatch) -> None:
+    _install_fake_graphql(monkeypatch, registered=False)
+
+    probe = bucket_lib.probe_bucket_access(make_fake_catalog(), "bucket-a")
+
+    assert probe.failed
+    assert probe.capability == "catalog registration"
+
+
+def test_test_passes_for_empty_bucket_with_no_index_entries(
+    monkeypatch, capsys
+) -> None:
+    """Issue #87: a valid empty bucket passes; an empty index is not a failure."""
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_index_probe(
+        monkeypatch, results=None, error="search index returned 0 results after ~60s"
+    )
+
+    assert bucket_tool.main(["test", "bucket-a"]) == 0
+    captured = capsys.readouterr()
+    assert "OK: catalog stack has live access" in captured.out
+    assert "WARNING: search index has no entries" in captured.err
+    assert "--require-index" in captured.err
+
+
+def test_test_require_index_treats_empty_index_as_failure(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_index_probe(monkeypatch, results=None, error="0 results")
+    monkeypatch.setattr(
+        bucket_tool, "_control_context", lambda stack: ("123456789012", None)
+    )
+
+    assert bucket_tool.main(["test", "bucket-a", "--require-index"]) == 1
+    captured = capsys.readouterr()
+    assert "failed at search index probe" in captured.err
+    assert "failed capability: notification/index wiring" in captured.err
+
+
+def test_test_fails_on_revoked_access_despite_stale_index(monkeypatch, capsys) -> None:
+    """Issue #87: a stale index entry must not mask revoked live access."""
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_fake_graphql(
+        monkeypatch,
+        typename="InsufficientPermissions",
+        message="s3:ListBucket denied",
+    )
+    _install_index_probe(monkeypatch, results=5)
+    monkeypatch.setattr(
+        bucket_tool,
+        "_control_context",
+        lambda stack: ("123456789012", "arn:aws:iam::123456789012:role/quilt-registry"),
+    )
+
+    assert bucket_tool.main(["test", "bucket-a"]) == 1
+    captured = capsys.readouterr()
+    assert "failed at live access probe" in captured.err
+    assert "failed capability: S3 read access" in captured.err
+    assert "s3:ListBucket denied" in captured.err
+    # Issue #92: the lines that identify a wrong-account grant are populated.
+    assert "Quilt control account: 123456789012" in captured.err
+    assert "arn:aws:iam::123456789012:role/quilt-registry" in captured.err
+    assert "OK: search index" not in captured.out
+
+
+def test_test_falls_back_to_index_when_probe_unavailable(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_fake_graphql(monkeypatch, error=RuntimeError("unknown field bucketUpdate"))
+    _install_index_probe(monkeypatch, results=1)
+
+    assert bucket_tool.main(["test", "bucket-a"]) == 0
+    captured = capsys.readouterr()
+    assert "SKIPPED: live access probe unavailable" in captured.out
+    assert "OK: search index is populated" in captured.out
+
+
+def test_test_unavailable_probe_keeps_index_failure_fatal(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_fake_graphql(monkeypatch, error=RuntimeError("unknown field bucketUpdate"))
+    _install_index_probe(monkeypatch, results=None, error="0 results")
+    monkeypatch.setattr(bucket_tool, "_control_context", lambda stack: (None, None))
+
+    assert bucket_tool.main(["test", "bucket-a"]) == 1
+    assert "failed at search index probe" in capsys.readouterr().err
+
+
+def test_test_live_probe_can_be_disabled_by_env(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, listed=[FakeBucket("bucket-a", "Bucket A")])
+    _install_fake_graphql(
+        monkeypatch,
+        error=AssertionError("QUILTX_NO_LIVE_PROBE must skip the mutation"),
+    )
+    _install_index_probe(monkeypatch, results=1)
+    monkeypatch.setenv("QUILTX_NO_LIVE_PROBE", "1")
+
+    assert bucket_tool.main(["test", "bucket-a"]) == 0
+    assert "QUILTX_NO_LIVE_PROBE" in capsys.readouterr().out
+
+
+def test_probe_search_index_retries_before_giving_up(monkeypatch) -> None:
+    """Issue #87: indexing delay is retried, then reported as a delay."""
+    attempts: list[int] = []
+
+    class _SlowBucket:
+        def search(self, _query, limit=10):
+            attempts.append(1)
+            return [] if len(attempts) < 3 else [{"_source": {}}]
+
+    monkeypatch.setattr("quiltx.quilt3_facade.make_bucket", lambda _uri: _SlowBucket())
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert bucket_tool._probe_search_index("bucket-a", delay=0) == (1, None)
+    assert len(attempts) == 3
+
+
+def test_probe_search_index_reports_indexing_delay(monkeypatch) -> None:
+    class _EmptyBucket:
+        def search(self, _query, limit=10):
+            return []
+
+    monkeypatch.setattr("quiltx.quilt3_facade.make_bucket", lambda _uri: _EmptyBucket())
+
+    count, error = bucket_tool._probe_search_index("bucket-a", attempts=2, delay=0)
+    assert count is None
+    assert error is not None and "0 results" in error
+
+
+def test_add_no_preflight_verification_failure_exits_nonzero(
+    monkeypatch, capsys
+) -> None:
+    """Issue #92: --no-preflight cannot return 0 for an unreadable bucket."""
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(
+        monkeypatch,
+        get_result=None,
+        listed=[FakeBucket("bucket-a", "Bucket A")],
+        add_calls=[],
+    )
+    _install_fake_graphql(
+        monkeypatch, typename="InsufficientPermissions", message="s3:GetObject denied"
+    )
+    _install_index_probe(monkeypatch, results=1)
+    monkeypatch.setattr(
+        bucket_tool, "_control_context", lambda stack: ("123456789012", None)
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: AddBucketResult(
+            bucket, title or bucket, "", False
+        ),
+    )
+
+    assert bucket_tool.main(["add", "bucket-a", "--no-preflight"]) == 1
+    captured = capsys.readouterr()
+    assert "Registered bucket bucket-a" in captured.out
+    assert "failed at live access probe" in captured.err
+
+
+def test_add_no_preflight_no_test_skips_verification(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
+    monkeypatch.setattr(
+        bucket_tool,
+        "_verify_bucket_registration_and_access",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("--no-test must skip verification")
+        ),
+    )
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: AddBucketResult(
+            bucket, title or bucket, "", False
+        ),
+    )
+
+    assert bucket_tool.main(["add", "bucket-a", "--no-preflight", "--no-test"]) == 0
+    assert "quiltx bucket test bucket-a" in capsys.readouterr().out
+
+
+def test_add_no_preflight_verifies_already_registered_bucket(monkeypatch) -> None:
+    """An existing catalog row does not prove the stack can read the bucket."""
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(
+        monkeypatch, get_result=FakeBucket("bucket-a", "Bucket A"), add_calls=[]
+    )
+    verify_calls = _stub_verification(monkeypatch)
+    monkeypatch.setattr(
+        bucket_tool.bucket_lib,
+        "add_bucket_without_preflight",
+        lambda stack, bucket, *, title=None: (_ for _ in ()).throw(
+            AssertionError("registered bucket must not be re-added")
+        ),
+    )
+
+    assert bucket_tool.main(["add", "bucket-a", "--no-preflight"]) == 0
+    assert verify_calls == ["bucket-a"]
 
 
 def test_build_parser_uses_bucket_prog() -> None:
@@ -3224,6 +3577,7 @@ def test_add_no_preflight_does_not_prompt_without_yes(monkeypatch) -> None:
     """Spec 7-no-preflight §144: --no-preflight should not need or trigger prompts."""
     _install_fake_quilt3(monkeypatch, get_result=None, add_calls=[])
     _install_stack_context(monkeypatch)
+    _stub_verification(monkeypatch)
     monkeypatch.setattr(
         "builtins.input",
         lambda _prompt="": (_ for _ in ()).throw(
@@ -3239,3 +3593,240 @@ def test_add_no_preflight_does_not_prompt_without_yes(monkeypatch) -> None:
     )
 
     assert bucket_tool.main(["add", "bucket", "--no-preflight"]) == 0
+
+
+# ------------------------------------------------------------------------
+# Pre-registration grant checks (issue #92)
+# ------------------------------------------------------------------------
+
+
+TOPIC_ARN = "arn:aws:sns:us-east-1:111122223333:quilt-bucket-a-notifications"
+
+
+def _grant_sns_policy(*actions: str, principal: str = "arn:aws:iam::123456789012:root"):
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "QuiltCrossAccountSNSAccess",
+                "Effect": "Allow",
+                "Principal": {"AWS": principal},
+                "Action": list(actions),
+                "Resource": TOPIC_ARN,
+            }
+        ],
+    }
+
+
+class _GrantS3:
+    """S3 double covering the calls the pre-registration grant probe makes."""
+
+    def __init__(self, *, location_error=None, list_error=None, topic_arn=TOPIC_ARN):
+        self._location_error = location_error
+        self._list_error = list_error
+        self._topic_arn = topic_arn
+        self.meta = SimpleNamespace(region_name="us-east-1")
+
+    def get_bucket_location(self, Bucket):
+        if self._location_error:
+            raise self._location_error
+        return {"LocationConstraint": None}
+
+    def head_bucket(self, Bucket):
+        if self._location_error:
+            raise self._location_error
+        return {}
+
+    def list_objects_v2(self, Bucket, MaxKeys=1):
+        if self._list_error:
+            raise self._list_error
+        return {"KeyCount": 0}
+
+    def get_bucket_notification_configuration(self, Bucket):
+        if not self._topic_arn:
+            return {}
+        return {
+            "TopicConfigurations": [
+                {
+                    "Id": bucket_lib.SNS_TOPIC_CONFIG_ID,
+                    "TopicArn": self._topic_arn,
+                    "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],
+                }
+            ]
+        }
+
+
+class _GrantSns:
+    def __init__(self, policy=None, error=None):
+        self._policy = policy
+        self._error = error
+
+    def get_topic_attributes(self, TopicArn):
+        if self._error:
+            raise self._error
+        return {"Attributes": {"Policy": json.dumps(self._policy)}}
+
+
+class _GrantSession:
+    def __init__(self, *, account="123456789012", s3=None, sns=None):
+        self._account = account
+        self._s3 = s3 if s3 is not None else _GrantS3()
+        self._sns = (
+            sns
+            if sns is not None
+            else _GrantSns(_grant_sns_policy("sns:GetTopicAttributes", "sns:Subscribe"))
+        )
+
+    def client(self, service, region_name=None):
+        if service == "sts":
+            return SimpleNamespace(
+                get_caller_identity=lambda: {
+                    "Account": self._account,
+                    "Arn": f"arn:aws:iam::{self._account}:role/operator",
+                }
+            )
+        if service == "s3":
+            return self._s3
+        if service == "sns":
+            return self._sns
+        raise AssertionError(f"unexpected client {service}")
+
+
+def _checks(report) -> dict[str, bool]:
+    return {check.name: check.ok for check in report.checks}
+
+
+def test_probe_bucket_grant_passes_for_usable_grant() -> None:
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(),
+        expected_account_id="123456789012",
+    )
+
+    assert report.ok
+    assert report.principal == "arn:aws:iam::123456789012:role/operator"
+    assert report.account_id == "123456789012"
+    assert report.region == "us-east-1"
+    assert all(_checks(report).values())
+
+
+def test_probe_bucket_grant_flags_wrong_control_account() -> None:
+    """A grant issued to the wrong account is detectable at handoff time."""
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(account="999988887777"),
+        expected_account_id="123456789012",
+    )
+
+    assert not report.ok
+    assert _checks(report)["control account match"] is False
+    detail = next(
+        check.detail for check in report.checks if check.name == "control account match"
+    )
+    assert "999988887777" in detail
+    assert "123456789012" in detail
+
+
+def test_probe_bucket_grant_reports_unreachable_bucket() -> None:
+    denied = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+        "GetBucketLocation",
+    )
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(s3=_GrantS3(location_error=denied)),
+    )
+
+    assert not report.ok
+    checks = _checks(report)
+    assert checks["bucket reachable (s3:GetBucketLocation)"] is False
+    # Later S3 checks are skipped once the bucket cannot be opened at all.
+    assert "list bucket (s3:ListBucket)" not in checks
+
+
+def test_probe_bucket_grant_flags_missing_subscribe_permission() -> None:
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(sns=_GrantSns(_grant_sns_policy("sns:Publish"))),
+        expected_account_id="123456789012",
+    )
+
+    assert not report.ok
+    assert _checks(report)["SNS topic policy grants subscribe"] is False
+
+
+def test_probe_bucket_grant_flags_missing_notification_topic() -> None:
+    report = bucket_lib.probe_bucket_grant(
+        "bucket-a",
+        session=_GrantSession(s3=_GrantS3(topic_arn=None)),
+    )
+
+    assert not report.ok
+    assert _checks(report)["read notifications (s3:GetBucketNotification)"] is False
+
+
+def test_sns_policy_granted_actions_matches_assumed_role_sessions() -> None:
+    policy = _grant_sns_policy(
+        "sns:Subscribe",
+        principal="arn:aws:iam::123456789012:role/operator",
+    )
+    granted = bucket_lib.sns_policy_granted_actions(
+        policy,
+        ("sns:Subscribe",),
+        principal="arn:aws:sts::123456789012:assumed-role/operator/session",
+        account_id="123456789012",
+        topic_arn=TOPIC_ARN,
+    )
+    assert granted == {"sns:Subscribe"}
+
+
+def test_sns_policy_granted_actions_ignores_other_principals() -> None:
+    policy = _grant_sns_policy(
+        "sns:Subscribe", principal="arn:aws:iam::999988887777:root"
+    )
+    granted = bucket_lib.sns_policy_granted_actions(
+        policy,
+        ("sns:Subscribe",),
+        principal="arn:aws:iam::123456789012:role/operator",
+        account_id="123456789012",
+        topic_arn=TOPIC_ARN,
+    )
+    assert granted == set()
+
+
+def test_test_pre_registration_passes_before_registration(monkeypatch, capsys) -> None:
+    """Issue #92: an unregistered bucket is an expected state in this mode."""
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, get_result=None)
+    monkeypatch.setattr(
+        bucket_tool, "_control_context", lambda stack: ("123456789012", None)
+    )
+    monkeypatch.setattr(
+        bucket_tool.boto3, "Session", lambda profile_name=None: _GrantSession()
+    )
+
+    assert bucket_tool.main(["test", "bucket-a", "--pre-registration"]) == 0
+    captured = capsys.readouterr()
+    assert "Pre-registration grant check for s3://bucket-a" in captured.out
+    assert "registered in Quilt: no (expected with --pre-registration)" in captured.out
+    assert "arn:aws:iam::123456789012:role/operator" in captured.out
+    assert "quiltx bucket add bucket-a --no-preflight" in captured.out
+
+
+def test_test_pre_registration_reports_failed_checks(monkeypatch, capsys) -> None:
+    _install_stack_context(monkeypatch)
+    _install_fake_quilt3(monkeypatch, get_result=None)
+    monkeypatch.setattr(
+        bucket_tool, "_control_context", lambda stack: ("123456789012", None)
+    )
+    monkeypatch.setattr(
+        bucket_tool.boto3,
+        "Session",
+        lambda profile_name=None: _GrantSession(account="999988887777"),
+    )
+
+    assert bucket_tool.main(["test", "bucket-a", "--pre-registration"]) == 1
+    captured = capsys.readouterr()
+    assert "FAILED: control account match" in captured.out
+    assert "probing principal: arn:aws:iam::999988887777:role/operator" in captured.err
+    assert "Quilt control account: 123456789012" in captured.err

--- a/tests/test_quilt3_facade.py
+++ b/tests/test_quilt3_facade.py
@@ -191,3 +191,25 @@ def test_catalog_sts_account_id_fails_on_incomplete_credentials(monkeypatch) -> 
         quilt3_facade.CatalogCredentialsError, match="no usable credentials"
     ):
         quilt3_facade.catalog_sts_account_id()
+
+
+def test_admin_graphql_returns_the_data_payload(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class _FakeClient:
+        def execute(self, query: str, variables: dict[str, object]):
+            calls.append({"query": query, "variables": variables})
+            return "raw-response"
+
+        def get_data(self, response: object) -> dict[str, object]:
+            assert response == "raw-response"
+            return {"bucketConfig": {"name": "bucket-a"}}
+
+    monkeypatch.setattr(quilt3_facade, "admin_graphql_client", lambda: _FakeClient())
+
+    data = quilt3_facade.admin_graphql("query Q($name: String!) { x }", {"name": "b"})
+
+    assert data == {"bucketConfig": {"name": "bucket-a"}}
+    assert calls == [
+        {"query": "query Q($name: String!) { x }", "variables": {"name": "b"}}
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
Closes #87. Closes #92.

## Why

`bucket test` proved a bucket was registered and that its search index had an
entry. Neither shows the catalog stack can read the bucket now: a stale index
entry survives revoked access, and an empty or freshly registered bucket has
nothing to index. Meanwhile `bucket add --no-preflight` — the documented
cross-account flow, spanning two accounts and often two organizations — never
verified at all and returned 0 regardless.

## What changed

**Live access probe (#87).** `quiltx.bucket.probe_bucket_access` reads a
bucket's full catalog configuration and resubmits it unchanged, so the registry
re-validates S3 and SNS access with the stack's own service identity while
handling that mutation. Configuration is never rewritten (every
`BucketUpdateInput` field is round-tripped). A catalog that cannot answer yields
`status "unavailable"` and callers fall back to the index probe.
`QUILTX_NO_LIVE_PROBE=1` skips the probe where no bucket mutation is acceptable.

**Three separate checks.** `bucket test` now reports registration, live access,
and index wiring independently. Once live access is verified, an empty index is
a warning rather than a failure — indexing lags registration and empty buckets
never index — and `--require-index` makes it fatal. Failures name the failed
capability, the Quilt control account, and the stack principal.

**Verification on the no-preflight path (#92).** `add --no-preflight` verifies
after registering, `--no-test` is the opt-out there instead of a silent no-op,
and an already-registered bucket is verified rather than skipped.

**Pre-registration grant check (#92).** `bucket test --pre-registration
[--profile P]` answers "is this grant usable?" straight from a `bucket prepare`
handoff: bucket reachable, `GetBucketNotification` readable, SNS topic policy
granting `Subscribe`/`GetTopicAttributes`. It reports the principal that ran the
checks and fails when that principal is not in the catalog's control account, so
a wrong-account grant surfaces at handoff instead of as an opaque `AccessDenied`
inside `catalog acl`. "Not registered" is expected in this mode.

**Diagnostics (#92).** Standalone `bucket test` failures print the control
account and stack principal instead of `unknown`.

## Testing

`./poe lint-check` and the full suite pass (436 passed, 1 skipped). New coverage:
accessible, inaccessible, empty-bucket, stale-index, indexing-delay, and
probe-unavailable scenarios; no-preflight verification and its `--no-test`
opt-out; pre-registration grant checks including wrong-account, unreachable
bucket, missing notification topic, and missing subscribe permission; SNS policy
matching for assumed-role sessions.

Version bumped to 0.18.2 with a CHANGELOG entry.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side live bucket-access verification, post-registration verification for the no-preflight flow, and a pre-registration cross-account grant check.

- Round-trips catalog bucket configuration through `bucketUpdate` to trigger stack-side access validation.
- Separates registration, live-access, and search-index checks, with optional strict index enforcement.
- Adds direct S3, notification, and SNS-policy checks for pre-registration handoffs.
- Updates CLI behavior, documentation, tests, and the package version to 0.18.2.

<h3>Confidence Score: 4/5</h3>

The SNS policy check should be corrected before merging because it can approve a cross-account grant that AWS will deny.

The new pre-registration flow statically interprets SNS policies but ignores Conditions and explicit Deny precedence, allowing it to return success without establishing that Subscribe is effective.

**Files Needing Attention:** quiltx/bucket.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/bucket.py | Adds live-access and pre-registration probes; the SNS policy evaluator can incorrectly accept conditional or explicitly denied grants. |
| quiltx/tools/bucket.py | Integrates the new probes into add/test flows and adds strict-index and pre-registration CLI options. |
| quiltx/quilt3_facade.py | Adds a small authenticated raw GraphQL execution facade for the live probe. |
| tests/test_bucket.py | Adds broad probe and CLI coverage but does not cover SNS Conditions or explicit Deny precedence. |
| uv.lock | Updates only the local quiltx package version; dependency versions remain unchanged. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bucket test] --> B{pre-registration?}
    B -- No --> C[Check catalog registration]
    C --> D[Resubmit bucket configuration]
    D --> E[Registry validates live S3/SNS access]
    E --> F[Probe search index]
    B -- Yes --> G[Resolve control-account identity]
    G --> H[Check S3 location and listing]
    H --> I[Read bucket notifications]
    I --> J[Read and inspect SNS topic policy]
    J --> K[Report grant usable or failed]
```

<sub>Reviews (1): Last reviewed commit: ["Verify live bucket access server-side an..."](https://github.com/quiltdata/quiltx/commit/748ea854ecdc0c8949404dfbae388d538d2060c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54075624)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->