### PR TITLE
Preserve unrepresented buckets in ACL captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.4] - 2026-08-19
+
+### Fixed
+
+- `quiltx catalog acl --yaml` now preserves registered buckets that have no
+  explicit managed-policy association
+  ([#97](https://github.com/quiltdata/quiltx/issues/97)). Otherwise-unrepresented
+  buckets are emitted as registration-only references on the built-in
+  `ReadQuiltBucket` and `ReadWriteQuiltBucket` roles, while buckets already
+  represented by managed policies or managed-role inline policies are not
+  duplicated. Captures remain parseable and replayable: a compatible target
+  plans only missing bucket registration, never policy changes or mutations to
+  the IAM-backed built-in roles. Custom unmanaged roles still reject
+  `buckets.*`, and `config.policies` remains invalid on every unmanaged role.
+
 ## [0.18.3] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,11 +219,17 @@ roles:
 Referenced this way, a role stays addressable from `users:`, `sso.<claim>`
 selectors, and `config.default_role` while quiltx never creates, updates, or
 deletes it. Because their bucket grants live in IAM rather than the registry,
-unmanaged roles cannot carry `config.policies`, `buckets.read`, or
-`buckets.read_write`.
+unmanaged roles cannot carry `config.policies` or `buckets.*` grants. The two
+QuiltStack built-ins are the exception for registration references:
+`ReadQuiltBucket.buckets.read` and
+`ReadWriteQuiltBucket.buckets.read_write` may list buckets that the ACL should
+register, but those fields never modify the roles' IAM permissions. Other
+bucket fields and bucket fields on custom unmanaged roles remain invalid.
 
-`--yaml` always emits these entries for the unmanaged roles it finds, even when
-no user or selector currently references them, so a capture stays replayable.
+`--yaml` always emits entries for the unmanaged roles it finds, even when no
+user or selector currently references them. Registered buckets not already
+represented by managed permissions are listed on both built-in roles, so a
+capture can register them when replayed without duplicating explicit grants.
 
 ### Downgrade warnings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quiltx"
-version = "0.18.3"
+version = "0.18.4"
 description = "Unified toolkit for Quilt workflows."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/quiltx/_version.py
+++ b/quiltx/_version.py
@@ -1,3 +1,3 @@
 """Version information for quiltx."""
 
-__version__ = "0.18.3"
+__version__ = "0.18.4"

--- a/quiltx/acl.py
+++ b/quiltx/acl.py
@@ -29,6 +29,10 @@ CONFIG_UNMANAGED_KEY = "config.unmanaged"
 EVERYONE_GROUP = "Everyone"
 REGISTRY_MANAGED_POLICY_EXCLUSIONS = frozenset({"CanaryBucketAccess"})
 REGISTRY_MANAGED_ROLE_EXCLUSIONS = frozenset({"Canary"})
+BUILTIN_BUCKET_REGISTRATION_FIELDS = {
+    "ReadQuiltBucket": "buckets.read",
+    "ReadWriteQuiltBucket": "buckets.read_write",
+}
 
 
 @dataclass(frozen=True)
@@ -58,7 +62,9 @@ class AclStaticRole:
     Unmanaged roles are IAM-role-backed and their permissions live outside the
     registry, so quiltx never creates, updates, or deletes them. Declaring one
     keeps it addressable from ``users:``, SSO selectors, and
-    ``config.default_role`` so a captured ACL stays replayable.
+    ``config.default_role`` so a captured ACL stays replayable. The built-in
+    QuiltStack bucket roles may also carry their matching ``buckets.*`` field
+    as a registration reference; it never changes the role's IAM permissions.
     """
 
 
@@ -375,10 +381,12 @@ def parse_acl_config_text(text: str) -> AclConfig:
         if not isinstance(unmanaged, bool):
             raise ValueError(f"roles.{name}.{CONFIG_UNMANAGED_KEY} must be a boolean")
         if unmanaged:
+            allowed_registration_field = BUILTIN_BUCKET_REGISTRATION_FIELDS.get(name)
             forbidden = sorted(
                 key
                 for key in (CONFIG_POLICIES_KEY, "buckets.read", "buckets.read_write")
-                if value.get(key)
+                if key in value
+                and (key == CONFIG_POLICIES_KEY or key != allowed_registration_field)
             )
             if forbidden:
                 raise ValueError(
@@ -1284,6 +1292,7 @@ def current_state_as_acl_yaml_with_warnings(
     notes: list[str] = []
     role_entries: dict[str, dict[str, Any]] = {}
     policy_entries: dict[str, dict[str, Any]] = {}
+    represented_buckets: set[str] = set()
 
     managed_roles = {
         name: role
@@ -1306,6 +1315,8 @@ def current_state_as_acl_yaml_with_warnings(
             else:
                 read, read_write, permission_notes = _acl_bucket_fields(inline_policy)
                 notes.extend(permission_notes)
+                represented_buckets.update(read)
+                represented_buckets.update(read_write)
                 if read:
                     entry["buckets.read"] = read
                 if read_write:
@@ -1341,6 +1352,8 @@ def current_state_as_acl_yaml_with_warnings(
             continue
         read, read_write, permission_notes = _acl_bucket_fields(policy)
         notes.extend(permission_notes)
+        represented_buckets.update(read)
+        represented_buckets.update(read_write)
         policy_entry: dict[str, Any] = {CONFIG_SYNTHESIZE_KEY: False}
         if read:
             policy_entry["buckets.read"] = read
@@ -1351,7 +1364,10 @@ def current_state_as_acl_yaml_with_warnings(
     # Existing unmanaged roles (the catalog's built-in defaults) are emitted as
     # reference-only entries so users, SSO selectors, and the default role that
     # point at them survive a capture/replay round trip. They are always
-    # emitted, even when nothing currently references them.
+    # emitted, even when nothing currently references them. The matching bucket
+    # fields on QuiltStack's two built-ins preserve registration only; their IAM
+    # permissions remain unmanaged.
+    unrepresented_buckets = sorted(set(current.buckets) - represented_buckets)
     for name in sorted(current.unmanaged_roles):
         if name in REGISTRY_MANAGED_ROLE_EXCLUSIONS:
             notes.append(f"registry-managed role {name!r}")
@@ -1359,7 +1375,11 @@ def current_state_as_acl_yaml_with_warnings(
         if name in role_entries:
             notes.append(f"unmanaged role {name!r} collides with a managed role")
             continue
-        role_entries[name] = {CONFIG_UNMANAGED_KEY: True}
+        entry = {CONFIG_UNMANAGED_KEY: True}
+        registration_field = BUILTIN_BUCKET_REGISTRATION_FIELDS.get(name)
+        if registration_field is not None and unrepresented_buckets:
+            entry[registration_field] = unrepresented_buckets
+        role_entries[name] = entry
 
     sso_notes, selectors, admin_roles, sso_default_role = _acl_sso_fields(
         current, set(role_entries)

--- a/stack-acl.example.yaml
+++ b/stack-acl.example.yaml
@@ -47,6 +47,9 @@ roles:
   # Reference a catalog built-in (IAM-backed) role by name. quiltx never
   # creates, updates, or deletes it; the entry only keeps it addressable from
   # `users:`, sso selectors, and config.default_role. Unmanaged roles cannot
-  # carry config.policies or buckets.* grants.
+  # carry config.policies or buckets.* grants. QuiltStack's two built-ins may
+  # carry their matching bucket field as a registration-only reference:
+  # ReadQuiltBucket.buckets.read or ReadWriteQuiltBucket.buckets.read_write.
+  # Those fields do not modify IAM permissions.
   ReadWriteQuiltBucket:
     config.unmanaged:   true

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1948,6 +1948,9 @@ def test_acl_tool_no_config_shows_current_state(monkeypatch, capsys) -> None:
 
 def test_acl_tool_json_exports_valid_json_without_header(monkeypatch, capsys) -> None:
     current = replace(_empty_current_state(), default_role_name="readers")
+    current.buckets["orphan-bucket"] = FakeBucket(
+        name="orphan-bucket", title="Orphan bucket"
+    )
     role = FakeRole(id="role-1", name="readers", policies=[], permissions=[])
     current.managed_roles[role.name] = role
     current.all_roles[role.name] = role
@@ -1977,6 +1980,7 @@ def test_acl_tool_json_exports_valid_json_without_header(monkeypatch, capsys) ->
     assert result == 0
     assert payload["catalog"] == "catalog"
     assert payload["default_role"] == "readers"
+    assert payload["buckets"] == [{"name": "orphan-bucket", "title": "Orphan bucket"}]
     assert payload["users"] == [
         {
             "name": "alice",
@@ -2783,44 +2787,82 @@ def _with_unmanaged_roles(current: acl.CurrentState, *names: str) -> acl.Current
     return current
 
 
-def test_current_state_yaml_emits_unused_builtin_unmanaged_roles() -> None:
-    """Both built-in unmanaged roles are captured even when nothing uses them."""
+def test_current_state_yaml_preserves_only_unrepresented_buckets_on_builtins() -> None:
+    """Built-in registration references omit buckets captured by managed grants."""
+    config = acl.AclConfig(
+        policies=[
+            acl.AclPolicy(
+                name="shared",
+                read=["policy-bucket"],
+                synthesize=False,
+            )
+        ],
+        roles={
+            "Analysts": acl.AclStaticRole(
+                name="Analysts",
+                policies=["shared"],
+                read_write=["inline-bucket"],
+            )
+        },
+    )
     current = _with_unmanaged_roles(
-        _empty_current_state(), "ReadQuiltBucket", "ReadWriteQuiltBucket"
+        _current_state_for_config(config),
+        "ReadQuiltBucket",
+        "ReadWriteQuiltBucket",
+    )
+    current.buckets["orphan-bucket"] = FakeBucket(
+        name="orphan-bucket", title="Orphan bucket"
     )
 
     exported = acl.current_state_as_acl_yaml(
-        current, catalog="catalog", captured_on="2026-08-17"
+        current, catalog="catalog", captured_on="2026-08-19"
     )
     payload = yaml.safe_load(exported)
 
-    assert payload["roles"] == {
-        "ReadQuiltBucket": {"config.unmanaged": True},
-        "ReadWriteQuiltBucket": {"config.unmanaged": True},
+    assert payload["policies"]["shared"]["buckets.read"] == ["policy-bucket"]
+    assert payload["roles"]["Analysts"]["buckets.read_write"] == ["inline-bucket"]
+    assert payload["roles"]["ReadQuiltBucket"] == {
+        "config.unmanaged": True,
+        "buckets.read": ["orphan-bucket"],
+    }
+    assert payload["roles"]["ReadWriteQuiltBucket"] == {
+        "config.unmanaged": True,
+        "buckets.read_write": ["orphan-bucket"],
     }
     assert "not captured" not in exported
 
 
-def test_replaying_captured_unmanaged_roles_never_manages_them() -> None:
-    """Reapplying the capture leaves the built-in roles completely alone."""
+def test_replaying_captured_unmanaged_roles_only_registers_missing_buckets() -> None:
+    """Built-in bucket markers register buckets without managing the roles."""
     current = _with_unmanaged_roles(
         _empty_current_state(), "ReadQuiltBucket", "ReadWriteQuiltBucket"
     )
+    current.buckets["orphan-bucket"] = FakeBucket(
+        name="orphan-bucket", title="Orphan bucket"
+    )
     exported = acl.current_state_as_acl_yaml(
-        current, catalog="catalog", captured_on="2026-08-17"
+        current, catalog="catalog", captured_on="2026-08-19"
     )
 
     parsed = acl.parse_acl_config_text(exported)
-    diff = acl.compute_diff(parsed, current)
+    source_diff = acl.compute_diff(parsed, current)
+    target = _with_unmanaged_roles(
+        _empty_current_state(), "ReadQuiltBucket", "ReadWriteQuiltBucket"
+    )
+    target_diff = acl.compute_diff(parsed, target)
 
     assert set(parsed.roles) == {"ReadQuiltBucket", "ReadWriteQuiltBucket"}
     assert all(role.unmanaged for role in parsed.roles.values())
-    assert not diff.has_changes()
-    assert diff.roles_to_create == []
-    assert diff.roles_to_update == []
-    assert diff.roles_to_delete == []
-    assert diff.policies_to_create == []
-    assert diff.warnings == []
+    assert not source_diff.has_changes()
+    assert source_diff.warnings == []
+    assert target_diff.buckets_to_add == ["orphan-bucket"]
+    assert target_diff.roles_to_create == []
+    assert target_diff.roles_to_update == []
+    assert target_diff.roles_to_delete == []
+    assert target_diff.policies_to_create == []
+    assert target_diff.policies_to_update == []
+    assert target_diff.policies_to_delete == []
+    assert target_diff.warnings == []
 
 
 def test_current_state_yaml_captures_users_and_default_on_unmanaged_role() -> None:
@@ -2896,12 +2938,14 @@ def test_current_state_yaml_round_trips_sso_mapped_unmanaged_role() -> None:
     assert not diff.has_changes()
 
 
-def test_parse_acl_config_rejects_grants_on_unmanaged_role(tmp_path: Path) -> None:
+def test_parse_acl_config_rejects_grants_on_custom_unmanaged_role(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "acl.yml"
     path.write_text("""
 policies: {}
 roles:
-  ReadQuiltBucket:
+  CustomUnmanaged:
     config.unmanaged: true
     buckets.read: [bucket-a]
 """)
@@ -2910,7 +2954,7 @@ roles:
         acl.parse_acl_config(path)
 
     message = str(error.value)
-    assert "roles.ReadQuiltBucket cannot set buckets.read" in message
+    assert "roles.CustomUnmanaged cannot set buckets.read" in message
     assert "config.unmanaged is true" in message
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1890,7 +1890,7 @@ wheels = [
 
 [[package]]
 name = "quiltx"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Summary
- preserve registered buckets missing from managed ACL permissions through the built-in unmanaged bucket roles
- treat those built-in bucket fields as registration-only references while retaining strict validation for other unmanaged roles
- bump quiltx to 0.18.4 and document the fix in the changelog and ACL examples

## Validation
- `./poe lint-check`
- `./poe test` (473 passed, 1 skipped)
- `./poe release-notes`
- pre-commit and pre-push hooks

Closes #97

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up preserves registered buckets that are absent from managed ACL permissions by capturing them as registration-only references on QuiltStack’s built-in unmanaged roles.
- Allows each built-in unmanaged bucket role to carry its matching registration field while retaining strict validation elsewhere.
- Tracks buckets represented by managed permissions and emits only the remaining registered buckets through built-in roles.
- Adds capture/replay tests and updates documentation, examples, changelog, and package metadata for version 0.18.4.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quiltx/acl.py | Adds registration-only fields for built-in unmanaged roles and preserves buckets omitted from managed ACL permission captures. |
| tests/test_acl.py | Verifies capture filtering, replay registration, and the absence of role or policy mutations. |
| README.md | Documents the built-in-role exception and its registration-only semantics. |
| stack-acl.example.yaml | Updates the example to explain valid built-in bucket registration references. |
| CHANGELOG.md | Records the bucket-preservation fix and replay behavior for version 0.18.4. |
| pyproject.toml | Bumps the project version to 0.18.4. |
| quiltx/_version.py | Keeps the runtime version synchronized at 0.18.4. |
| uv.lock | Synchronizes the editable quiltx package version with project metadata. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Registered catalog buckets] --> B[Subtract buckets represented by managed permissions]
  B --> C[Unrepresented buckets]
  C --> D[ReadQuiltBucket buckets.read]
  C --> E[ReadWriteQuiltBucket buckets.read_write]
  D --> F[Replay registers missing buckets]
  E --> F
  F --> G[Unmanaged IAM roles remain unchanged]
```

<sub>Reviews (2): Last reviewed commit: ["Preserve unrepresented buckets in ACL ca..."](https://github.com/quiltdata/quiltx/commit/2172bede8a43d369d035911054187c51a5cfe6df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54842809)</sub>

<!-- /greptile_comment -->